### PR TITLE
Move proposal across profiles. Fixes #216

### DIFF
--- a/funnel/forms/proposal.py
+++ b/funnel/forms/proposal.py
@@ -81,7 +81,8 @@ class ProposalStatusForm(forms.Form):
 
 
 class ProposalMoveForm(forms.Form):
-    target = QuerySelectField(__("Move proposal to"), get_label='title')
+    target = QuerySelectField(__("Move proposal to"), validators=[
+                              forms.validators.DataRequired()], get_label='title')
 
     def set_queries(self):
         team_ids = [t.id for t in g.user.teams]

--- a/funnel/forms/proposal.py
+++ b/funnel/forms/proposal.py
@@ -5,7 +5,7 @@ import baseframe.forms as forms
 from baseframe.forms.sqlalchemy import QuerySelectField
 from ..models import PROPOSALSTATUS
 
-__all__ = ['TransferProposal', 'ProposalForm', 'ProposalStatusForm']
+__all__ = ['TransferProposal', 'ProposalForm', 'ProposalStatusForm', 'ProposalMoveForm']
 
 
 class TransferProposal(forms.Form):
@@ -77,3 +77,7 @@ class ProposalStatusForm(forms.Form):
     status = forms.SelectField(
         __("Status"), coerce=int,
         choices=[(status, label.title) for (status, label) in PROPOSALSTATUS.items() if status != PROPOSALSTATUS.DRAFT])
+
+
+class ProposalMoveForm(forms.Form):
+    target = forms.SelectField(__("Move Proposal To"))

--- a/funnel/models/proposal.py
+++ b/funnel/models/proposal.py
@@ -297,7 +297,7 @@ class Proposal(BaseScopedIdNameMixin, CoordinatesMixin, db.Model):
         elif action == 'status':
             return url_for('proposal_status', profile=self.proposal_space.profile.name, space=self.proposal_space.name, proposal=self.url_name, _external=_external, **kwargs)
         elif action == 'move-to':
-            return url_for('proposal_moveto', profile=self.proposal_space.profile.name, space=self.proposal_space.name, proposal=self.url_name, _external=_external, target="%s/%s" % (kwargs['target'].profile.name, kwargs['target'].name))
+            return url_for('proposal_moveto', profile=self.proposal_space.profile.name, space=self.proposal_space.name, proposal=self.url_name, _external=_external, **kwargs)
 
 
 class ProposalRedirect(TimestampMixin, db.Model):

--- a/funnel/templates/proposal.html.jinja2
+++ b/funnel/templates/proposal.html.jinja2
@@ -121,7 +121,7 @@
           <iframe class="facebooklike" src="//www.facebook.com/plugins/like.php?app_id=114496105304651&amp;href={{ request.url }}&amp;send=false&amp;layout=button_count&amp;width=150&amp;show_faces=false&amp;action=recommend&amp;colorscheme=light&amp;font&amp;height=21" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:150px; height:21px;" allowTransparency="true"></iframe>
         </div>
         <div class="col-md-3 col-lg-3 col-sm-12 col-xs-12">
-          Status: 
+          Status:
           {%- if 'view-status' in g.permissions %}
             {{ PROPOSALSTATUS[proposal.status] }}
             {% if proposal.session and proposal.confirmed %} &amp; Scheduled{% endif %}

--- a/funnel/templates/proposal.html.jinja2
+++ b/funnel/templates/proposal.html.jinja2
@@ -142,7 +142,7 @@
                 Move <span class="caret"></span>
               </button>
               <ul class="dropdown-menu" role="menu">
-                {%- for movespace in proposal.proposal_space.profile.spaces %}
+                {%- for movespace in movable_spaces %}
                   <li><a href="{{ proposal.url_for('move-to', target=movespace) }}">{{ movespace.title }}</a></li>
                 {%- endfor %}
               </ul>

--- a/funnel/templates/proposal.html.jinja2
+++ b/funnel/templates/proposal.html.jinja2
@@ -142,8 +142,11 @@
                 Move <span class="caret"></span>
               </button>
               <ul class="dropdown-menu" role="menu">
+                <form id="form-move-proposal" action="{{ proposal.url_for('move-to') }}" method="POST">
+                  <input id="input-move-target" type="hidden" name="target" value="" />
+                </form>
                 {%- for movespace in movable_spaces %}
-                  <li><a href="{{ proposal.url_for('move-to', target=movespace) }}">{{ movespace.title }}</a></li>
+                  <li><a href="#" onClick="moveProposalTo('{{movespace.profile.name}}/{{movespace.name}}')">{{ movespace.title }}</a></li>
                 {%- endfor %}
               </ul>
             </div>
@@ -352,4 +355,11 @@
 </script>
 <script type="text/javascript" src="//apis.google.com/js/plusone.js"></script>
 <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
+
+<script type="text/javascript">
+var moveProposalTo = function (target) {
+  $('#input-move-target').val(target);
+  $('#form-move-proposal').submit();
+}
+</script>
 {% endblock %}

--- a/funnel/templates/proposal.html.jinja2
+++ b/funnel/templates/proposal.html.jinja2
@@ -143,6 +143,7 @@
               </button>
               <ul class="dropdown-menu" role="menu">
                 <form id="form-move-proposal" action="{{ proposal.url_for('move-to') }}" method="POST">
+                  {{ csrf_form.hidden_tag() }}
                   <input id="input-move-target" type="hidden" name="target" value="" />
                 </form>
                 {%- for movespace in movable_spaces %}

--- a/funnel/templates/proposal.html.jinja2
+++ b/funnel/templates/proposal.html.jinja2
@@ -135,7 +135,7 @@
           {% if proposal.session %}
             <a class="btn btn-xs btn-info" href="{{ proposal.session.url_for() }}">View session in schedule</a>
           {% endif %}
-          {%- if 'move-proposal' in g.permissions and proposal_move_form %}
+          {%- if 'move-proposal' in g.permissions %}
             <br>
             {{ renderform(proposal_move_form, 'proposal-move', action=proposal.url_for('move-to'), submit='Move', style=None) }}
           {%- endif %}

--- a/funnel/templates/proposal.html.jinja2
+++ b/funnel/templates/proposal.html.jinja2
@@ -115,12 +115,12 @@
       </div>
       <div class="row">
         <!-- Social buttons -->
-        <div class="social col-md-9 col-lg-9 col-sm-12 col-xs-12">
+        <div class="social col-md-6 col-lg-6 col-sm-12 col-xs-12">
           <a href="//twitter.com/share" class="twitter-share-button" data-count="horizontal" data-via="{{ config['TWITTER_ID'] }}">Tweet</a>
           <g:plusone size="medium"></g:plusone>
           <iframe class="facebooklike" src="//www.facebook.com/plugins/like.php?app_id=114496105304651&amp;href={{ request.url }}&amp;send=false&amp;layout=button_count&amp;width=150&amp;show_faces=false&amp;action=recommend&amp;colorscheme=light&amp;font&amp;height=21" scrolling="no" frameborder="0" style="border:none; overflow:hidden; width:150px; height:21px;" allowTransparency="true"></iframe>
         </div>
-        <div class="col-md-3 col-lg-3 col-sm-12 col-xs-12">
+        <div class="col-md-6 col-lg-6 col-sm-12 col-xs-12">
           Status:
           {%- if 'view-status' in g.permissions %}
             {{ proposal.state.label.title }}
@@ -133,24 +133,11 @@
             {% endif %}
           {% endif %}
           {% if proposal.session %}
-            <br><a class="btn btn-xs btn-info" href="{{ proposal.session.url_for() }}">View session in schedule</a>
+            <a class="btn btn-xs btn-info" href="{{ proposal.session.url_for() }}">View session in schedule</a>
           {% endif %}
-          {%- if 'move-proposal' in g.permissions %}
+          {%- if 'move-proposal' in g.permissions and proposal_move_form %}
             <br>
-            <div class="btn-group">
-              <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-expanded="false">
-                Move <span class="caret"></span>
-              </button>
-              <ul class="dropdown-menu" role="menu">
-                <form id="form-move-proposal" action="{{ proposal.url_for('move-to') }}" method="POST">
-                  {{ csrf_form.hidden_tag() }}
-                  <input id="input-move-target" type="hidden" name="target" value="" />
-                </form>
-                {%- for movespace in movable_spaces %}
-                  <li><a href="#" onClick="moveProposalTo('{{movespace.profile.name}}/{{movespace.name}}')">{{ movespace.title }}</a></li>
-                {%- endfor %}
-              </ul>
-            </div>
+            {{ renderform(proposal_move_form, 'proposal-move', action=proposal.url_for('move-to'), submit='Move', style=None) }}
           {%- endif %}
         </div>
       </div>

--- a/funnel/templates/proposal.html.jinja2
+++ b/funnel/templates/proposal.html.jinja2
@@ -343,11 +343,4 @@
 </script>
 <script type="text/javascript" src="//apis.google.com/js/plusone.js"></script>
 <script type="text/javascript" src="//platform.twitter.com/widgets.js"></script>
-
-<script type="text/javascript">
-var moveProposalTo = function (target) {
-  $('#input-move-target').val(target);
-  $('#form-move-proposal').submit();
-}
-</script>
 {% endblock %}

--- a/funnel/views/proposal.py
+++ b/funnel/views/proposal.py
@@ -299,7 +299,6 @@ def proposal_view(profile, space, proposal):
     else:
         statusform = None
 
-    movable_spaces = []
     proposal_move_form = None
     if 'move-proposal' in space.permissions(g.user, g.permissions):
         proposal_move_form = ProposalMoveForm()
@@ -408,14 +407,11 @@ def proposal_moveto(profile, space, proposal):
         return redirect(proposal.url_for(), 303)
 
     target_space = proposal_move_form.target.data
-    if not target_space:
-        abort(404)
-
     if not (target_space.profile.admin_team in g.user.teams or target_space.admin_team in g.user.teams):
         flash(_("You do not have permission to move this proposal to {space}.".format(space=target_space.title)))
         abort(403)
 
     proposal.move_to(target_space)
-    db.session.commit()  # WARNING: GET request!
+    db.session.commit()
     flash(_("The proposal has been successfully moved to {space}.".format(space=target_space.title)))
     return redirect(proposal.url_for(), 303)

--- a/funnel/views/proposal.py
+++ b/funnel/views/proposal.py
@@ -300,11 +300,12 @@ def proposal_view(profile, space, proposal):
         statusform = None
 
     movable_spaces = []
-    print g.user.teams, dir(proposal.proposal_space.profile)
     if 'move-proposal' in g.permissions:
-        movable_spaces = ProposalSpace.query.filter(ProposalSpace.admin_team_id.in_([t.id for t in g.user.teams])).all()
-        for profile in Profile.query.filter(Profile.admin_team_id.in_([t.id for t in g.user.teams])):
-            movable_spaces += [space for space in profile.spaces if space not in movable_spaces]
+        team_ids = [t.id for t in g.user.teams]
+        movable_spaces = ProposalSpace.query.join(ProposalSpace.profile).filter(
+            (ProposalSpace.admin_team_id.in_(team_ids)) |
+            (Profile.admin_team_id.in_(team_ids))
+            ).order_by(ProposalSpace.date.desc())
 
     return render_template('proposal.html.jinja2', space=space, proposal=proposal,
         comments=comments, commentform=commentform, delcommentform=delcommentform,

--- a/funnel/views/proposal.py
+++ b/funnel/views/proposal.py
@@ -397,10 +397,6 @@ def proposal_prev(profile, space, proposal):
     ((Proposal, ProposalRedirect), {'url_name': 'proposal', 'proposal_space': 'space'}, 'proposal'),
     permission='move-proposal', addlperms=lastuser.permissions)
 def proposal_moveto(profile, space, proposal):
-    csrf_form = Form()
-    if not csrf_form.validate_on_submit():
-        abort(403)
-
     proposal_move_form = ProposalMoveForm()
     if not proposal_move_form.validate_on_submit():
         flash(_("Please choose a proposal space you want to move this proposal to."))

--- a/funnel/views/proposal.py
+++ b/funnel/views/proposal.py
@@ -296,9 +296,14 @@ def proposal_view(profile, space, proposal):
     else:
         statusform = None
 
+    movable_spaces = None
+    print g.user.teams, dir(proposal.proposal_space.profile)
+    if 'move-proposal' in g.permissions:
+        movable_spaces = ProposalSpace.query.filter(ProposalSpace.admin_team_id.in_([t.id for t in g.user.teams])).all()
+
     return render_template('proposal.html.jinja2', space=space, proposal=proposal,
         comments=comments, commentform=commentform, delcommentform=delcommentform,
-        votes_groups=proposal.votes_by_group(),
+        votes_groups=proposal.votes_by_group(), movable_spaces=movable_spaces,
         PROPOSALSTATUS=PROPOSALSTATUS, links=links, statusform=statusform,
         part_a=space.proposal_part_a.get('title', 'Objective'),
         part_b=space.proposal_part_b.get('title', 'Description'), csrf_form=Form())

--- a/funnel/views/proposal.py
+++ b/funnel/views/proposal.py
@@ -401,9 +401,14 @@ def proposal_prev(profile, space, proposal):
     ((Proposal, ProposalRedirect), {'url_name': 'proposal', 'proposal_space': 'space'}, 'proposal'),
     permission='move-proposal', addlperms=lastuser.permissions)
 def proposal_moveto(profile, space, proposal):
+    csrf_form = Form()
+    if not csrf_form.validate_on_submit():
+        abort(403)
+
     target_name = request.values.get('target')
     if not target_name:
         abort(404)
+
     profile_name, space_name = target_name.split('/', 1)
     target_space = ProposalSpace.query.filter(ProposalSpace.name == space_name).join(Profile).filter(Profile.name == profile_name).one_or_none()
 

--- a/funnel/views/proposal.py
+++ b/funnel/views/proposal.py
@@ -394,14 +394,14 @@ def proposal_prev(profile, space, proposal):
         return redirect(space.url_for())
 
 
-@app.route('/<space>/<proposal>/move', subdomain='<profile>')
+@app.route('/<space>/<proposal>/move', methods=['POST',], subdomain='<profile>')
 @load_models(
     (Profile, {'name': 'profile'}, 'g.profile'),
     ((ProposalSpace, ProposalSpaceRedirect), {'name': 'space', 'profile': 'profile'}, 'space'),
     ((Proposal, ProposalRedirect), {'url_name': 'proposal', 'proposal_space': 'space'}, 'proposal'),
     permission='move-proposal', addlperms=lastuser.permissions)
 def proposal_moveto(profile, space, proposal):
-    target_name = request.args.get('target')
+    target_name = request.values.get('target')
     if not target_name:
         abort(404)
     profile_name, space_name = target_name.split('/', 1)


### PR DESCRIPTION
Fixes #216.

This is how it is in production right now 

![selection_223](https://user-images.githubusercontent.com/357253/35241340-28ce237a-ffdc-11e7-9859-41931fc63f03.jpg)

This is how it is after the changes introduced 

![selection_222](https://user-images.githubusercontent.com/357253/35241353-3444df6e-ffdc-11e7-9365-276d1b22b166.jpg)

My user is in admin team of metarefresh 2017. So looks like, currently, if you are in admin team of Metarefresh 2017, you can move proposals in any other proposal space in metarefresh profile even though you are not in admin_team of any of them, nor in admin team of metarefresh. Is that ok?

My proposed logic is, you can only move proposals to spaces you are admin of, or all the spaces within the profiles you are admin of. Does that sound right?