### PR TITLE
Initialized MAIL_DEFAULT_SENDER to make Flask-Mail work correctly. (clos...

### DIFF
--- a/settings-sample.py
+++ b/settings-sample.py
@@ -34,6 +34,9 @@ TWITTER_ID = "hasgeek"
 MAIL_FAIL_SILENTLY = False
 MAIL_SERVER = 'localhost'
 DEFAULT_MAIL_SENDER = ('Bill Gate', 'test@example.com')
+
+# Required for Flask-Mail to work.
+MAIL_DEFAULT_SENDER = DEFAULT_MAIL_SENDER
 #: Logging: recipients of error emails
 ADMINS=[]
 #: Log file


### PR DESCRIPTION
...es #41)

The setting `DEFAULT_MAIL_SENDER` is used by Coaster and Flask-Mail expects `MAIL_DEFAULT_SENDER`. Initialized `MAIL_DEFAULT_SENDER` to the value of `DEFAULT_MAIL_SENDER` to make Flask-Mail happy.
