### PR TITLE
[FIX] Fixing issue #205

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ Flask-WTF
 pytz
 unicodecsv
 icalendar
-git+https://github.com/hasgeek/coaster.git
+coaster
 git+https://github.com/hasgeek/flask-lastuser.git
 git+https://github.com/hasgeek/baseframe.git
 alembic


### PR DESCRIPTION
* **Description:** Deprecating GitHub reference for package coaster to prevent unreleased version glitch. Linking coaster package through [pypi](https://pypi.python.org/pypi/coaster/) to get a released
version. This fixes issue #205 
