### PR TITLE
Use _html suffix for HTML fields in JSON

### DIFF
--- a/funnel/templates/search.html.jinja2
+++ b/funnel/templates/search.html.jinja2
@@ -80,7 +80,7 @@
                               <h3 class="zero-top-margin zero-bottom-margin"><a href="{{ url }}" class="mui--text-headline">{{{ title }}}</a></h3>
                               {{#if obj.location }}<p class="mui--text-body1 zero-top-margin zero-bottom-margin"><i class="material-icons mui--text-caption mui--text-light mui--align-middle" aria-hidden="true" title="Project venue">place</i> {{obj.location}}</p>{{/if}}
                               <p class="mui--text-subhead mui--text-light zero-top-margin">{{ obj.tagline }}</p>
-                              <p class="mui--text-body1 mui--text-light zero-top-margin snippets"><span class="search-icon"></span>{{{ snippet }}}</p>
+                              <p class="mui--text-body1 mui--text-light zero-top-margin snippets"><span class="search-icon"></span>{{{ snippet_html }}}</p>
                             </div>
                           </div>
                         {{elseif result == 'profile'}}
@@ -98,7 +98,7 @@
                             <div class="card__body">
                               <h3 class="zero-top-margin zero-bottom-margin"><a href="{{ url }}" class="mui--text-headline mui--text-hyperlink">{{{ title }}}</a></h3>
                               <p class="mui--text-subhead mui--text-light zero-top-margin">{{{ obj.description.html }}}</p>
-                              <p class="mui--text-body1 mui--text-light zero-top-margin snippets"><span class="search-icon"></span>{{{ snippet }}}</p>
+                              <p class="mui--text-body1 mui--text-light zero-top-margin snippets"><span class="search-icon"></span>{{{ snippet_html }}}</p>
                             </div>
                           </div>
                         {{elseif result == 'session'}}
@@ -111,7 +111,7 @@
                             <h2 class="mui--text-subhead mui--text-bold zero-top-margin zero-bottom-margin"><a href="{{ url }}">{{{ title }}}</a></h2>
                             <h3 class="mui--text-body1 zero-top-margin zero-bottom-margin">{{#if obj.speaker }}<span>{{ obj.speaker }}</span> <span class="mui--text-light">in</span>{{/if}} <span>{{ obj.project.title }} </span></h3>
                             <p class="mui--text-body1 zero-top-margin  zero-bottom-margin"><span class="mui--text-light">at</span> {{ formatTime(obj.start) }}–{{ formatTime(obj.end) }} <span class="mui--text-light">on</span> {{ formatDate(obj.start) }}</p>
-                            <p class="mui--text-body1 mui--text-light zero-top-margin snippets"><span class="search-icon"></span>{{{ snippet }}}</p>
+                            <p class="mui--text-body1 mui--text-light zero-top-margin snippets"><span class="search-icon"></span>{{{ snippet_html }}}</p>
                           </div>
                         {{elseif result == 'proposal'}}
                           <div class="user-box">
@@ -125,7 +125,7 @@
                             {{#if obj.session }}
                               <p class="mui--text-body1 zero-top-margin"><span class="mui--text-light">at</span> {{ formatTime(obj.session.start) }}–{{ formatTime(obj.session.end) }} <span class="mui--text-light">on</span> {{ formatDate(obj.session.start) }}</p>
                             {{/if}}
-                            <p class="mui--text-body1 mui--text-light snippets"><span class="search-icon"></span>{{{ snippet }}}</p>
+                            <p class="mui--text-body1 mui--text-light snippets"><span class="search-icon"></span>{{{ snippet_html }}}</p>
                           </div>
                         {{elseif result == 'comment'}}
                           <div class="user-box">
@@ -136,7 +136,7 @@
                             {{/if}}
                             <h2 class="mui--text-subhead mui--text-bold zero-top-margin zero-bottom-margin"><a href="{{ url }}">{{{ obj.title }}}</a></h2>
                             <p class="mui--text-body1 mui--text-light">{{ formatDate(obj.created_at) }} {{#if obj.edited_at}}(edited {{ formatDate(obj.created_at) }}) {{/if}}</p>
-                            <p class="mui--text-body1 mui--text-light zero-top-margin snippets"><span class="search-icon"></span>{{{ snippet }}}</p>
+                            <p class="mui--text-body1 mui--text-light zero-top-margin snippets"><span class="search-icon"></span>{{{ snippet_html }}}</p>
                           </div>
                         {{/if}}
                       </div>

--- a/funnel/templates/search.html.jinja2
+++ b/funnel/templates/search.html.jinja2
@@ -77,7 +77,7 @@
                                 {{/if}}
                             </div>
                             <div class="card__body">
-                              <h3 class="zero-top-margin zero-bottom-margin"><a href="{{ url }}" class="mui--text-headline">{{{ title }}}</a></h3>
+                              <h3 class="zero-top-margin zero-bottom-margin"><a href="{{ url }}" class="mui--text-headline">{{{ title_html }}}</a></h3>
                               {{#if obj.location }}<p class="mui--text-body1 zero-top-margin zero-bottom-margin"><i class="material-icons mui--text-caption mui--text-light mui--align-middle" aria-hidden="true" title="Project venue">place</i> {{obj.location}}</p>{{/if}}
                               <p class="mui--text-subhead mui--text-light zero-top-margin">{{ obj.tagline }}</p>
                               <p class="mui--text-body1 mui--text-light zero-top-margin snippets"><span class="search-icon"></span>{{{ snippet_html }}}</p>
@@ -91,12 +91,12 @@
                               {{else}}
                                 <div class="card__image--default">
                                   <a href="{{ url }}" aria-label="{{ title }}"><img class="card__image" src="{{ defaultImage }}" alt="{{ title }}"/></a>
-                                  <p class="card__image__tagline mui--text-body1">{{{ title }}}</p>
+                                  <p class="card__image__tagline mui--text-body1">{{{ title_html }}}</p>
                                 </div>
                               {{/if}}
                             </div>
                             <div class="card__body">
-                              <h3 class="zero-top-margin zero-bottom-margin"><a href="{{ url }}" class="mui--text-headline mui--text-hyperlink">{{{ title }}}</a></h3>
+                              <h3 class="zero-top-margin zero-bottom-margin"><a href="{{ url }}" class="mui--text-headline mui--text-hyperlink">{{{ title_html }}}</a></h3>
                               <p class="mui--text-subhead mui--text-light zero-top-margin">{{{ obj.description.html }}}</p>
                               <p class="mui--text-body1 mui--text-light zero-top-margin snippets"><span class="search-icon"></span>{{{ snippet_html }}}</p>
                             </div>
@@ -108,7 +108,7 @@
                             {{else}}
                               <img class="user-gravatar" src="https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y" {{#if obj.speaker }} alt="{{ obj.speaker }}" aria-labl="{{ obj.speaker }}"{{/if}} />
                             {{/if}}
-                            <h2 class="mui--text-subhead mui--text-bold zero-top-margin zero-bottom-margin"><a href="{{ url }}">{{{ title }}}</a></h2>
+                            <h2 class="mui--text-subhead mui--text-bold zero-top-margin zero-bottom-margin"><a href="{{ url }}">{{{ title_html }}}</a></h2>
                             <h3 class="mui--text-body1 zero-top-margin zero-bottom-margin">{{#if obj.speaker }}<span>{{ obj.speaker }}</span> <span class="mui--text-light">in</span>{{/if}} <span>{{ obj.project.title }} </span></h3>
                             <p class="mui--text-body1 zero-top-margin  zero-bottom-margin"><span class="mui--text-light">at</span> {{ formatTime(obj.start) }}–{{ formatTime(obj.end) }} <span class="mui--text-light">on</span> {{ formatDate(obj.start) }}</p>
                             <p class="mui--text-body1 mui--text-light zero-top-margin snippets"><span class="search-icon"></span>{{{ snippet_html }}}</p>
@@ -120,7 +120,7 @@
                             {{else}}
                               <img class="user-gravatar" src="https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y" {{#if obj.speaker }} alt="{{ obj.speaker }}" aria-labl="{{ obj.speaker }}" {{/if}} />
                             {{/if}}
-                            <h2 class="mui--text-subhead mui--text-bold zero-top-margin zero-bottom-margin"><a href="{{ url }}">{{{ title }}}</a></h2>
+                            <h2 class="mui--text-subhead mui--text-bold zero-top-margin zero-bottom-margin"><a href="{{ url }}">{{{ title_html }}}</a></h2>
                             <h3 class="mui--text-body1 zero-top-margin zero-bottom-margin">{{#if obj.speaker.fullname }}<span>{{ obj.speaker.fullname }}</span> <span class="mui--text-light">in</span>{{/if}} <span>{{ obj.project.title }} </span></h3>
                             {{#if obj.session }}
                               <p class="mui--text-body1 zero-top-margin"><span class="mui--text-light">at</span> {{ formatTime(obj.session.start) }}–{{ formatTime(obj.session.end) }} <span class="mui--text-light">on</span> {{ formatDate(obj.session.start) }}</p>
@@ -134,7 +134,7 @@
                             {{else}}
                               <img class="user-gravatar" src="https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp&f=y" {{#if obj.speaker }} alt="{{ obj.speaker }}" aria-labl="{{ obj.speaker }}" {{/if}} />
                             {{/if}}
-                            <h2 class="mui--text-subhead mui--text-bold zero-top-margin zero-bottom-margin"><a href="{{ url }}">{{{ obj.title }}}</a></h2>
+                            <h2 class="mui--text-subhead mui--text-bold zero-top-margin zero-bottom-margin"><a href="{{ url }}">{{ obj.title }}</a></h2>
                             <p class="mui--text-body1 mui--text-light">{{ formatDate(obj.created_at) }} {{#if obj.edited_at}}(edited {{ formatDate(obj.created_at) }}) {{/if}}</p>
                             <p class="mui--text-body1 mui--text-light zero-top-margin snippets"><span class="search-icon"></span>{{{ snippet_html }}}</p>
                           </div>

--- a/funnel/views/search.py
+++ b/funnel/views/search.py
@@ -114,10 +114,11 @@ def search_results(squery, stype, page=1, per_page=20):
     # Return a page of results
     return {
         'items': [{
-            'title': escape_quotes(title) if title is not None else None,
+            'title': item.title if st.has_title else None,
+            'title_html': escape_quotes(title) if title is not None else None,
             'url': item.absolute_url,
-            'snippet': escape_quotes(snippet),
-            'obj': dict(item.current_access()),
+            'snippet_html': escape_quotes(snippet),
+            'obj': item.current_access(),
             } for item, title, snippet in pagination.items],
         'has_next': pagination.has_next,
         'has_prev': pagination.has_prev,


### PR DESCRIPTION
The search result fields `title` and `snippet` are now `title_html` and `snippet_html`. An additional plain text `title` is included for use in attributes such as img alt text and ARIA labels.