### PR TITLE
Offline support for check in using browser local storage

### DIFF
--- a/funnel/__init__.py
+++ b/funnel/__init__.py
@@ -45,7 +45,7 @@ def init_for(env):
     lastuser.init_app(app)
     lastuser.init_usermanager(UserManager(db, models.User, models.Team))
     baseframe.init_app(app, requires=['funnel'], ext_requires=[
-        ('codemirror-markdown', 'pygments'), 'toastr', 'baseframe-bs3', 'fontawesome>=4.0.0', 'footable'
+        ('codemirror-markdown', 'pygments'), 'toastr', 'baseframe-bs3', 'fontawesome>=4.0.0', 'footable', 'ractive'
         ])
     app.assets.register('js_fullcalendar',
         Bundle(assets.require('!jquery.js', 'jquery.fullcalendar.js', 'spectrum.js'),

--- a/funnel/static/css/app.css
+++ b/funnel/static/css/app.css
@@ -706,22 +706,22 @@ td .status-btn-list li:last-child {
     margin: 0 0 5px;
   }
 }
-.loader, .abort {
+.loader, .js-abort {
   display: none;
   margin: 0 2px;
 }
 
-.abort {
+.js-abort {
   cursor: pointer;
 }
 
-.checkin {
+.js-checkin {
   background-color: #EC971F;
   border-bottom: 2px solid #D58512;
   color: #fff;
 }
 
-.cancel-checkin {
+.js-cancel-checkin {
   background-color: #D9534F;
   border-bottom: 2px solid #AC2925;
   color: #fff;

--- a/funnel/static/css/app.css
+++ b/funnel/static/css/app.css
@@ -706,3 +706,27 @@ td .status-btn-list li:last-child {
     margin: 0 0 5px;
   }
 }
+.loader, .abort {
+  display: none;
+  margin: 0 2px;
+}
+
+.abort {
+  cursor: pointer;
+}
+
+.checkin {
+  background-color: #EC971F;
+  border-bottom: 2px solid #D58512;
+  color: #fff;
+}
+
+.cancel-checkin {
+  background-color: #D9534F;
+  border-bottom: 2px solid #AC2925;
+  color: #fff;
+}
+
+td .btn:hover, td .btn:active, td .btn:focus {
+  color: #fff;
+}

--- a/funnel/static/js/scripts.js
+++ b/funnel/static/js/scripts.js
@@ -1,3 +1,5 @@
+window.Talkfunnel = {};
+
 function radioHighlight(radioName, highlightClass) {
     var selector = "input[name='" + radioName + "']";
     $(selector + ":checked").parent().addClass(highlightClass);
@@ -89,3 +91,12 @@ $(function() {
     }
   });
 });
+
+//convert array of objects into hashmap
+function tohashMap(objectArray, key) {
+    var hashMap = {};
+    objectArray.forEach(function(obj) {
+        hashMap[obj[key]] = obj;
+    });
+    return hashMap;
+}

--- a/funnel/static/sass/_layout.scss
+++ b/funnel/static/sass/_layout.scss
@@ -716,3 +716,28 @@ td .status-btn-list li:last-child {
     margin: 0 0 5px;
   }
 }
+
+.loader, .abort {
+  display: none;
+  margin: 0 2px;
+}
+
+.abort {
+  cursor: pointer;
+}
+
+.checkin {
+  background-color: #EC971F;
+  border-bottom: 2px solid #D58512;
+  color: #fff;
+}
+
+.cancel-checkin {
+  background-color: #D9534F;
+  border-bottom: 2px solid #AC2925;
+  color: #fff;
+}
+
+td .btn:hover, td .btn:active, td .btn:focus {
+  color:#fff;
+}

--- a/funnel/static/sass/_layout.scss
+++ b/funnel/static/sass/_layout.scss
@@ -717,22 +717,22 @@ td .status-btn-list li:last-child {
   }
 }
 
-.loader, .abort {
+.loader, .js-abort {
   display: none;
   margin: 0 2px;
 }
 
-.abort {
+.js-abort {
   cursor: pointer;
 }
 
-.checkin {
+.js-checkin {
   background-color: #EC971F;
   border-bottom: 2px solid #D58512;
   color: #fff;
 }
 
-.cancel-checkin {
+.js-cancel-checkin {
   background-color: #D9534F;
   border-bottom: 2px solid #AC2925;
   color: #fff;

--- a/funnel/templates/event.html
+++ b/funnel/templates/event.html
@@ -131,8 +131,8 @@
   }
 
   $(document).ready(function() {
-    var checkinUrl = window.location.href + "/checkin/";
-    var getParticipantsUrl = window.location.href + "/participants/json";
+    var checkinUrl = "{{ '{0}event/{1}/checkin/'.format(space.url_for(), event.name) }}";
+    var getParticipantsUrl = "{{ '{0}event/{1}/participants/json'.format(space.url_for(), event.name) }}";
 
     // To disable debug mode
     Ractive.DEBUG = false;

--- a/funnel/templates/event.html
+++ b/funnel/templates/event.html
@@ -90,13 +90,13 @@
 
     //Local storage can only save strings, so value is converted into strings and stored.
     window.Talkfunnel.Store.addToLocalstorage = function(key, value) {
-      return localStorage.setItem(key, JSON.stringify(value))
-    }
+      return localStorage.setItem(key, JSON.stringify(value));
+    };
 
     //Reads from LocalStorage.
     window.Talkfunnel.Store.readFromLocalstorage = function(key) {
       return JSON.parse(localStorage.getItem(key));
-    }
+    };
 
     window.Talkfunnel.Queue = {};
 
@@ -105,9 +105,9 @@
       var participantList = window.Talkfunnel.Store.readFromLocalstorage(queueName) || [];
       if(participantList.indexOf(participant_id) === -1) {
         participantList.push(participant_id);
-        return window.Talkfunnel.Store.addToLocalstorage(queueName, participantList)
+        return window.Talkfunnel.Store.addToLocalstorage(queueName, participantList);
       }
-    }
+    };
 
     //Reads and returns all items from queue
     //Returns undefined when queue is empty or not defined
@@ -116,7 +116,7 @@
       if(participantList && participantList.length) {
         return participantList;
       }
-    }
+    };
 
     //Removes item from queue and returns true
     //Returns undefined when item not present in queue
@@ -129,7 +129,7 @@
         window.Talkfunnel.Store.addToLocalstorage(queueName, participantList);
         return true;
       }
-    }
+    };
   }
 
   $(document).ready(function() {
@@ -149,6 +149,7 @@
       var participantIDs = window.Talkfunnel.Queue.peekAll(queueName);
       if(participantIDs) {
         participantIDs.forEach(function(participantID) {
+          var participant = "[data-pid=" + participantID +"]";
           if(queueName === "checkin-queue") {
             if(participants[participantID].checked_in) {
               //Participant has been checked-in so remove from 'checkin-queue' 
@@ -272,7 +273,7 @@
         if(!navigator.onLine) {
           return 'There is no network!';
         }
-      }
+      };
 
       //Read 'checkin-queue' and 'cancelcheckin-queue' every 8 second and post check-in status to server
       setInterval(processQueues, 8000);
@@ -285,7 +286,7 @@
        if ($('#badge_form select.field-badge_printed').val() === "") {
         return false;
        }
-       return window.confirm("Are you sure? Selected action will apply to all listed participants.")
+       return window.confirm("Are you sure? Selected action will apply to all listed participants.");
     });
 
     var TableSearch = function(tableId){
@@ -301,7 +302,7 @@
       this.tableId = tableId;
       this.rowData = [];
       this.allMatchedIds = [];
-    }
+    };
 
     TableSearch.prototype.getRows = function(){
       return $('#' + this.tableId +' tbody tr');
@@ -321,7 +322,7 @@
 
     TableSearch.prototype.setAllMatchedIds = function(ids) {
       this.allMatchedIds = ids;
-    }
+    };
 
     TableSearch.prototype.searchRows = function(q){
       // Search the rows of the table for a supplied query.
@@ -329,26 +330,26 @@
       // reset data collection on first search or if table has changed
       if (this.rowData.length !== this.getRows().length) {
         this.setRowData();
-      };
+      }
 
       // return cached matched ids if query is blank
       if (q === '' && this.allMatchedIds.length !== 0) {
         return this.allMatchedIds;
-      };
+      }
 
       var matchedIds = [];
       for (var i = this.rowData.length - 1; i >= 0; i--) {
         if (this.rowData[i].text.indexOf(q.toLowerCase()) !== -1) {
           matchedIds.push(this.rowData[i]['rid']);
         }
-      };
+      }
 
       // cache ids if query is blank
       if (q === '') {
         this.setAllMatchedIds(matchedIds);
-      };
+      }
       return matchedIds;
-    }
+    };
 
     var tableSearch = new TableSearch('participants-table');
 

--- a/funnel/templates/event.html
+++ b/funnel/templates/event.html
@@ -46,37 +46,223 @@
         <th>Actions</th>
       </tr>
     </thead>
-    <tbody>
-      {%- for p in participants %}
-        <tr id="p-{{ p.id }}">
-          <td class='js-searchable'>{{ p.fullname }}</td>
-          <td class='js-searchable'>{{ p.email }}</td>
-          <td class='js-searchable'>{{ p.company }}</td>
+    <tbody id="participants">
+      {% raw %}
+      <script id='participant' type='text/ractive'>
+      {{#each participants}}
+        <tr id="p-{{ pid }}">
+          <td class='js-searchable'>{{ fullname }}</td>
+          <td class='js-searchable'>{{ email }}</td>
+          <td class='js-searchable'>{{ company }}</td>
           <td>
             <ul class="list-inline status-btn-list">
             <li>
-              <a href={{ "{0}participant/{1}/badge".format(space.url_for(), p.id) }} class={% if p.badge_printed %} 'btn btn-xs btn-success'  {% else %} 'btn btn-xs btn-info' {% endif %} target="_blank">Show badge</a>
+              <a href="{{ showbadge_url }}" {{#badge_printed}} class="btn btn-xs btn-success" {{/badge_printed}} {{^badge_printed}} class="btn btn-xs btn-info" {{/badge_printed}} target="_blank">Show badge</a>
             </li>
             <li>
-              <a href={{ "{0}participant/{1}/edit".format(space.url_for(), p.id) }} class='btn btn-xs btn-default'>Edit</a>
+              <a href="{{ edit_url }}" class='btn btn-xs btn-default'>Edit</a>
             </li>
             <li>
-            {%- if p.checked_in %}
-              <a href="{{ event.name }}/checkin/{{ p.id }}" class='btn btn-xs btn-danger'>Cancel Check-in</a>
-            {%- else %}
-            <a href="{{ event.name }}/checkin/{{ p.id }}?checkin=t" class='btn btn-xs btn-warning'>Check-in</a>
-            {%- endif %}
+            {{#checked_in}}
+              <a href="{{ checkin_url }}/checkin/{{ pid }}" data-pid="{{ pid }}" class="btn btn-xs cancel-checkin">Cancel Check-in</a>
+              <i class="fa fa-spinner fa-pulse loader"></i>
+              <i class="fa fa-close loader abort"></i>
+            {{/checked_in}}
+            {{^checked_in}}
+              <a href="{{ checkin_url }}/checkin/{{ pid }}?checkin=t" data-pid="{{ pid }}"sd class="btn btn-xs checkin">Check-in</a>
+              <i class="fa fa-spinner fa-pulse loader"></i>
+              <i class="fa fa-close loader abort"></i>
+            {{/checked_in}}
             </li>
             </ul>
           </td>
         </tr>
-      {%- endfor %}
+      {{/each}}
+      </script>
+      {% endraw %}
     </tbody>
   </table>
 {% endblock %}
 {% block footerscripts %}
 <script>
+  if (Modernizr.localstorage) {
+    //Two arrays: checkin-queue and cancelcheckin-queue
+    Storage.prototype.set = function(queue, id) {
+      var participantList = JSON.parse(this.getItem(queue));
+      if(participantList) {
+        participantList.push(id);
+      }
+      else {
+        participantList = [];
+        participantList.push(id);
+      }
+      return this.setItem(queue, JSON.stringify(participantList))
+    }
+
+    Storage.prototype.getFirstItem = function(queue) {
+      var participantList = JSON.parse(this.getItem(queue));
+      if(participantList && participantList.length) {
+        return participantList[0];
+      }
+    }
+
+    Storage.prototype.getItems = function(queue) {
+      var participantList = JSON.parse(this.getItem(queue));
+      if(participantList && participantList.length) {
+        return participantList;
+      }
+    }
+
+    Storage.prototype.findItem = function(queue, id) {
+      var participantList = JSON.parse(this.getItem(queue));
+      if(participantList && participantList.indexOf(id) !== -1) {
+        return true;
+      }
+    }
+
+    Storage.prototype.remove = function(queue, id) {
+      var participantList = JSON.parse(this.getItem(queue));
+      if(participantList && participantList.indexOf(id) !== -1) {
+        participantList.splice(participantList.indexOf(id),1);
+        this.setItem(queue, JSON.stringify(participantList));
+        return true;
+      }
+    }
+  }
+
   $(document).ready(function() {
+    var checkinUrl = window.location.href + "/checkin/";
+    var getParticipantsUrl = window.location.href + "/participants/json";
+
+    // To disable debug mode
+    Ractive.DEBUG = false;
+
+    var participantTable = new Ractive({
+      el: '#participants',
+      template: '#participant',
+      data: {
+        participants: ''
+      }
+    });
+
+    function getParticipantsData() {
+      $.ajax({
+        type: 'GET',
+        url:  getParticipantsUrl,
+        timeout: 5000,
+        dataType: 'jsonp',
+        success: function(data) {
+          participantTable.set('participants', data.participants).then(function() {
+            $('.loader').hide();
+            updateQueue(localStorage.getItems('checkin-queue'), true);
+            updateQueue(localStorage.getItems('cancelcheckin-queue'), false);
+          });
+        }
+      });
+    }
+
+    function updateQueue(participantIDs, action) {
+      if(participantIDs) {
+        participantIDs.forEach(function(participantID) {
+          var participant = "[data-pid=" + participantID +"]";
+          if(action) {
+            if($(participant).hasClass('cancel-checkin')) {
+              localStorage.remove('checkin-queue', participantID);
+            }
+            else {
+              $(participant).siblings('.loader').show();
+            }
+          }
+          else {
+            if($(participant).hasClass('checkin')) {
+              localStorage.remove('cancel-checkin', participantID);
+            }
+            else {
+              $(participant).siblings('.loader').show();
+            }
+          }
+        });
+      }
+    }
+
+    function checkQueue() {
+      var participantID = localStorage.getFirstItem('checkin-queue');
+      if(participantID) {
+        postCheckinStatus(participantID, true);
+      }
+      participantID = localStorage.getFirstItem('cancelcheckin-queue');
+      if(participantID) {
+        postCheckinStatus(participantID, false);
+      }
+    }
+
+    function postCheckinStatus(participantID, action) {
+      if(action) {
+        var posturl = checkinUrl + participantID + "?checkin=t";
+      }
+      else {
+        var posturl = checkinUrl + participantID;
+      }
+      $.ajax({
+        type: 'post',
+        url:  posturl,
+        timeout: 5000,
+        dataType: "json",
+        success: function(data) {
+          if(data.checked_in) {
+            localStorage.remove('checkin-queue', data.participant_id);
+          }
+          else {
+            localStorage.remove('cancelcheckin-queue', data.participant_id);
+          }
+        }
+      });
+    }
+
+    //Get the list of participants from server
+    getParticipantsData();
+
+    if (Modernizr.localstorage) {
+      $('#participants').on('click', '.checkin', function(event) {
+        event.preventDefault();
+        localStorage.set('checkin-queue', $(this).data('pid'));
+        $(this).siblings('.loader').show();
+      });
+
+      $('#participants').on('click', '.cancel-checkin', function(event) {
+        event.preventDefault();
+        localStorage.set('cancelcheckin-queue', $(this).data('pid'));
+        $(this).siblings('.loader').show();
+      });
+
+      $('#participants').on('click', '.abort', function(event) {
+        event.preventDefault();
+        var participantID = $(this).siblings('a').data('pid');
+        var participant = "[data-pid=" + participantID +"]";
+
+        if($(participant).hasClass('checkin')) {
+          // If participantID not in queue, checkin status has been sent to server
+          // then for this participantID send a cancel checkin to server
+          if(!localStorage.remove('checkin-queue', participantID)) {
+            localStorage.set('cancelcheckin-queue', participantID);
+          }
+        }
+        else{
+          if(!localStorage.remove('cancelcheckin-queue', participantID)) {
+            localStorage.set('checkin-queue', participantID);
+          }
+        }
+        $(participant).parent().find('.loader').hide();
+      });
+
+      // Check checkin-queue and cancelcheckin-queue arrays every 8 second, for any participant
+      // whose check-in status needs to be send to server.
+      setInterval(checkQueue, 8000);
+
+      //Get participants list from server every 1 min
+      setInterval(getParticipantsData, 60000);
+    }
+
     $('#badge_form').on("submit", function(){
        if ($('#badge_form select.field-badge_printed').val() === "") {
         return false;

--- a/funnel/templates/event.html
+++ b/funnel/templates/event.html
@@ -86,7 +86,6 @@
 {% block footerscripts %}
 <script>
   if (Modernizr.localstorage) {
-    localStorage.clear();
     window.Talkfunnel.Store = {};
 
     //Local storage can only save strings, so value is converted into strings and stored.

--- a/funnel/templates/event.html
+++ b/funnel/templates/event.html
@@ -117,7 +117,7 @@
     window.Queue.peek = function(queueName) {
       var participantList = window.Store.readFromLocalstorage(queueName);
       if(participantList && participantList.length) {
-        return participantList.shift();
+        return participantList[0];
       }
     }
 

--- a/funnel/templates/event.html
+++ b/funnel/templates/event.html
@@ -60,7 +60,7 @@
               <a href="{{ showbadge_url }}" {{#badge_printed}} class="btn btn-xs btn-success" {{/badge_printed}} {{^badge_printed}} class="btn btn-xs btn-info" {{/badge_printed}} target="_blank">Show badge</a>
             </li>
             <li>
-              <a href="{{ edit_url }}" class='btn btn-xs btn-default'>Edit</a>
+              <a href="{{ edit_url }}" class="btn btn-xs btn-default" target="_blank">Edit</a>
             </li>
             <li>
             {{#checked_in}}
@@ -85,54 +85,127 @@
 {% endblock %}
 {% block footerscripts %}
 <script>
-  if (Modernizr.localstorage) {
-    //Two arrays: checkin-queue and cancelcheckin-queue
-    Storage.prototype.set = function(queue, id) {
-      var participantList = JSON.parse(this.getItem(queue));
+  $(document).ready(function() {
+    // To disable debug mode
+    Ractive.DEBUG = false;
+
+    //Reads from LocalStorage (key is 'checkin-queue' or 'cancelcheckin-queue')
+    function readFromLocalstorage(key) {
+      return JSON.parse(localStorage.getItem(key));
+    }
+    //Adds to LocalStorage (key is 'checkin-queue' or 'cancelcheckin-queue')
+    function addToLocalstorage(key, value) {
+      return localStorage.setItem(key, JSON.stringify(value))
+    }
+
+    //Adds a participant_id to queue
+    function enqueue(queueName, participant_id) {
+      var participantList = readFromLocalstorage(queueName);
       if(participantList) {
-        participantList.push(id);
+        participantList.push(participant_id);
       }
       else {
         participantList = [];
-        participantList.push(id);
+        participantList.push(participant_id);
       }
-      return this.setItem(queue, JSON.stringify(participantList))
+      return addToLocalstorage(queueName, participantList)
     }
 
-    Storage.prototype.getFirstItem = function(queue) {
-      var participantList = JSON.parse(this.getItem(queue));
+    //Reads first item from queue
+    //Returns undefined when queue is empty or not defined
+    function peek(queueName) {
+      var participantList = readFromLocalstorage(queueName);
       if(participantList && participantList.length) {
-        return participantList[0];
+        return participantList.shift();
       }
     }
 
-    Storage.prototype.getItems = function(queue) {
-      var participantList = JSON.parse(this.getItem(queue));
+    //Reads and returns all items from queue
+    //Returns undefined when queue is empty or not defined
+    function peekAllItems(queueName) {
+      var participantList = readFromLocalstorage(queueName);
       if(participantList && participantList.length) {
         return participantList;
       }
     }
 
-    Storage.prototype.findItem = function(queue, id) {
-      var participantList = JSON.parse(this.getItem(queue));
-      if(participantList && participantList.indexOf(id) !== -1) {
+    //Removes item from queue and returns true
+    //Returns undefined when item not present in queue
+    function dequeue(queueName, participant_id) {
+      var participantList = peekAllItems(queueName);
+      var index = participantList ? participantList.indexOf(participant_id) : -1;
+      if(index !== -1) {
+        //Remove item from queue and add updated queue to localStorage
+        participantList.splice(index, 1);
+        addToLocalstorage(queueName, participantList);
         return true;
       }
     }
 
-    Storage.prototype.remove = function(queue, id) {
-      var participantList = JSON.parse(this.getItem(queue));
-      if(participantList && participantList.indexOf(id) !== -1) {
-        participantList.splice(participantList.indexOf(id),1);
-        this.setItem(queue, JSON.stringify(participantList));
-        return true;
+    //updateQueue eg:- If participant in "checkin-queue" has already been checked-in then remove from queue
+    function updateQueue(queueName) {
+      var participantIDs = peekAllItems(queueName);
+      if(participantIDs) {
+        participantIDs.forEach(function(participantID) {
+          var participant = "[data-pid=" + participantID +"]";
+          if(queueName === "checkin-queue") {
+            if($(participant).hasClass('js-cancel-checkin')) {
+              //Participant has been checked-in so remove from 'checkin-queue' 
+              dequeue("checkin-queue", participantID);
+            }
+            else {
+              $(participant).siblings('.loader').show();
+            }
+          }
+          else {
+            if($(participant).hasClass('js-checkin')) {
+              //Participant's check-in has been cancelled so remove from 'cancelcheckin-queue' 
+              dequeue("cancelcheckin-queue", participantID);
+            }
+            else {
+              $(participant).siblings('.loader').show();
+            }
+          }
+        });
       }
     }
-  }
 
-  $(document).ready(function() {
-    // To disable debug mode
-    Ractive.DEBUG = false;
+    function postCheckinStatus(participantID, action) {
+      if(action) {
+        var posturl = "{{ '{0}event/{1}/checkin/'.format(space.url_for(), event.name) }}" + participantID + "?checkin=t";
+      }
+      else {
+        var posturl = "{{ '{0}event/{1}/checkin/'.format(space.url_for(), event.name) }}" + participantID;
+      }
+      $.ajax({
+        type: 'post',
+        url:  posturl,
+        timeout: 5000,
+        dataType: "json",
+        success: function(data) {
+          //Successfully posted to server so remove from queue
+          if(data.checked_in) {
+            dequeue("checkin-queue", data.participant_id);
+          }
+          else {
+            dequeue("cancelcheckin-queue", data.participant_id);
+          }
+        }
+      });
+    }
+
+    function checkQueues() {
+      //Read first participant from 'checkin-queue' and post check-in to server
+      var participantID = peek("checkin-queue");
+      if(participantID) {
+        postCheckinStatus(participantID, true);
+      }
+      //Read first participant from 'cancelcheckin-queue' and post cancel check-in to server
+      participantID = peek("cancelcheckin-queue");
+      if(participantID) {
+        postCheckinStatus(participantID, false);
+      }
+    }
 
     var participantTableContent = new Ractive({
       el: '#participants-table-content',
@@ -150,68 +223,12 @@
         dataType: 'jsonp',
         success: function(data) {
           participantTableContent.set('participants', data.participants).then(function() {
-            $('.loader').hide();
-            updateQueue(localStorage.getItems('checkin-queue'), true);
-            updateQueue(localStorage.getItems('cancelcheckin-queue'), false);
+            if (Modernizr.localstorage) {
+              $('.loader').hide();
+              updateQueue("checkin-queue");
+              updateQueue("cancelcheckin-queue");
+            }
           });
-        }
-      });
-    }
-
-    function updateQueue(participantIDs, action) {
-      if(participantIDs) {
-        participantIDs.forEach(function(participantID) {
-          var participant = "[data-pid=" + participantID +"]";
-          if(action) {
-            if($(participant).hasClass('js-cancel-checkin')) {
-              localStorage.remove('checkin-queue', participantID);
-            }
-            else {
-              $(participant).siblings('.loader').show();
-            }
-          }
-          else {
-            if($(participant).hasClass('js-checkin')) {
-              localStorage.remove('cancel-checkin', participantID);
-            }
-            else {
-              $(participant).siblings('.loader').show();
-            }
-          }
-        });
-      }
-    }
-
-    function checkQueue() {
-      var participantID = localStorage.getFirstItem('checkin-queue');
-      if(participantID) {
-        postCheckinStatus(participantID, true);
-      }
-      participantID = localStorage.getFirstItem('cancelcheckin-queue');
-      if(participantID) {
-        postCheckinStatus(participantID, false);
-      }
-    }
-
-    function postCheckinStatus(participantID, action) {
-      if(action) {
-        var posturl = "{{ '{0}event/{1}/checkin/'.format(space.url_for(), event.name) }}" + participantID + "?checkin=t";
-      }
-      else {
-        var posturl = "{{ '{0}event/{1}/checkin/'.format(space.url_for(), event.name) }}" + participantID;
-      }
-      $.ajax({
-        type: 'post',
-        url:  posturl,
-        timeout: 5000,
-        dataType: "json",
-        success: function(data) {
-          if(data.checked_in) {
-            localStorage.remove('checkin-queue', data.participant_id);
-          }
-          else {
-            localStorage.remove('cancelcheckin-queue', data.participant_id);
-          }
         }
       });
     }
@@ -219,16 +236,19 @@
     //Get the list of participants from server
     getParticipantsData();
 
+    //If localStorage is available, register event handlers for check-in, cancel-checkin and abort
     if (Modernizr.localstorage) {
       $('#participants-table-content').on('click', '.js-checkin', function(event) {
         event.preventDefault();
-        localStorage.set('checkin-queue', $(this).data('pid'));
+        //Add to participant_id to "checkin-queue"
+        enqueue("checkin-queue", $(this).data('pid'));
         $(this).siblings('.loader').show();
       });
 
       $('#participants-table-content').on('click', '.js-cancel-checkin', function(event) {
         event.preventDefault();
-        localStorage.set('cancelcheckin-queue', $(this).data('pid'));
+        //Add to participant_id to "cancelcheckin-queue"
+        enqueue("cancelcheckin-queue", $(this).data('pid'));
         $(this).siblings('.loader').show();
       });
 
@@ -238,25 +258,31 @@
         var participant = "[data-pid=" + participantID +"]";
 
         if($(participant).hasClass('js-checkin')) {
-          // If participantID not in queue, checkin status has been sent to server
-          // then for this participantID send a cancel checkin to server
-          if(!localStorage.remove('checkin-queue', participantID)) {
-            localStorage.set('cancelcheckin-queue', participantID);
+          // On abort, if participantID present in the queue, then remove from "checkin-queue"
+          // On abort, if participantID is not present in the "checkin-queue" it implies check-in has already been done, so a cancel check-in requires to be send(add it to "cancelcheckin-queue")
+          if(!dequeue("checkin-queue", participantID)) {
+            enqueue("cancelcheckin-queue", participantID);
           }
         }
         else{
-          if(!localStorage.remove('cancelcheckin-queue', participantID)) {
-            localStorage.set('checkin-queue', participantID);
+          if(!dequeue("cancelcheckin-queue", participantID)) {
+            enqueue("checkin-queue", participantID);
           }
         }
-        $(participant).parent().find('.loader').hide();
+        $(participant).siblings('.loader').hide();
       });
 
-      // Check checkin-queue and cancelcheckin-queue arrays every 8 second, for any participant
-      // whose check-in status needs to be send to server.
-      setInterval(checkQueue, 8000);
+      //If there is no network, display a confirmation dialog when user closes/reloades the page
+      window.onbeforeunload = function() {
+        if(!navigator.onLine) {
+          return 'There is no network!';
+        }
+      }
 
-      //Get participants list from server every 1 min
+      //Read 'checkin-queue' and 'cancelcheckin-queue' every 8 second
+      setInterval(checkQueues, 8000);
+
+      //Get participants data from server every 1 min
       setInterval(getParticipantsData, 60000);
     }
 
@@ -343,12 +369,6 @@
         tablet: 768,
       }
     });
-
-    window.onbeforeunload = function() {
-      if(!navigator.onLine) {
-        return 'There is no network!';
-      }
-    }
 
   });
 </script>

--- a/funnel/templates/event.html
+++ b/funnel/templates/event.html
@@ -64,12 +64,12 @@
             </li>
             <li>
             {{#checked_in}}
-              <a href="{{ checkin_url }}/checkin/{{ pid }}" data-pid="{{ pid }}" class="btn btn-xs js-cancel-checkin">Cancel Check-in</a>
+              <a href="{{ checkin_url }}/checkin/?pid={{ pid }}" data-pid="{{ pid }}" class="btn btn-xs js-cancel-checkin">Cancel Check-in</a>
               <i class="fa fa-spinner fa-pulse loader"></i>
               <i class="fa fa-close loader js-abort"></i>
             {{/checked_in}}
             {{^checked_in}}
-              <a href="{{ checkin_url }}/checkin/{{ pid }}?checkin=t" data-pid="{{ pid }}"sd class="btn btn-xs js-checkin">Check-in</a>
+              <a href="{{ checkin_url }}/checkin/?pid={{ pid }}&checkin=t" data-pid="{{ pid }}" class="btn btn-xs js-checkin">Check-in</a>
               <i class="fa fa-spinner fa-pulse loader"></i>
               <i class="fa fa-close loader js-abort"></i>
             {{/checked_in}}
@@ -86,45 +86,35 @@
 {% block footerscripts %}
 <script>
   if (Modernizr.localstorage) {
-    window.Store = {};
+    window.HasGeekTalkfunnel = {}
 
-    //Reads from LocalStorage (key is 'checkin-queue' or 'cancelcheckin-queue')
-    window.Store.readFromLocalstorage = function(key) {
-      return JSON.parse(localStorage.getItem(key));
-    }
-    //Adds to LocalStorage (key is 'checkin-queue' or 'cancelcheckin-queue')
-    window.Store.addToLocalstorage = function(key, value) {
+    window.HasGeekTalkfunnel.Store = {};
+
+    //Local storage can only save strings, so value is converted into strings and stored.
+    window.HasGeekTalkfunnel.Store.addToLocalstorage = function(key, value) {
       return localStorage.setItem(key, JSON.stringify(value))
     }
 
-    window.Queue = {};
-
-    //Adds a participant_id to queue
-    window.Queue.enqueue = function(queueName, participant_id) {
-      var participantList = window.Store.readFromLocalstorage(queueName);
-      if(participantList) {
-        participantList.push(participant_id);
-      }
-      else {
-        participantList = [];
-        participantList.push(participant_id);
-      }
-      return window.Store.addToLocalstorage(queueName, participantList)
+    //Reads from LocalStorage.
+    window.HasGeekTalkfunnel.Store.readFromLocalstorage = function(key) {
+      return JSON.parse(localStorage.getItem(key));
     }
 
-    //Reads first item from queue
-    //Returns undefined when queue is empty or not defined
-    window.Queue.peek = function(queueName) {
-      var participantList = window.Store.readFromLocalstorage(queueName);
-      if(participantList && participantList.length) {
-        return participantList[0];
+    window.HasGeekTalkfunnel.Queue = {};
+
+    //Adds a participant_id to queue
+    window.HasGeekTalkfunnel.Queue.enqueue = function(queueName, participant_id) {
+      var participantList = window.HasGeekTalkfunnel.Store.readFromLocalstorage(queueName) || [];
+      if(participantList.indexOf(participant_id) === -1) {
+        participantList.push(participant_id);
+        return window.HasGeekTalkfunnel.Store.addToLocalstorage(queueName, participantList)
       }
     }
 
     //Reads and returns all items from queue
     //Returns undefined when queue is empty or not defined
-    window.Queue.peekAllItems = function(queueName) {
-      var participantList = window.Store.readFromLocalstorage(queueName);
+    window.HasGeekTalkfunnel.Queue.peekAll = function(queueName) {
+      var participantList = window.HasGeekTalkfunnel.Store.readFromLocalstorage(queueName);
       if(participantList && participantList.length) {
         return participantList;
       }
@@ -132,13 +122,13 @@
 
     //Removes item from queue and returns true
     //Returns undefined when item not present in queue
-    window.Queue.dequeue = function(queueName, participant_id) {
-      var participantList = window.Store.readFromLocalstorage(queueName);
+    window.HasGeekTalkfunnel.Queue.dequeue = function(queueName, participant_id) {
+      var participantList = window.HasGeekTalkfunnel.Store.readFromLocalstorage(queueName);
       var index = participantList ? participantList.indexOf(participant_id) : -1;
       if(index !== -1) {
         //Remove item from queue and add updated queue to localStorage
         participantList.splice(index, 1);
-        window.Store.addToLocalstorage(queueName, participantList);
+        window.HasGeekTalkfunnel.Store.addToLocalstorage(queueName, participantList);
         return true;
       }
     }
@@ -158,14 +148,14 @@
 
     //updateQueue: If participant in "checkin-queue" has already been checked-in then it is removed from checkin queue
     function updateQueue(queueName) {
-      var participantIDs = window.Queue.peekAllItems(queueName);
+      var participantIDs = window.HasGeekTalkfunnel.Queue.peekAll(queueName);
       if(participantIDs) {
         participantIDs.forEach(function(participantID) {
           var participant = "[data-pid=" + participantID +"]";
           if(queueName === "checkin-queue") {
             if($(participant).hasClass('js-cancel-checkin')) {
               //Participant has been checked-in so remove from 'checkin-queue' 
-              window.Queue.dequeue("checkin-queue", participantID);
+              window.HasGeekTalkfunnel.Queue.dequeue("checkin-queue", participantID);
             }
             else {
               $(participant).siblings('.loader').show();
@@ -174,7 +164,7 @@
           else {
             if($(participant).hasClass('js-checkin')) {
               //Participant's check-in has been cancelled so remove from 'cancelcheckin-queue' 
-              window.Queue.dequeue("cancelcheckin-queue", participantID);
+              window.HasGeekTalkfunnel.Queue.dequeue("cancelcheckin-queue", participantID);
             }
             else {
               $(participant).siblings('.loader').show();
@@ -184,7 +174,7 @@
       }
     }
 
-    function getParticipantsData() {
+    function updateParticipantList() {
       $.ajax({
         type: 'GET',
         url:  '{{ "{0}event/{1}/participants/json".format(space.url_for(), event.name) }}',
@@ -202,12 +192,10 @@
       });
     }
 
-    function postCheckinStatus(participantID, action) {
+    function postCheckinStatus(participantIDs, action) {
+      var posturl = "{{ '{0}event/{1}/checkin/'.format(space.url_for(), event.name) }}" + "?" + $.param({"pid":participantIDs}, true);
       if(action) {
-        var posturl = "{{ '{0}event/{1}/checkin/'.format(space.url_for(), event.name) }}" + participantID + "?checkin=t";
-      }
-      else {
-        var posturl = "{{ '{0}event/{1}/checkin/'.format(space.url_for(), event.name) }}" + participantID;
+        posturl += "&checkin=t";
       }
       $.ajax({
         type: 'post',
@@ -216,62 +204,66 @@
         dataType: "json",
         success: function(data) {
           if(data.checked_in) {
-            window.Queue.dequeue("checkin-queue", data.participant_id);
+            data.participant_ids.forEach(function(participant_id) {
+              window.HasGeekTalkfunnel.Queue.dequeue("checkin-queue", participant_id);
+            });
           }
           else {
-            window.Queue.dequeue("cancelcheckin-queue", data.participant_id);
+            data.participant_ids.forEach(function(participant_id) {
+              window.HasGeekTalkfunnel.Queue.dequeue("cancelcheckin-queue", participant_id);
+            });
           }
         }
       });
     }
 
     function checkQueues() {
-      //Read first participant from 'checkin-queue' and post check-in to server
-      var participantID = window.Queue.peek("checkin-queue");
-      if(participantID) {
-        postCheckinStatus(participantID, true);
+      //Read all participants from 'checkin-queue' and post check-in to server
+      var participantIDs = window.HasGeekTalkfunnel.Queue.peekAll("checkin-queue");
+      if(participantIDs) {
+        postCheckinStatus(participantIDs, true);
       }
-      //Read first participant from 'cancelcheckin-queue' and post cancel check-in to server
-      participantID = window.Queue.peek("cancelcheckin-queue");
-      if(participantID) {
-        postCheckinStatus(participantID, false);
+      //Read all participants from 'cancelcheckin-queue' and post cancel check-in to server
+      participantIDs = window.HasGeekTalkfunnel.Queue.peekAll("cancelcheckin-queue");
+      if(participantIDs) {
+        postCheckinStatus(participantIDs, false);
       }
     }
 
     //Get the list of participants from server
-    getParticipantsData();
+    updateParticipantList();
 
     //If localStorage is available, register event handlers for check-in, cancel-checkin and abort
     if (Modernizr.localstorage) {
       $('#participants-table-content').on('click', '.js-checkin', function(event) {
         event.preventDefault();
         //Add to participant_id to "checkin-queue"
-        window.Queue.enqueue("checkin-queue", $(this).data('pid'));
+        window.HasGeekTalkfunnel.Queue.enqueue("checkin-queue", $(this).attr('data-pid'));
         $(this).siblings('.loader').show();
       });
 
       $('#participants-table-content').on('click', '.js-cancel-checkin', function(event) {
         event.preventDefault();
         //Add to participant_id to "cancelcheckin-queue"
-        window.Queue.enqueue("cancelcheckin-queue", $(this).data('pid'));
+        window.HasGeekTalkfunnel.Queue.enqueue("cancelcheckin-queue", $(this).attr('data-pid'));
         $(this).siblings('.loader').show();
       });
 
       $('#participants-table-content').on('click', '.js-abort', function(event) {
         event.preventDefault();
-        var participantID = $(this).siblings('a').data('pid');
+        var participantID = $(this).siblings('a').attr('data-pid');
         var participant = "[data-pid=" + participantID +"]";
 
         if($(participant).hasClass('js-checkin')) {
           // On abort, if participantID present in the queue, then remove from "checkin-queue"
           // On abort, if participantID is not present in the "checkin-queue" it implies check-in has already been done, so a cancel check-in requires to be send(add it to "cancelcheckin-queue")
-          if(!window.Queue.dequeue("checkin-queue", participantID)) {
-            window.Queue.enqueue("cancelcheckin-queue", participantID);
+          if(!window.HasGeekTalkfunnel.Queue.dequeue("checkin-queue", participantID)) {
+            window.HasGeekTalkfunnel.Queue.enqueue("cancelcheckin-queue", participantID);
           }
         }
         else{
-          if(!window.Queue.dequeue("cancelcheckin-queue", participantID)) {
-            window.Queue.enqueue("checkin-queue", participantID);
+          if(!window.HasGeekTalkfunnel.Queue.dequeue("cancelcheckin-queue", participantID)) {
+            window.HasGeekTalkfunnel.Queue.enqueue("checkin-queue", participantID);
           }
         }
         $(participant).siblings('.loader').hide();
@@ -288,7 +280,7 @@
       setInterval(checkQueues, 8000);
 
       //Get participants data from server every 1 min
-      setInterval(getParticipantsData, 60000);
+      setInterval(updateParticipantList, 60000);
     }
 
     $('#badge_form').on("submit", function(){

--- a/funnel/templates/event.html
+++ b/funnel/templates/event.html
@@ -86,48 +86,58 @@
 {% block footerscripts %}
 <script>
   if (Modernizr.localstorage) {
+    localStorage.clear();
     window.Talkfunnel.Store = {};
 
     //Local storage can only save strings, so value is converted into strings and stored.
-    window.Talkfunnel.Store.addToLocalstorage = function(key, value) {
+    window.Talkfunnel.Store.add = function(key, value) {
       return localStorage.setItem(key, JSON.stringify(value));
     };
 
     //Reads from LocalStorage.
-    window.Talkfunnel.Store.readFromLocalstorage = function(key) {
+    window.Talkfunnel.Store.read = function(key) {
       return JSON.parse(localStorage.getItem(key));
     };
 
-    window.Talkfunnel.Queue = {};
+    window.Talkfunnel.Queue = function(queueName) {
+      this.queueName = queueName;
 
-    //Adds a participant_id to queue
-    window.Talkfunnel.Queue.enqueue = function(queueName, participant_id) {
-      var participantList = window.Talkfunnel.Store.readFromLocalstorage(queueName) || [];
-      if(participantList.indexOf(participant_id) === -1) {
-        participantList.push(participant_id);
-        return window.Talkfunnel.Store.addToLocalstorage(queueName, participantList);
-      }
-    };
+      //Adds a participant_id to queue
+      this.enqueue = function(participant_id) {
+        var participantList = window.Talkfunnel.Store.read(this.queueName) || [];
+        if(participantList.indexOf(participant_id) === -1) {
+          participantList.push(participant_id);
+          return window.Talkfunnel.Store.add(this.queueName, participantList);
+        }
+      };
 
-    //Reads and returns all items from queue
-    //Returns undefined when queue is empty or not defined
-    window.Talkfunnel.Queue.peekAll = function(queueName) {
-      var participantList = window.Talkfunnel.Store.readFromLocalstorage(queueName);
-      if(participantList && participantList.length) {
-        return participantList;
-      }
-    };
+      //Reads and returns all items from queue
+      //Returns undefined when queue is empty or not defined
+      this.readAll = function() {
+        var participantList = window.Talkfunnel.Store.read(this.queueName);
+        if(participantList && participantList.length) {
+          return participantList;
+        }
+      };
 
-    //Removes item from queue and returns true
-    //Returns undefined when item not present in queue
-    window.Talkfunnel.Queue.dequeue = function(queueName, participant_id) {
-      var participantList = window.Talkfunnel.Store.readFromLocalstorage(queueName);
-      var index = participantList ? participantList.indexOf(participant_id) : -1;
-      if(index !== -1) {
-        //Remove item from queue and add updated queue to localStorage
-        participantList.splice(index, 1);
-        window.Talkfunnel.Store.addToLocalstorage(queueName, participantList);
-        return true;
+      //Removes item from queue and returns true
+      //Returns undefined when item not present in queue
+      this.dequeue = function(participant_id) {
+        var participantList = window.Talkfunnel.Store.read(this.queueName);
+        var index = participantList ? participantList.indexOf(participant_id) : -1;
+        if(index !== -1) {
+          //Remove item from queue and add updated queue to localStorage
+          participantList.splice(index, 1);
+          window.Talkfunnel.Store.add(this.queueName, participantList);
+          return participant_id;
+        }
+      };
+    }
+
+    //If there is no network, display a confirmation dialog when user closes/reloades the page
+    window.onbeforeunload = function() {
+      if(!navigator.onLine) {
+        return 'There is no network!';
       }
     };
   }
@@ -144,16 +154,19 @@
       }
     });
 
+    var checkinQ = new window.Talkfunnel.Queue("checkin-queue");
+    var cancelcheckinQ = new window.Talkfunnel.Queue("cancelcheckin-queue");
+
     //updateQueue: If participant in "checkin-queue" has already been checked-in then it is removed from checkin queue
-    function updateQueue(queueName, participants) {
-      var participantIDs = window.Talkfunnel.Queue.peekAll(queueName);
+    var updateQueue = function(queue, participants) {
+      var participantIDs = queue.readAll();
       if(participantIDs) {
         participantIDs.forEach(function(participantID) {
           var participant = "[data-pid=" + participantID +"]";
-          if(queueName === "checkin-queue") {
+          if(queue.queueName === "checkin-queue") {
             if(participants[participantID].checked_in) {
               //Participant has been checked-in so remove from 'checkin-queue' 
-              window.Talkfunnel.Queue.dequeue("checkin-queue", participantID);
+              queue.dequeue(participantID);
             }
             else {
               $(participant).siblings('.loader').show();
@@ -162,7 +175,7 @@
           else {
             if(!participants[participantID].checked_in) {
               //Participant's check-in has been cancelled so remove from 'cancelcheckin-queue' 
-              window.Talkfunnel.Queue.dequeue("cancelcheckin-queue", participantID);
+              queue.dequeue(participantID);
             }
             else {
               $(participant).siblings('.loader').show();
@@ -172,7 +185,7 @@
       }
     }
 
-    function updateParticipantList() {
+    var updateParticipantList = function() {
       $.ajax({
         type: 'GET',
         url:  '{{ "{0}event/{1}/participants/json".format(space.url_for(), event.name) }}',
@@ -183,15 +196,15 @@
             if (Modernizr.localstorage) {
               $('.loader').hide();
               var participants = tohashMap(data.participants, "pid");
-              updateQueue("checkin-queue", participants);
-              updateQueue("cancelcheckin-queue", participants);
+              updateQueue(checkinQ, participants);
+              updateQueue(cancelcheckinQ, participants);
             }
           });
         }
       });
     }
 
-    function postCheckinStatus(participantIDs, action) {
+    var postCheckinStatus = function(participantIDs, action) {
       var posturl = "{{ '{0}event/{1}/checkin/'.format(space.url_for(), event.name) }}" + "?" + $.param({"pid":participantIDs}, true);
       if(action) {
         posturl += "&checkin=t";
@@ -204,30 +217,44 @@
         success: function(data) {
           if(data.checked_in) {
             data.participant_ids.forEach(function(participant_id) {
-              window.Talkfunnel.Queue.dequeue("checkin-queue", participant_id);
+              checkinQ.dequeue(participant_id);
             });
           }
           else {
             data.participant_ids.forEach(function(participant_id) {
-              window.Talkfunnel.Queue.dequeue("cancelcheckin-queue", participant_id);
+              cancelcheckinQ.dequeue(participant_id);
             });
           }
         }
       });
     }
 
-    function processQueues() {
+    var processQueues = function() {
       //Read all participants from 'checkin-queue' and post check-in to server
-      var participantIDs = window.Talkfunnel.Queue.peekAll("checkin-queue");
+      var participantIDs = checkinQ.readAll();
       if(participantIDs) {
         postCheckinStatus(participantIDs, true);
       }
       //Read all participants from 'cancelcheckin-queue' and post cancel check-in to server
-      participantIDs = window.Talkfunnel.Queue.peekAll("cancelcheckin-queue");
+      participantIDs = cancelcheckinQ.readAll();
       if(participantIDs) {
         postCheckinStatus(participantIDs, false);
       }
     }
+
+    /*
+      Check-in scenarios:
+      1. A participant is checked-in & Internet is available. Also verify for cancel check-in and multiple participants check-in.
+      2. A participant is checked-in & Internet is down.
+      3. Abort a participant's check-in(A wrong particpant was checked in so cancel check-in immediately using abort) when Internet is available.
+      4. Abort a participant's check-in when Internet is down.
+      5. There are two check-in counters & both counters have internet: They have checked-in different participants. Verify both counters have the recent check-in status of participants.
+      6. There are two check-in counters & both counter's internet is down: They have checked-in different participants. Verify both counters have the recent check-in status of participants, once internet is up.
+      7. There are two check-in counters & both counters have internet: They checked-in few same participants. Verify both counters have the recent check-in status of participants.
+      8. There are two check-in counters & both counter's internet is down: They checked-in few same participants. Verify both counters have the recent check-in status of participants, once internet is up.
+      8. There are two check-in counters & one counters has internet and the other counter doesn't: They have checked-in different participants. Verify both counters have the recent check-in status of participants, once internet is up.
+      9. There are two check-in counters & one counters has internet and the other counter doesn't: They have checked-in few same participants. Verify both counters have the recent check-in status of participants, once internet is up.
+    */
 
     //Get the list of participants from server
     updateParticipantList();
@@ -237,14 +264,14 @@
       $('#participants-table-content').on('click', '.js-checkin', function(event) {
         event.preventDefault();
         //Add to participant_id to "checkin-queue"
-        window.Talkfunnel.Queue.enqueue("checkin-queue", $(this).attr('data-pid'));
+        checkinQ.enqueue($(this).attr('data-pid'));
         $(this).siblings('.loader').show();
       });
 
       $('#participants-table-content').on('click', '.js-cancel-checkin', function(event) {
         event.preventDefault();
         //Add to participant_id to "cancelcheckin-queue"
-        window.Talkfunnel.Queue.enqueue("cancelcheckin-queue", $(this).attr('data-pid'));
+        cancelcheckinQ.enqueue($(this).attr('data-pid'));
         $(this).siblings('.loader').show();
       });
 
@@ -254,26 +281,19 @@
         var participant = "[data-pid=" + participantID +"]";
 
         if($(participant).hasClass('js-checkin')) {
-          // On abort, if participantID present in the queue, then remove from "checkin-queue"
-          // On abort, if participantID is not present in the "checkin-queue" it implies check-in has already been done, so a cancel check-in requires to be send(add it to "cancelcheckin-queue")
-          if(!window.Talkfunnel.Queue.dequeue("checkin-queue", participantID)) {
-            window.Talkfunnel.Queue.enqueue("cancelcheckin-queue", participantID);
+          // Case 1: On abort, participantID is removed from "checkin-queue" if present.
+          // Case 2: On abort, if participantID is not present in the "checkin-queue" it implies check-in request has been sent to server, so check-in has to be cancelled hence add it to "cancelcheckin-queue".
+          if(!checkinQ.dequeue(participantID)) {
+            cancelcheckinQ.enqueue(participantID);
           }
         }
         else{
-          if(!window.Talkfunnel.Queue.dequeue("cancelcheckin-queue", participantID)) {
-            window.Talkfunnel.Queue.enqueue("checkin-queue", participantID);
+          if(!cancelcheckinQ.dequeue(participantID)) {
+            checkinQ.enqueue(participantID);
           }
         }
         $(participant).siblings('.loader').hide();
       });
-
-      //If there is no network, display a confirmation dialog when user closes/reloades the page
-      window.onbeforeunload = function() {
-        if(!navigator.onLine) {
-          return 'There is no network!';
-        }
-      };
 
       //Read 'checkin-queue' and 'cancelcheckin-queue' every 8 second and post check-in status to server
       setInterval(processQueues, 8000);

--- a/funnel/templates/event.html
+++ b/funnel/templates/event.html
@@ -24,7 +24,7 @@
     </div>
     <div class="col-lg-9 col-xs-12">
       <ul class="list-inline status-btn-list">
-        <li><a href={{ space.url_for('new-participant') }} class='btn btn-primary'>New Participant</a></li>
+        <li><a href={{ space.url_for('new-participant') }} class='btn btn-primary' target="_blank">New Participant</a></li>
         <li><a href={{ "{0}event/{1}/badges".format(space.url_for(), event.name) }} class='btn btn-info' target="_blank">Badges to be printed</a></li>
         <li><a href={{ "{0}event/{1}/badges?badge_printed=t".format(space.url_for(), event.name) }} class='btn btn-success' target="_blank">Badges printed</a></li>
         <li class="badge-print-status-btn">
@@ -343,6 +343,12 @@
         tablet: 768,
       }
     });
+
+    window.onbeforeunload = function() {
+      if(!navigator.onLine) {
+        return 'There is no network!';
+      }
+    }
 
   });
 </script>

--- a/funnel/templates/event.html
+++ b/funnel/templates/event.html
@@ -86,35 +86,33 @@
 {% block footerscripts %}
 <script>
   if (Modernizr.localstorage) {
-    window.HasGeekTalkfunnel = {}
-
-    window.HasGeekTalkfunnel.Store = {};
+    window.Talkfunnel.Store = {};
 
     //Local storage can only save strings, so value is converted into strings and stored.
-    window.HasGeekTalkfunnel.Store.addToLocalstorage = function(key, value) {
+    window.Talkfunnel.Store.addToLocalstorage = function(key, value) {
       return localStorage.setItem(key, JSON.stringify(value))
     }
 
     //Reads from LocalStorage.
-    window.HasGeekTalkfunnel.Store.readFromLocalstorage = function(key) {
+    window.Talkfunnel.Store.readFromLocalstorage = function(key) {
       return JSON.parse(localStorage.getItem(key));
     }
 
-    window.HasGeekTalkfunnel.Queue = {};
+    window.Talkfunnel.Queue = {};
 
     //Adds a participant_id to queue
-    window.HasGeekTalkfunnel.Queue.enqueue = function(queueName, participant_id) {
-      var participantList = window.HasGeekTalkfunnel.Store.readFromLocalstorage(queueName) || [];
+    window.Talkfunnel.Queue.enqueue = function(queueName, participant_id) {
+      var participantList = window.Talkfunnel.Store.readFromLocalstorage(queueName) || [];
       if(participantList.indexOf(participant_id) === -1) {
         participantList.push(participant_id);
-        return window.HasGeekTalkfunnel.Store.addToLocalstorage(queueName, participantList)
+        return window.Talkfunnel.Store.addToLocalstorage(queueName, participantList)
       }
     }
 
     //Reads and returns all items from queue
     //Returns undefined when queue is empty or not defined
-    window.HasGeekTalkfunnel.Queue.peekAll = function(queueName) {
-      var participantList = window.HasGeekTalkfunnel.Store.readFromLocalstorage(queueName);
+    window.Talkfunnel.Queue.peekAll = function(queueName) {
+      var participantList = window.Talkfunnel.Store.readFromLocalstorage(queueName);
       if(participantList && participantList.length) {
         return participantList;
       }
@@ -122,13 +120,13 @@
 
     //Removes item from queue and returns true
     //Returns undefined when item not present in queue
-    window.HasGeekTalkfunnel.Queue.dequeue = function(queueName, participant_id) {
-      var participantList = window.HasGeekTalkfunnel.Store.readFromLocalstorage(queueName);
+    window.Talkfunnel.Queue.dequeue = function(queueName, participant_id) {
+      var participantList = window.Talkfunnel.Store.readFromLocalstorage(queueName);
       var index = participantList ? participantList.indexOf(participant_id) : -1;
       if(index !== -1) {
         //Remove item from queue and add updated queue to localStorage
         participantList.splice(index, 1);
-        window.HasGeekTalkfunnel.Store.addToLocalstorage(queueName, participantList);
+        window.Talkfunnel.Store.addToLocalstorage(queueName, participantList);
         return true;
       }
     }
@@ -147,24 +145,23 @@
     });
 
     //updateQueue: If participant in "checkin-queue" has already been checked-in then it is removed from checkin queue
-    function updateQueue(queueName) {
-      var participantIDs = window.HasGeekTalkfunnel.Queue.peekAll(queueName);
+    function updateQueue(queueName, participants) {
+      var participantIDs = window.Talkfunnel.Queue.peekAll(queueName);
       if(participantIDs) {
         participantIDs.forEach(function(participantID) {
-          var participant = "[data-pid=" + participantID +"]";
           if(queueName === "checkin-queue") {
-            if($(participant).hasClass('js-cancel-checkin')) {
+            if(participants[participantID].checked_in) {
               //Participant has been checked-in so remove from 'checkin-queue' 
-              window.HasGeekTalkfunnel.Queue.dequeue("checkin-queue", participantID);
+              window.Talkfunnel.Queue.dequeue("checkin-queue", participantID);
             }
             else {
               $(participant).siblings('.loader').show();
             }
           }
           else {
-            if($(participant).hasClass('js-checkin')) {
+            if(!participants[participantID].checked_in) {
               //Participant's check-in has been cancelled so remove from 'cancelcheckin-queue' 
-              window.HasGeekTalkfunnel.Queue.dequeue("cancelcheckin-queue", participantID);
+              window.Talkfunnel.Queue.dequeue("cancelcheckin-queue", participantID);
             }
             else {
               $(participant).siblings('.loader').show();
@@ -184,8 +181,9 @@
           participantTableContent.set('participants', data.participants).then(function() {
             if (Modernizr.localstorage) {
               $('.loader').hide();
-              updateQueue("checkin-queue");
-              updateQueue("cancelcheckin-queue");
+              var participants = tohashMap(data.participants, "pid");
+              updateQueue("checkin-queue", participants);
+              updateQueue("cancelcheckin-queue", participants);
             }
           });
         }
@@ -205,26 +203,26 @@
         success: function(data) {
           if(data.checked_in) {
             data.participant_ids.forEach(function(participant_id) {
-              window.HasGeekTalkfunnel.Queue.dequeue("checkin-queue", participant_id);
+              window.Talkfunnel.Queue.dequeue("checkin-queue", participant_id);
             });
           }
           else {
             data.participant_ids.forEach(function(participant_id) {
-              window.HasGeekTalkfunnel.Queue.dequeue("cancelcheckin-queue", participant_id);
+              window.Talkfunnel.Queue.dequeue("cancelcheckin-queue", participant_id);
             });
           }
         }
       });
     }
 
-    function checkQueues() {
+    function processQueues() {
       //Read all participants from 'checkin-queue' and post check-in to server
-      var participantIDs = window.HasGeekTalkfunnel.Queue.peekAll("checkin-queue");
+      var participantIDs = window.Talkfunnel.Queue.peekAll("checkin-queue");
       if(participantIDs) {
         postCheckinStatus(participantIDs, true);
       }
       //Read all participants from 'cancelcheckin-queue' and post cancel check-in to server
-      participantIDs = window.HasGeekTalkfunnel.Queue.peekAll("cancelcheckin-queue");
+      participantIDs = window.Talkfunnel.Queue.peekAll("cancelcheckin-queue");
       if(participantIDs) {
         postCheckinStatus(participantIDs, false);
       }
@@ -238,14 +236,14 @@
       $('#participants-table-content').on('click', '.js-checkin', function(event) {
         event.preventDefault();
         //Add to participant_id to "checkin-queue"
-        window.HasGeekTalkfunnel.Queue.enqueue("checkin-queue", $(this).attr('data-pid'));
+        window.Talkfunnel.Queue.enqueue("checkin-queue", $(this).attr('data-pid'));
         $(this).siblings('.loader').show();
       });
 
       $('#participants-table-content').on('click', '.js-cancel-checkin', function(event) {
         event.preventDefault();
         //Add to participant_id to "cancelcheckin-queue"
-        window.HasGeekTalkfunnel.Queue.enqueue("cancelcheckin-queue", $(this).attr('data-pid'));
+        window.Talkfunnel.Queue.enqueue("cancelcheckin-queue", $(this).attr('data-pid'));
         $(this).siblings('.loader').show();
       });
 
@@ -257,13 +255,13 @@
         if($(participant).hasClass('js-checkin')) {
           // On abort, if participantID present in the queue, then remove from "checkin-queue"
           // On abort, if participantID is not present in the "checkin-queue" it implies check-in has already been done, so a cancel check-in requires to be send(add it to "cancelcheckin-queue")
-          if(!window.HasGeekTalkfunnel.Queue.dequeue("checkin-queue", participantID)) {
-            window.HasGeekTalkfunnel.Queue.enqueue("cancelcheckin-queue", participantID);
+          if(!window.Talkfunnel.Queue.dequeue("checkin-queue", participantID)) {
+            window.Talkfunnel.Queue.enqueue("cancelcheckin-queue", participantID);
           }
         }
         else{
-          if(!window.HasGeekTalkfunnel.Queue.dequeue("cancelcheckin-queue", participantID)) {
-            window.HasGeekTalkfunnel.Queue.enqueue("checkin-queue", participantID);
+          if(!window.Talkfunnel.Queue.dequeue("cancelcheckin-queue", participantID)) {
+            window.Talkfunnel.Queue.enqueue("checkin-queue", participantID);
           }
         }
         $(participant).siblings('.loader').hide();
@@ -276,8 +274,8 @@
         }
       }
 
-      //Read 'checkin-queue' and 'cancelcheckin-queue' every 8 second
-      setInterval(checkQueues, 8000);
+      //Read 'checkin-queue' and 'cancelcheckin-queue' every 8 second and post check-in status to server
+      setInterval(processQueues, 8000);
 
       //Get participants data from server every 1 min
       setInterval(updateParticipantList, 60000);

--- a/funnel/templates/event.html
+++ b/funnel/templates/event.html
@@ -46,9 +46,9 @@
         <th>Actions</th>
       </tr>
     </thead>
-    <tbody id="participants">
+    <tbody id="participants-table-content">
       {% raw %}
-      <script id='participant' type='text/ractive'>
+      <script id='participant-row' type='text/ractive'>
       {{#each participants}}
         <tr id="p-{{ pid }}">
           <td class='js-searchable'>{{ fullname }}</td>
@@ -64,14 +64,14 @@
             </li>
             <li>
             {{#checked_in}}
-              <a href="{{ checkin_url }}/checkin/{{ pid }}" data-pid="{{ pid }}" class="btn btn-xs cancel-checkin">Cancel Check-in</a>
+              <a href="{{ checkin_url }}/checkin/{{ pid }}" data-pid="{{ pid }}" class="btn btn-xs js-cancel-checkin">Cancel Check-in</a>
               <i class="fa fa-spinner fa-pulse loader"></i>
-              <i class="fa fa-close loader abort"></i>
+              <i class="fa fa-close loader js-abort"></i>
             {{/checked_in}}
             {{^checked_in}}
-              <a href="{{ checkin_url }}/checkin/{{ pid }}?checkin=t" data-pid="{{ pid }}"sd class="btn btn-xs checkin">Check-in</a>
+              <a href="{{ checkin_url }}/checkin/{{ pid }}?checkin=t" data-pid="{{ pid }}"sd class="btn btn-xs js-checkin">Check-in</a>
               <i class="fa fa-spinner fa-pulse loader"></i>
-              <i class="fa fa-close loader abort"></i>
+              <i class="fa fa-close loader js-abort"></i>
             {{/checked_in}}
             </li>
             </ul>
@@ -131,15 +131,12 @@
   }
 
   $(document).ready(function() {
-    var checkinUrl = "{{ '{0}event/{1}/checkin/'.format(space.url_for(), event.name) }}";
-    var getParticipantsUrl = "{{ '{0}event/{1}/participants/json'.format(space.url_for(), event.name) }}";
-
     // To disable debug mode
     Ractive.DEBUG = false;
 
-    var participantTable = new Ractive({
-      el: '#participants',
-      template: '#participant',
+    var participantTableContent = new Ractive({
+      el: '#participants-table-content',
+      template: '#participant-row',
       data: {
         participants: ''
       }
@@ -148,11 +145,11 @@
     function getParticipantsData() {
       $.ajax({
         type: 'GET',
-        url:  getParticipantsUrl,
+        url:  '{{ "{0}event/{1}/participants/json".format(space.url_for(), event.name) }}',
         timeout: 5000,
         dataType: 'jsonp',
         success: function(data) {
-          participantTable.set('participants', data.participants).then(function() {
+          participantTableContent.set('participants', data.participants).then(function() {
             $('.loader').hide();
             updateQueue(localStorage.getItems('checkin-queue'), true);
             updateQueue(localStorage.getItems('cancelcheckin-queue'), false);
@@ -166,7 +163,7 @@
         participantIDs.forEach(function(participantID) {
           var participant = "[data-pid=" + participantID +"]";
           if(action) {
-            if($(participant).hasClass('cancel-checkin')) {
+            if($(participant).hasClass('js-cancel-checkin')) {
               localStorage.remove('checkin-queue', participantID);
             }
             else {
@@ -174,7 +171,7 @@
             }
           }
           else {
-            if($(participant).hasClass('checkin')) {
+            if($(participant).hasClass('js-checkin')) {
               localStorage.remove('cancel-checkin', participantID);
             }
             else {
@@ -198,10 +195,10 @@
 
     function postCheckinStatus(participantID, action) {
       if(action) {
-        var posturl = checkinUrl + participantID + "?checkin=t";
+        var posturl = "{{ '{0}event/{1}/checkin/'.format(space.url_for(), event.name) }}" + participantID + "?checkin=t";
       }
       else {
-        var posturl = checkinUrl + participantID;
+        var posturl = "{{ '{0}event/{1}/checkin/'.format(space.url_for(), event.name) }}" + participantID;
       }
       $.ajax({
         type: 'post',
@@ -223,24 +220,24 @@
     getParticipantsData();
 
     if (Modernizr.localstorage) {
-      $('#participants').on('click', '.checkin', function(event) {
+      $('#participants-table-content').on('click', '.js-checkin', function(event) {
         event.preventDefault();
         localStorage.set('checkin-queue', $(this).data('pid'));
         $(this).siblings('.loader').show();
       });
 
-      $('#participants').on('click', '.cancel-checkin', function(event) {
+      $('#participants-table-content').on('click', '.js-cancel-checkin', function(event) {
         event.preventDefault();
         localStorage.set('cancelcheckin-queue', $(this).data('pid'));
         $(this).siblings('.loader').show();
       });
 
-      $('#participants').on('click', '.abort', function(event) {
+      $('#participants-table-content').on('click', '.js-abort', function(event) {
         event.preventDefault();
         var participantID = $(this).siblings('a').data('pid');
         var participant = "[data-pid=" + participantID +"]";
 
-        if($(participant).hasClass('checkin')) {
+        if($(participant).hasClass('js-checkin')) {
           // If participantID not in queue, checkin status has been sent to server
           // then for this participantID send a cancel checkin to server
           if(!localStorage.remove('checkin-queue', participantID)) {

--- a/funnel/templates/event.html
+++ b/funnel/templates/event.html
@@ -85,22 +85,23 @@
 {% endblock %}
 {% block footerscripts %}
 <script>
-  $(document).ready(function() {
-    // To disable debug mode
-    Ractive.DEBUG = false;
+  if (Modernizr.localstorage) {
+    window.Store = {};
 
     //Reads from LocalStorage (key is 'checkin-queue' or 'cancelcheckin-queue')
-    function readFromLocalstorage(key) {
+    window.Store.readFromLocalstorage = function(key) {
       return JSON.parse(localStorage.getItem(key));
     }
     //Adds to LocalStorage (key is 'checkin-queue' or 'cancelcheckin-queue')
-    function addToLocalstorage(key, value) {
+    window.Store.addToLocalstorage = function(key, value) {
       return localStorage.setItem(key, JSON.stringify(value))
     }
 
+    window.Queue = {};
+
     //Adds a participant_id to queue
-    function enqueue(queueName, participant_id) {
-      var participantList = readFromLocalstorage(queueName);
+    window.Queue.enqueue = function(queueName, participant_id) {
+      var participantList = window.Store.readFromLocalstorage(queueName);
       if(participantList) {
         participantList.push(participant_id);
       }
@@ -108,13 +109,13 @@
         participantList = [];
         participantList.push(participant_id);
       }
-      return addToLocalstorage(queueName, participantList)
+      return window.Store.addToLocalstorage(queueName, participantList)
     }
 
     //Reads first item from queue
     //Returns undefined when queue is empty or not defined
-    function peek(queueName) {
-      var participantList = readFromLocalstorage(queueName);
+    window.Queue.peek = function(queueName) {
+      var participantList = window.Store.readFromLocalstorage(queueName);
       if(participantList && participantList.length) {
         return participantList.shift();
       }
@@ -122,8 +123,8 @@
 
     //Reads and returns all items from queue
     //Returns undefined when queue is empty or not defined
-    function peekAllItems(queueName) {
-      var participantList = readFromLocalstorage(queueName);
+    window.Queue.peekAllItems = function(queueName) {
+      var participantList = window.Store.readFromLocalstorage(queueName);
       if(participantList && participantList.length) {
         return participantList;
       }
@@ -131,81 +132,21 @@
 
     //Removes item from queue and returns true
     //Returns undefined when item not present in queue
-    function dequeue(queueName, participant_id) {
-      var participantList = peekAllItems(queueName);
+    window.Queue.dequeue = function(queueName, participant_id) {
+      var participantList = window.Store.readFromLocalstorage(queueName);
       var index = participantList ? participantList.indexOf(participant_id) : -1;
       if(index !== -1) {
         //Remove item from queue and add updated queue to localStorage
         participantList.splice(index, 1);
-        addToLocalstorage(queueName, participantList);
+        window.Store.addToLocalstorage(queueName, participantList);
         return true;
       }
     }
+  }
 
-    //updateQueue eg:- If participant in "checkin-queue" has already been checked-in then remove from queue
-    function updateQueue(queueName) {
-      var participantIDs = peekAllItems(queueName);
-      if(participantIDs) {
-        participantIDs.forEach(function(participantID) {
-          var participant = "[data-pid=" + participantID +"]";
-          if(queueName === "checkin-queue") {
-            if($(participant).hasClass('js-cancel-checkin')) {
-              //Participant has been checked-in so remove from 'checkin-queue' 
-              dequeue("checkin-queue", participantID);
-            }
-            else {
-              $(participant).siblings('.loader').show();
-            }
-          }
-          else {
-            if($(participant).hasClass('js-checkin')) {
-              //Participant's check-in has been cancelled so remove from 'cancelcheckin-queue' 
-              dequeue("cancelcheckin-queue", participantID);
-            }
-            else {
-              $(participant).siblings('.loader').show();
-            }
-          }
-        });
-      }
-    }
-
-    function postCheckinStatus(participantID, action) {
-      if(action) {
-        var posturl = "{{ '{0}event/{1}/checkin/'.format(space.url_for(), event.name) }}" + participantID + "?checkin=t";
-      }
-      else {
-        var posturl = "{{ '{0}event/{1}/checkin/'.format(space.url_for(), event.name) }}" + participantID;
-      }
-      $.ajax({
-        type: 'post',
-        url:  posturl,
-        timeout: 5000,
-        dataType: "json",
-        success: function(data) {
-          //Successfully posted to server so remove from queue
-          if(data.checked_in) {
-            dequeue("checkin-queue", data.participant_id);
-          }
-          else {
-            dequeue("cancelcheckin-queue", data.participant_id);
-          }
-        }
-      });
-    }
-
-    function checkQueues() {
-      //Read first participant from 'checkin-queue' and post check-in to server
-      var participantID = peek("checkin-queue");
-      if(participantID) {
-        postCheckinStatus(participantID, true);
-      }
-      //Read first participant from 'cancelcheckin-queue' and post cancel check-in to server
-      participantID = peek("cancelcheckin-queue");
-      if(participantID) {
-        postCheckinStatus(participantID, false);
-      }
-    }
+  $(document).ready(function() {
+    // To disable debug mode
+    Ractive.DEBUG = false;
 
     var participantTableContent = new Ractive({
       el: '#participants-table-content',
@@ -214,6 +155,34 @@
         participants: ''
       }
     });
+
+    //updateQueue: If participant in "checkin-queue" has already been checked-in then it is removed from checkin queue
+    function updateQueue(queueName) {
+      var participantIDs = window.Queue.peekAllItems(queueName);
+      if(participantIDs) {
+        participantIDs.forEach(function(participantID) {
+          var participant = "[data-pid=" + participantID +"]";
+          if(queueName === "checkin-queue") {
+            if($(participant).hasClass('js-cancel-checkin')) {
+              //Participant has been checked-in so remove from 'checkin-queue' 
+              window.Queue.dequeue("checkin-queue", participantID);
+            }
+            else {
+              $(participant).siblings('.loader').show();
+            }
+          }
+          else {
+            if($(participant).hasClass('js-checkin')) {
+              //Participant's check-in has been cancelled so remove from 'cancelcheckin-queue' 
+              window.Queue.dequeue("cancelcheckin-queue", participantID);
+            }
+            else {
+              $(participant).siblings('.loader').show();
+            }
+          }
+        });
+      }
+    }
 
     function getParticipantsData() {
       $.ajax({
@@ -233,6 +202,42 @@
       });
     }
 
+    function postCheckinStatus(participantID, action) {
+      if(action) {
+        var posturl = "{{ '{0}event/{1}/checkin/'.format(space.url_for(), event.name) }}" + participantID + "?checkin=t";
+      }
+      else {
+        var posturl = "{{ '{0}event/{1}/checkin/'.format(space.url_for(), event.name) }}" + participantID;
+      }
+      $.ajax({
+        type: 'post',
+        url:  posturl,
+        timeout: 5000,
+        dataType: "json",
+        success: function(data) {
+          if(data.checked_in) {
+            window.Queue.dequeue("checkin-queue", data.participant_id);
+          }
+          else {
+            window.Queue.dequeue("cancelcheckin-queue", data.participant_id);
+          }
+        }
+      });
+    }
+
+    function checkQueues() {
+      //Read first participant from 'checkin-queue' and post check-in to server
+      var participantID = window.Queue.peek("checkin-queue");
+      if(participantID) {
+        postCheckinStatus(participantID, true);
+      }
+      //Read first participant from 'cancelcheckin-queue' and post cancel check-in to server
+      participantID = window.Queue.peek("cancelcheckin-queue");
+      if(participantID) {
+        postCheckinStatus(participantID, false);
+      }
+    }
+
     //Get the list of participants from server
     getParticipantsData();
 
@@ -241,14 +246,14 @@
       $('#participants-table-content').on('click', '.js-checkin', function(event) {
         event.preventDefault();
         //Add to participant_id to "checkin-queue"
-        enqueue("checkin-queue", $(this).data('pid'));
+        window.Queue.enqueue("checkin-queue", $(this).data('pid'));
         $(this).siblings('.loader').show();
       });
 
       $('#participants-table-content').on('click', '.js-cancel-checkin', function(event) {
         event.preventDefault();
         //Add to participant_id to "cancelcheckin-queue"
-        enqueue("cancelcheckin-queue", $(this).data('pid'));
+        window.Queue.enqueue("cancelcheckin-queue", $(this).data('pid'));
         $(this).siblings('.loader').show();
       });
 
@@ -260,13 +265,13 @@
         if($(participant).hasClass('js-checkin')) {
           // On abort, if participantID present in the queue, then remove from "checkin-queue"
           // On abort, if participantID is not present in the "checkin-queue" it implies check-in has already been done, so a cancel check-in requires to be send(add it to "cancelcheckin-queue")
-          if(!dequeue("checkin-queue", participantID)) {
-            enqueue("cancelcheckin-queue", participantID);
+          if(!window.Queue.dequeue("checkin-queue", participantID)) {
+            window.Queue.enqueue("cancelcheckin-queue", participantID);
           }
         }
         else{
-          if(!dequeue("cancelcheckin-queue", participantID)) {
-            enqueue("checkin-queue", participantID);
+          if(!window.Queue.dequeue("cancelcheckin-queue", participantID)) {
+            window.Queue.enqueue("checkin-queue", participantID);
           }
         }
         $(participant).siblings('.loader').hide();

--- a/funnel/views/event.py
+++ b/funnel/views/event.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from flask import flash, redirect, render_template, request, g
+from flask import flash, redirect, render_template, request, g, jsonify
 from baseframe import _
 from baseframe.forms import render_form
 from coaster.views import load_models, jsonp
@@ -155,6 +155,31 @@ def event(profile, space, event):
     return render_template('event.html', profile=profile, space=space, participants=participants, event=event, badge_form=ParticipantBadgeForm(model=Participant))
 
 
+def participant_checkin_data(participant, space, event_name):
+    return {
+        'pid': participant.id,
+        'fullname': participant.fullname,
+        'company': participant.company,
+        'email': participant.email,
+        'badge_printed': participant.badge_printed,
+        'checked_in': participant.checked_in,
+        'showbadge_url': "{0}participant/{1}/badge".format(space.url_for(), participant.id),
+        'edit_url': "{0}participant/{1}/edit".format(space.url_for(), participant.id),
+        'checkin_url': "{0}/{1}".format(space.url_for('events'), event_name)
+    }
+
+
+@app.route('/<space>/event/<name>/participants/json', subdomain='<profile>')
+@lastuser.requires_login
+@load_models(
+    (Profile, {'name': 'profile'}, 'g.profile'),
+    ((ProposalSpace, ProposalSpaceRedirect), {'name': 'space', 'profile': 'profile'}, 'space'),
+    (Event, {'name': 'name', 'proposal_space': 'space'}, 'event'),
+    permission='view')
+def event_participants_json(profile, space, event):
+    return jsonp(participants=[participant_checkin_data(participant, space, event.name) for participant in Participant.attendees_by_event(event)])
+
+
 def participant_badge_data(participants, space):
     badges = []
     for participant in participants:
@@ -195,7 +220,7 @@ def participant_badge(profile, space, participant):
     return render_template('badge.html', badges=participant_badge_data([participant], space))
 
 
-@app.route('/<space>/event/<name>/checkin/<participant_id>', subdomain='<profile>')
+@app.route('/<space>/event/<name>/checkin/<participant_id>', methods=['GET', 'POST'], subdomain='<profile>')
 @lastuser.requires_login
 @load_models(
     (Profile, {'name': 'profile'}, 'g.profile'),
@@ -209,4 +234,6 @@ def event_checkin(profile, space, event, participant):
     a.checked_in = checked_in
     db.session.add(a)
     db.session.commit()
+    if request.is_xhr:
+        return jsonify(status=True, participant_id=participant.id, checked_in=checked_in)
     return redirect("{0}event/{1}".format(space.url_for(), event.name), code=303)


### PR DESCRIPTION
`getParticipantsData` gets participants data as json from server and uses ractive to display it on the UI

LocalStorage stores only strings.
`addToLocalstorage` stringifies the (check-in / cancel check-in) array and stores in localStorage.
`readFromLocalstorage` reads from localStorage and parses it.

check-in and cancel check-in queue is implemented using arrays.
`enqueue` - adds participant to queue
`peek` - reads participant from queue
`peekAllItems` - reads all participant from queue
`dequeue` - removes participant from queue

If localStorage is available on the browser, event handlers for check-in, cancel-checkin and abort are registered.
`updateQueue` - checks all participants in the localStorage queue. If their status have been updated then removes them from the queue.
`checkQueues` is called every 8 seconds which reads the first item from queue(first from check-in queue and then cancel check-in queue) and calls `postCheckinStatus` which does a ajax post to server and removes from queue on successful post.

Workflow:
1) When a participant is checked-in, the participant id is added to a checkin queue which is stored in localStorage. Loading and abort icons are displayed on UI for this participant.
2) Every 8 seconds first item from check-in queue is read and check-in ajax post request is send to server. The participant id is removed from queue on successful post. Same is done for cancel check-in queue.
3) Every one minute participants data is requested from the server and UI is refreshed by ractive. Participant ids in the queue(stored in localStorage) are checked against their check-in status on the UI, if their status have already been updated (in case of multiple check-in counters) then their are removed from the queue. All participants remaining in the queue will have the loading and abort icons.
4) On aborting a check-in, if the participant id is present in check-in queue then it is removed from the queue. If participant id is not present in the check-in queue it implies check-in has already been posted to the server, so a cancel check-in requires to be send for which the participant is added it to cancel check-in queue.