### PR TITLE
Add missing dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ Flask-Script==0.5.3
 alembic
 git+https://github.com/tobiasandtobias/flask-alembic.git
 qrcode
+rq


### PR DESCRIPTION
When I tried to run `python manage.py db create` I found that the `rq` module was missing from the `requirements.txt`.