### PR TITLE
Populate form choices from enum

### DIFF
--- a/funnel/forms/space.py
+++ b/funnel/forms/space.py
@@ -75,8 +75,4 @@ class ProposalSpaceForm(Form):
 
 
 class RsvpForm(Form):
-    status = wtforms.RadioField("Status", choices=[
-        ('Y', __("Going")),
-        ('N', __("Not going")),
-        ('M', __("May be going"))
-        ])
+    status = wtforms.RadioField("Status", choices=[(k, RSVP_STATUS[k].title) for k in RSVP_STATUS.USER_CHOICES])

--- a/funnel/models/rsvp.py
+++ b/funnel/models/rsvp.py
@@ -14,7 +14,9 @@ class RSVP_STATUS(LabeledEnum):
     N = ('N', 'no', __("No"))
     M = ('M', 'maybe', __("Maybe"))
     A = ('A', 'awaiting', __("Awaiting"))
-    __order__ = (Y, N, M, A)
+    # To avoid interfering with LabeledEnum, the following should use a list, not a tuple,
+    # and should contain actual status values, not Python objects
+    USER_CHOICES = ['Y', 'N', 'M']
 
 
 class Rsvp(TimestampMixin, db.Model):


### PR DESCRIPTION
The form is for validation only and isn’t user facing, so no need to
define choices all over again.