### PR TITLE
Flake8 and pre-commit config

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,6 +1,0 @@
-[bandit]
-exclude_dirs:
-  - funnel
-  - migrations
-  - instance
-  - tests

--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,6 @@
+[bandit]
+exclude_dirs:
+  - funnel
+  - migrations
+  - instance
+  - tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.21
+    hooks:
+    -   id: isort
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.2.3
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+    -   id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,20 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
--   repo: https://github.com/pre-commit/mirrors-isort
+  - repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.21
     hooks:
-    -   id: isort
--   repo: https://github.com/pre-commit/pre-commit-hooks
+      - id: isort
+        additional_dependencies:
+          - toml
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3
     hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: check-yaml
-    -   id: check-added-large-files
-    -   id: flake8
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: flake8
         additional_dependencies:
           - toml
           - flake8-assertive

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,3 +13,15 @@ repos:
     -   id: check-yaml
     -   id: check-added-large-files
     -   id: flake8
+        additional_dependencies:
+          - toml
+          - flake8-assertive
+          - flake8-blind-except
+          - flake8-builtins
+          - flake8-coding
+          - flake8-comprehensions
+          - flake8-isort
+          - flake8-logging-format
+          - flake8-mutable
+          - flake8-print
+          - pep8-naming

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,3 @@
-black
 isort
 toml
 flake8

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,0 +1,15 @@
+black
+isort
+toml
+flake8
+flake8-assertive
+flake8-blind-except
+flake8-builtins
+flake8-coding
+flake8-comprehensions
+flake8-isort
+flake8-logging-format
+flake8-mutable
+flake8-print
+pep8-naming
+pre-commit

--- a/funnel/_version.py
+++ b/funnel/_version.py
@@ -1,4 +1,6 @@
+# -*- coding: utf-8 -*-
+
 __all__ = ['__version__', '__version_info__']
 
 __version__ = '0.1.0'
-__version_info__ = tuple([int(num) if num.isdigit() else num for num in __version__.replace('-', '.', 1).split('.')])
+__version_info__ = tuple(int(num) if num.isdigit() else num for num in __version__.replace('-', '.', 1).split('.'))

--- a/funnel/extapi/boxoffice.py
+++ b/funnel/extapi/boxoffice.py
@@ -12,9 +12,8 @@ __all__ = ['Boxoffice']
 
 
 class Boxoffice(object):
-    """
-    An interface that enables data retrieval from Boxoffice.
-    """
+    """Interface that enables data retrieval from Boxoffice."""
+
     def __init__(self, access_token, base_url=None):
         self.access_token = access_token
         if not base_url:

--- a/funnel/extapi/explara.py
+++ b/funnel/extapi/explara.py
@@ -13,9 +13,11 @@ def strip_or_empty(val):
 
 class ExplaraAPI(object):
     """
-    An interface that enables data retrieval from Explara.
+    Interface that enables data retrieval from Explara.
+
     Reference : https://developers.explara.com/api-document
     """
+
     def __init__(self, access_token):
         self.access_token = access_token
         self.headers = {'Authorization': u'Bearer ' + self.access_token}
@@ -26,8 +28,9 @@ class ExplaraAPI(object):
 
     def get_orders(self, explara_eventid):
         """
-        Gets the entire dump of orders for a given eventid in batches of 50,
-        owing to the restriction imposed by Explara's API.
+        Get the entire dump of orders for a given eventid in batches.
+
+        Batches are of size 50, owing to the restriction imposed by Explara's API.
         Explara does not make any assurances w.r.t the order; hence no order is assumed and
         the entire dump is retrieved.
         """

--- a/funnel/forms/profile.py
+++ b/funnel/forms/profile.py
@@ -6,17 +6,15 @@ from baseframe.forms.sqlalchemy import QuerySelectField
 
 
 class NewProfileForm(forms.Form):
-    """
-    Create a new profile.
-    """
+    """Create a new profile."""
+
     profile = forms.RadioField(__("Organization"), validators=[forms.validators.DataRequired("Select an organization")],
         description=__(u"Select the organization you’d like to create a Talkfunnel for"))
 
 
 class EditProfileForm(forms.Form):
-    """
-    Edit a profile.
-    """
+    """Edit a profile."""
+
     description = forms.MarkdownField(__("Welcome message"),
         validators=[forms.validators.DataRequired(_(u"Please write a message for the landing page"))],
         description=__("This welcome message will be shown on the landing page."))

--- a/funnel/forms/proposal.py
+++ b/funnel/forms/proposal.py
@@ -13,9 +13,7 @@ __all__ = ['ProposalTransferForm', 'ProposalForm', 'ProposalTransitionForm', 'Pr
 
 
 def proposal_label_form(project, proposal):
-    """
-    Returns a label form for the given project and proposal.
-    """
+    """Return a label form for the given project and proposal."""
     class ProposalLabelForm(forms.Form):
         pass
 
@@ -42,12 +40,12 @@ def proposal_label_admin_form(project, proposal):
         if not label.archived and (label.restricted or not label.has_options):
             form_kwargs = {}
             if label.has_options:
-                FieldType = forms.RadioField
+                field_type = forms.RadioField
                 form_kwargs['choices'] = [(option.name, option.title) for option in label.options if not option.archived]
             else:
-                FieldType = forms.BooleanField
+                field_type = forms.BooleanField
 
-            setattr(ProposalLabelAdminForm, label.name, FieldType(
+            setattr(ProposalLabelAdminForm, label.name, field_type(
                 label.form_label_text,
                 description=label.description,
                 validators=[forms.validators.DataRequired(__("Please select one"))] if label.required else [],

--- a/funnel/jobs/jobs.py
+++ b/funnel/jobs/jobs.py
@@ -44,8 +44,8 @@ def tag_locations(project_id):
                     if geoname:
                         geonames[geoname['geonameid']]['geonameid'] = geoname['geonameid']
                         geonames[geoname['geonameid']]['primary'] = geonames[geoname['geonameid']].get('primary', True)
-                        for type, related in geoname.get('related', {}).items():
-                            if type in ['admin2', 'admin1', 'country', 'continent']:
+                        for gtype, related in geoname.get('related', {}).items():
+                            if gtype in ['admin2', 'admin1', 'country', 'continent']:
                                 geonames[related['geonameid']]['geonameid'] = related['geonameid']
                                 geonames[related['geonameid']]['primary'] = False
 

--- a/funnel/models/commentvote.py
+++ b/funnel/models/commentvote.py
@@ -13,7 +13,7 @@ __all__ = ['Voteset', 'Vote', 'Commentset', 'Comment']
 
 # --- Constants ---------------------------------------------------------------
 
-class COMMENT_STATE(LabeledEnum):
+class COMMENT_STATE(LabeledEnum):  # NOQA: N801
     # If you add any new state, you need to add a migration to modify the check constraint
     PUBLIC = (0, 'public', __("Public"))
     SCREENED = (1, 'screened', __("Screened"))
@@ -23,7 +23,7 @@ class COMMENT_STATE(LabeledEnum):
 
 
 # What is this Voteset or Commentset attached to?
-class SET_TYPE:
+class SET_TYPE:  # NOQA: N801
     PROJECT = 0
     PROPOSAL = 2
     COMMENT = 3
@@ -33,7 +33,7 @@ class SET_TYPE:
 
 class Voteset(BaseMixin, db.Model):
     __tablename__ = 'voteset'
-    type = db.Column(db.Integer, nullable=True)
+    settype = db.Column('type', db.Integer, nullable=True)
     count = cached(db.Column(db.Integer, default=0, nullable=False))
 
     def __init__(self, **kwargs):
@@ -77,7 +77,7 @@ class Vote(BaseMixin, db.Model):
 
 class Commentset(BaseMixin, db.Model):
     __tablename__ = 'commentset'
-    type = db.Column(db.Integer, nullable=True)
+    settype = db.Column('type', db.Integer, nullable=True)
     count = db.Column(db.Integer, default=0, nullable=False)
 
     def __init__(self, **kwargs):
@@ -130,7 +130,7 @@ class Comment(UuidMixin, BaseMixin, db.Model):
 
     def __init__(self, **kwargs):
         super(Comment, self).__init__(**kwargs)
-        self.voteset = Voteset(type=SET_TYPE.COMMENT)
+        self.voteset = Voteset(settype=SET_TYPE.COMMENT)
 
     @property
     def absolute_url(self):

--- a/funnel/models/event.py
+++ b/funnel/models/event.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 import base64
 import os
 

--- a/funnel/models/helpers.py
+++ b/funnel/models/helpers.py
@@ -12,7 +12,7 @@ from sqlalchemy.dialects.postgresql.base import (
 __all__ = ['RESERVED_NAMES', 'add_search_trigger']
 
 
-RESERVED_NAMES = set([
+RESERVED_NAMES = {
     '_baseframe',
     'admin',
     'api',
@@ -78,7 +78,7 @@ RESERVED_NAMES = set([
     'workshop',
     'workshops',
     'www',
-    ])
+}
 
 
 def pgquote(identifier):

--- a/funnel/models/label.py
+++ b/funnel/models/label.py
@@ -125,7 +125,7 @@ class Label(BaseScopedNameMixin, db.Model):
         self._restricted = value
 
     @restricted.expression
-    def restricted(cls):
+    def restricted(cls):  # NOQA: N805
         return case([
             (cls.main_label_id != None, db.select([Label._restricted]).where(Label.id == cls.main_label_id).as_scalar())  # NOQA
         ], else_=cls._restricted)
@@ -139,7 +139,7 @@ class Label(BaseScopedNameMixin, db.Model):
         self._archived = value
 
     @archived.expression
-    def archived(cls):
+    def archived(cls):  # NOQA: N805
         return case([
             (cls._archived == True, cls._archived),  # NOQA
             (cls.main_label_id != None, db.select([Label._archived]).where(Label.id == cls.main_label_id).as_scalar())  # NOQA
@@ -150,7 +150,7 @@ class Label(BaseScopedNameMixin, db.Model):
         return bool(self.options)
 
     @has_options.expression
-    def has_options(cls):
+    def has_options(cls):  # NOQA: N805
         return exists().where(Label.main_label_id == cls.id)
 
     @property

--- a/funnel/models/project.py
+++ b/funnel/models/project.py
@@ -36,7 +36,7 @@ __all__ = ['Project', 'ProjectRedirect', 'ProjectLocation']
 
 # --- Constants ---------------------------------------------------------------
 
-class PROJECT_STATE(LabeledEnum):
+class PROJECT_STATE(LabeledEnum):  # NOQA: N801
     DRAFT = (0, 'draft', __(u"Draft"))
     PUBLISHED = (1, 'published', __(u"Published"))
     WITHDRAWN = (2, 'withdrawn', __(u"Withdrawn"))
@@ -45,7 +45,7 @@ class PROJECT_STATE(LabeledEnum):
     PUBLISHABLE = {DRAFT, WITHDRAWN}
 
 
-class CFP_STATE(LabeledEnum):
+class CFP_STATE(LabeledEnum):  # NOQA: N801
     NONE = (0, 'none', __(u"None"))
     PUBLIC = (1, 'public', __(u"Public"))
     CLOSED = (2, 'closed', __(u"Closed"))
@@ -53,7 +53,7 @@ class CFP_STATE(LabeledEnum):
     EXISTS = {PUBLIC, CLOSED}
 
 
-class SCHEDULE_STATE(LabeledEnum):
+class SCHEDULE_STATE(LabeledEnum):  # NOQA: N801
     DRAFT = (0, 'draft', __(u"Draft"))
     PUBLISHED = (1, 'published', __(u"Published"))
 
@@ -195,8 +195,8 @@ class Project(UuidMixin, BaseScopedNameMixin, db.Model):
 
     def __init__(self, **kwargs):
         super(Project, self).__init__(**kwargs)
-        self.voteset = Voteset(type=SET_TYPE.PROJECT)
-        self.commentset = Commentset(type=SET_TYPE.PROJECT)
+        self.voteset = Voteset(settype=SET_TYPE.PROJECT)
+        self.commentset = Commentset(settype=SET_TYPE.PROJECT)
 
     def __repr__(self):
         return '<Project %s/%s "%s">' % (self.profile.name if self.profile else "(none)", self.name, self.title)
@@ -445,10 +445,11 @@ class Project(UuidMixin, BaseScopedNameMixin, db.Model):
             basequery = Proposal.query.filter(Proposal.project_id.in_([self.id] + [s.id for s in self.subprojects]))
         else:
             basequery = Proposal.query.filter_by(project=self)
-        return dict(
-            confirmed=basequery.filter(Proposal.state.CONFIRMED).order_by(db.desc('created_at')).all(),
-            unconfirmed=basequery.filter(~Proposal.state.CONFIRMED, ~Proposal.state.DRAFT).order_by(
-                db.desc('created_at')).all())
+        return {
+            'confirmed': basequery.filter(Proposal.state.CONFIRMED).order_by(db.desc('created_at')).all(),
+            'unconfirmed': basequery.filter(~Proposal.state.CONFIRMED, ~Proposal.state.DRAFT).order_by(
+                db.desc('created_at')).all()
+        }
 
     @cached_property
     def location_geonameid(self):
@@ -523,7 +524,7 @@ class Project(UuidMixin, BaseScopedNameMixin, db.Model):
             projects = projects.join(Profile).filter(Profile.legacy == legacy)
         return projects
 
-    @classmethod
+    @classmethod  # NOQA: A003
     def all(cls, legacy=None):
         """
         Return currently active events, sorted by date.

--- a/funnel/models/proposal.py
+++ b/funnel/models/proposal.py
@@ -31,7 +31,7 @@ _marker = object()
 
 # --- Constants ------------------------------------------------------------------
 
-class PROPOSAL_STATE(LabeledEnum):
+class PROPOSAL_STATE(LabeledEnum):  # NOQA: N801
     # Draft-state for future use, so people can save their proposals and submit only when ready
     # If you add any new state, you need to add a migration to modify the check constraint
     DRAFT = (0, 'draft', __("Draft"))
@@ -151,8 +151,8 @@ class Proposal(UuidMixin, BaseScopedIdNameMixin, CoordinatesMixin, db.Model):
 
     def __init__(self, **kwargs):
         super(Proposal, self).__init__(**kwargs)
-        self.voteset = Voteset(type=SET_TYPE.PROPOSAL)
-        self.commentset = Commentset(type=SET_TYPE.PROPOSAL)
+        self.voteset = Voteset(settype=SET_TYPE.PROPOSAL)
+        self.commentset = Commentset(settype=SET_TYPE.PROPOSAL)
 
     def __repr__(self):
         return u'<Proposal "{proposal}" in project "{project}" by "{user}">'.format(
@@ -363,7 +363,7 @@ class ProposalRedirect(TimestampMixin, db.Model):
         return unicode(self.url_id)
 
     @url_id_name.comparator
-    def url_id_name(cls):
+    def url_id_name(cls):  # NOQA: N805
         return SqlSplitIdComparator(cls.url_id, splitindex=0)
 
     url_name = url_id_name  # Legacy name

--- a/funnel/models/rsvp.py
+++ b/funnel/models/rsvp.py
@@ -11,7 +11,7 @@ from .user import User
 __all__ = ['Rsvp', 'RSVP_STATUS']
 
 
-class RSVP_STATUS(LabeledEnum):
+class RSVP_STATUS(LabeledEnum):  # NOQA: N801
     # If you add any new state, you need to add a migration to modify the check constraint
     Y = ('Y', 'yes', __("Yes"))
     N = ('N', 'no', __("No"))

--- a/funnel/models/user.py
+++ b/funnel/models/user.py
@@ -26,7 +26,7 @@ class UseridMixin(object):
         self.uuid = buid2uuid(value)
 
     @userid.comparator
-    def userid(cls):
+    def userid(cls):  # NOQA: N805
         return SqlBuidComparator(cls.uuid)
 
 
@@ -75,7 +75,7 @@ class Team(UseridMixin, UuidMixin, TeamBase, db.Model):
         self.org_uuid = buid2uuid(value)
 
     @orgid.comparator
-    def orgid(cls):
+    def orgid(cls):  # NOQA: N805
         return SqlBuidComparator(cls.org_uuid)
 
     def __repr__(self):

--- a/funnel/util.py
+++ b/funnel/util.py
@@ -16,8 +16,8 @@ from baseframe import cache
 @cache.memoize(timeout=86400)
 def geonameid_from_location(text):
     """
-    Accepts a string, checks hascore if there's a location embedded
-    in the string, and returns a set of matched geonameids.
+    Convert location string into a set of matching geonameids.
+
     Eg: "Bangalore" -> {1277333}
 
     Returns an empty set if the request timed out, or if the Hascore config
@@ -37,7 +37,7 @@ def geonameid_from_location(text):
 
 def extract_twitter_handle(handle):
     """
-    Extracts a twitter handle from a user input.
+    Extract a twitter handle from a user input.
 
     Usage::
 
@@ -68,8 +68,8 @@ def format_twitter_handle(handle):
 
 def split_name(fullname):
     """
-    Splits a given fullname into two parts
-    a first name, and a concanetated last name.
+    Split a given fullname into a first name and remaining names.
+
     Eg: "ABC DEF EFG" -> ("ABC", "DEF EFG")
     """
     if not fullname:
@@ -80,9 +80,7 @@ def split_name(fullname):
 
 # TODO: Added tests for this
 def make_qrcode(data):
-    """
-    Makes a QR code in-memory and returns the raw svg
-    """
+    """Make a QR code in-memory and return the raw svg"""
     factory = qrcode.image.svg.SvgPathImage
     stream = six.BytesIO()
     img = qrcode.make(data, image_factory=factory)

--- a/funnel/views/decorators.py
+++ b/funnel/views/decorators.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from functools import wraps
 
 from flask import current_app, g, redirect, request

--- a/funnel/views/event.py
+++ b/funnel/views/event.py
@@ -43,7 +43,7 @@ class ProjectEventView(ProjectViewMixin, UrlForView, ModelView):
     @lastuser.requires_login
     @requires_permission('checkin_event')
     def events(self):
-        return dict(project=self.obj, profile=self.obj.profile, events=self.obj.events)
+        return {'project': self.obj, 'profile': self.obj.profile, 'events': self.obj.events}
 
     @route('json')
     @lastuser.requires_login

--- a/funnel/views/label.py
+++ b/funnel/views/label.py
@@ -31,7 +31,7 @@ class ProjectLabelView(ProjectViewMixin, UrlForView, ModelView):
                     lbl.seq = idx
                     db.session.commit()
             flash(_("Your changes have been saved"), category='success')
-        return dict(project=self.obj, labels=self.obj.labels, form=form)
+        return {'project': self.obj, 'labels': self.obj.labels, 'form': form}
 
     @route('new', methods=['GET', 'POST'])
     @lastuser.requires_login
@@ -66,7 +66,7 @@ class ProjectLabelView(ProjectViewMixin, UrlForView, ModelView):
 
                 if not subform.validate():
                     flash(_("Error with a label option: {}").format(subform.errors.pop()), category='error')
-                    return dict(title="Add label", form=form, project=self.obj)
+                    return {'title': "Add label", 'form': form, 'project': self.obj}
                 else:
                     subl = Label(project=self.obj)
                     subform.populate_obj(subl)
@@ -76,7 +76,7 @@ class ProjectLabelView(ProjectViewMixin, UrlForView, ModelView):
 
             db.session.commit()
             return redirect(self.obj.url_for('labels'), code=303)
-        return dict(title="Add label", form=form, emptysubform=emptysubform, project=self.obj)
+        return {'title': "Add label", 'form': form, 'emptysubform': emptysubform, 'project': self.obj}
 
 
 @route('/<project>/labels', subdomain='<profile>')
@@ -143,7 +143,7 @@ class LabelView(UrlForView, ModelView):
 
                     if not subform.validate():
                         flash(_("Error with a label option: {}").format(subform.errors.pop()), category='error')
-                        return dict(title="Edit label", form=form, project=self.obj.project)
+                        return {'title': "Edit label", 'form': form, 'project': self.obj.project}
                     else:
                         subl = Label(project=self.obj.project)
                         subform.populate_obj(subl)
@@ -158,7 +158,7 @@ class LabelView(UrlForView, ModelView):
             flash(_("Label has been edited"), category='success')
 
             return redirect(self.obj.project.url_for('labels'), code=303)
-        return dict(title="Edit label", form=form, subforms=subforms, emptysubform=emptysubform, project=self.obj.project)
+        return {'title': "Edit label", 'form': form, 'subforms': subforms, 'emptysubform': emptysubform, 'project': self.obj.project}
 
     @route('archive', methods=['POST'])
     @lastuser.requires_login

--- a/funnel/views/participant.py
+++ b/funnel/views/participant.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 from sqlalchemy.exc import IntegrityError
 
 from flask import (

--- a/funnel/views/project.py
+++ b/funnel/views/project.py
@@ -268,7 +268,7 @@ class ProjectView(ProjectViewMixin, DraftViewMixin, UrlForView, ModelView):
             form.populate_obj(rsvp)
             db.session.commit()
             if request.is_xhr:
-                return dict(project=self.obj, rsvp=rsvp, rsvp_form=form)
+                return {'project': self.obj, 'rsvp': rsvp, 'rsvp_form': form}
             else:
                 return redirect(self.obj.url_for(), code=303)
         else:
@@ -279,7 +279,7 @@ class ProjectView(ProjectViewMixin, DraftViewMixin, UrlForView, ModelView):
     @lastuser.requires_login
     @requires_permission('edit_project')
     def rsvp_list(self):
-        return dict(project=self.obj, statuses=RSVP_STATUS)
+        return {'project': self.obj, 'statuses': RSVP_STATUS}
 
     @route('admin', methods=['GET', 'POST'])
     @render_with('admin.html.jinja2')
@@ -293,7 +293,12 @@ class ProjectView(ProjectViewMixin, DraftViewMixin, UrlForView, ModelView):
                     import_tickets.queue(ticket_client.id)
             flash(_(u"Importing tickets from vendors...Refresh the page in about 30 seconds..."), 'info')
             return redirect(self.obj.url_for('admin'), code=303)
-        return dict(profile=self.obj.profile, project=self.obj, events=self.obj.events, csrf_form=csrf_form)
+        return {
+            'profile': self.obj.profile,
+            'project': self.obj,
+            'events': self.obj.events,
+            'csrf_form': csrf_form
+        }
 
 
 @route('/<project>/', subdomain='<profile>')

--- a/funnel/views/proposal.py
+++ b/funnel/views/proposal.py
@@ -172,11 +172,19 @@ class ProposalView(ProposalViewMixin, UrlChangeCheck, UrlForView, ModelView):
 
         proposal_label_admin_form = ProposalLabelsAdminForm(model=Proposal, obj=self.obj, parent=self.obj.project)
 
-        return dict(project=self.obj.project, proposal=self.obj,
-            comments=comments, commentform=commentform, delcommentform=delcommentform,
-            links=links, transition_form=transition_form, proposal_move_form=proposal_move_form,
-            csrf_form=Form(), proposal_transfer_form=proposal_transfer_form,
-            proposal_label_admin_form=proposal_label_admin_form)
+        return {
+            'project': self.obj.project,
+            'proposal': self.obj,
+            'comments': comments,
+            'commentform': commentform,
+            'delcommentform': delcommentform,
+            'links': links,
+            'transition_form': transition_form,
+            'proposal_move_form': proposal_move_form,
+            'csrf_form': Form(),
+            'proposal_transfer_form': proposal_transfer_form,
+            'proposal_label_admin_form': proposal_label_admin_form
+        }
 
     @route('json')
     @requires_permission('view')
@@ -228,12 +236,12 @@ class ProposalView(ProposalViewMixin, UrlChangeCheck, UrlForView, ModelView):
             abort(403)
         return redirect(self.obj.url_for())
 
-    @route('next')
+    @route('next')  # NOQA: A003
     @requires_permission('view')
     def next(self):
-        next = self.obj.getnext()
-        if next:
-            return redirect(next.url_for())
+        nextobj = self.obj.getnext()
+        if nextobj:
+            return redirect(nextobj.url_for())
         else:
             flash(_("You were at the last proposal"), 'info')
             return redirect(self.obj.project.url_for())
@@ -241,9 +249,9 @@ class ProposalView(ProposalViewMixin, UrlChangeCheck, UrlForView, ModelView):
     @route('prev')
     @requires_permission('view')
     def prev(self):
-        prev = self.obj.getprev()
-        if prev:
-            return redirect(prev.url_for())
+        prevobj = self.obj.getprev()
+        if prevobj:
+            return redirect(prevobj.url_for())
         else:
             flash(_("You were at the first proposal"), 'info')
             return redirect(self.obj.project.url_for())

--- a/funnel/views/schedule.py
+++ b/funnel/views/schedule.py
@@ -278,26 +278,26 @@ class ScheduleVenueRoomView(VenueRoomViewMixin, UrlForView, ModelView):
     @requires_permission('view')
     def updates(self):
         now = utcnow()
-        current = Session.query.filter(
+        current_session = Session.query.filter(
             Session.start_at <= now, Session.end_at >= now,
             Session.project == self.obj.venue.project,
             db.or_(Session.venue_room == room, Session.is_break == True)  # NOQA
             ).first()
-        next = Session.query.filter(
+        next_session = Session.query.filter(
             Session.start_at > now,
             db.or_(Session.venue_room == room, Session.is_break == True),  # NOQA
             Session.project == self.obj.venue.project
             ).order_by(Session.start_at).first()
-        if current:
-            current.start_at = localize_date(current.start_at, to_tz=self.obj.venue.project.timezone)
-            current.end_at = localize_date(current.end_at, to_tz=self.obj.venue.project.timezone)
+        if current_session:
+            current_session.start_at = localize_date(current_session.start_at, to_tz=self.obj.venue.project.timezone)
+            current_session.end_at = localize_date(current_session.end_at, to_tz=self.obj.venue.project.timezone)
         nextdiff = None
-        if next:
-            next.start_at = localize_date(next.start_at, to_tz=self.obj.venue.project.timezone)
-            next.end_at = localize_date(next.end_at, to_tz=self.obj.venue.project.timezone)
-            nextdiff = next.start_at.date() - now.date()
+        if next_session:
+            next_session.start_at = localize_date(next_session.start_at, to_tz=self.obj.venue.project.timezone)
+            next_session.end_at = localize_date(next_session.end_at, to_tz=self.obj.venue.project.timezone)
+            nextdiff = next_session.start_at.date() - now.date()
             nextdiff = nextdiff.total_seconds() / 86400
-        return dict(room=self.obj, current=current, next=next, nextdiff=nextdiff)
+        return dict(room=self.obj, current_session=current_session, next_session=next_session, nextdiff=nextdiff)
 
 
 @route('/<project>/schedule/<venue>/<room>', subdomain='<profile>')

--- a/funnel/views/session.py
+++ b/funnel/views/session.py
@@ -60,10 +60,15 @@ def session_form(project, proposal=None, session=None):
             session.parent = project
             session = failsafe_add(db.session, session, project_id=project.id, url_id=session.url_id)
         db.session.commit()
-        data = dict(
-            id=session.url_id, title=session.title, room_scoped_name=session.venue_room.scoped_name if session.venue_room else None,
-            is_break=session.is_break, modal_url=session.url_for('edit'), delete_url=session.url_for('delete'),
-            proposal_id=session.proposal_id)
+        data = {
+            'id': session.url_id,
+            'title': session.title,
+            'room_scoped_name': session.venue_room.scoped_name if session.venue_room else None,
+            'is_break': session.is_break,
+            'modal_url': session.url_for('edit'),
+            'delete_url': session.url_for('delete'),
+            'proposal_id': session.proposal_id  # FIXME: Switch to UUID
+        }
         return jsonify(status=True, data=data)
     return jsonify(
         status=False,
@@ -109,7 +114,11 @@ class SessionView(SessionViewMixin, UrlForView, ModelView):
     @render_with('session_view_popup.html.jinja2')
     @requires_permission('view')
     def view_popup(self):
-        return dict(session=self.obj, timezone=self.obj.project.timezone.zone, localize_date=localize_date)
+        return {
+            'session': self.obj,
+            'timezone': self.obj.project.timezone.zone,
+            'localize_date': localize_date
+        }
 
     @route('editsession', methods=['GET', 'POST'])
     @lastuser.requires_login

--- a/funnel/views/venue.py
+++ b/funnel/views/venue.py
@@ -55,7 +55,11 @@ class ProjectVenueView(ProjectViewMixin, UrlForView, ModelView):
     @lastuser.requires_login
     @requires_permission('view')
     def venues(self):
-        return dict(project=self.obj, venues=self.obj.venues, primary_venue_form=VenuePrimaryForm(parent=self.obj))
+        return {
+            'project': self.obj,
+            'venues': self.obj.venues,
+            'primary_venue_form': VenuePrimaryForm(parent=self.obj)
+        }
 
     @route('new', methods=['GET', 'POST'])
     @lastuser.requires_login

--- a/funnelwebsite.py
+++ b/funnelwebsite.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import os.path
 import sys
 

--- a/instance/funnelapp-sample.py
+++ b/instance/funnelapp-sample.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 SITE_TITLE = 'HasGeek Funnel'
 SERVER_NAME = 'talkfunnel.com'
 #: Lastuser client id

--- a/instance/hasgeekapp-sample.py
+++ b/instance/hasgeekapp-sample.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 SITE_TITLE = 'HasGeek App'
 #: Lastuser client id
 LASTUSER_CLIENT_ID = ''

--- a/instance/testing.py
+++ b/instance/testing.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 SECRET_KEY = 'testkey'
 SQLALCHEMY_DATABASE_URI = 'postgresql:///funnel_testing'
 SERVER_NAME = 'funnel.travis.local:3000'

--- a/manage.py
+++ b/manage.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+# -*- coding: utf-8 -*-
 
 from coaster.manage import init_manager
 from funnel import app, funnelapp, models

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from __future__ import with_statement
 
 import logging
@@ -21,8 +23,9 @@ logger = logging.getLogger('alembic.env')
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
-config.set_main_option('sqlalchemy.url',
-                       current_app.config.get('SQLALCHEMY_DATABASE_URI'))
+config.set_main_option(
+    'sqlalchemy.url', current_app.config.get('SQLALCHEMY_DATABASE_URI')
+)
 target_metadata = current_app.extensions['migrate'].db.metadata
 
 # other values from the config, defined by the needs of env.py,
@@ -68,15 +71,19 @@ def run_migrations_online():
                 directives[:] = []
                 logger.info('No changes in schema detected.')
 
-    engine = engine_from_config(config.get_section(config.config_ini_section),
-                                prefix='sqlalchemy.',
-                                poolclass=pool.NullPool)
+    engine = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix='sqlalchemy.',
+        poolclass=pool.NullPool,
+    )
 
     connection = engine.connect()
-    context.configure(connection=connection,
-                      target_metadata=target_metadata,
-                      process_revision_directives=process_revision_directives,
-                      **current_app.extensions['migrate'].configure_args)
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        process_revision_directives=process_revision_directives,
+        **current_app.extensions['migrate'].configure_args
+    )
 
     try:
         with context.begin_transaction():

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """${message}
 
 Revision ID: ${up_revision}

--- a/migrations/versions/034863dbaac2_label_name_check_constraint.py
+++ b/migrations/versions/034863dbaac2_label_name_check_constraint.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Label.name check constraint
 
 Revision ID: 034863dbaac2

--- a/migrations/versions/07ebe99161d5_add_banner_image_url_to_sessio.py
+++ b/migrations/versions/07ebe99161d5_add_banner_image_url_to_sessio.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """add banner_image_url field to session
 
 Revision ID: 07ebe99161d5
@@ -15,7 +17,9 @@ from alembic import op
 
 
 def upgrade():
-    op.add_column('session', sa.Column('banner_image_url', sa.Unicode(length=2000), nullable=True))
+    op.add_column(
+        'session', sa.Column('banner_image_url', sa.Unicode(length=2000), nullable=True)
+    )
 
 
 def downgrade():

--- a/migrations/versions/0b25df40d307_add_labels.py
+++ b/migrations/versions/0b25df40d307_add_labels.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """add labels
 
 # Revision ID: 0b25df40d307
@@ -15,7 +17,8 @@ from alembic import op
 
 
 def upgrade():
-    op.create_table('label',
+    op.create_table(
+        'label',
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
         sa.Column('project_id', sa.Integer(), nullable=False),
@@ -32,17 +35,20 @@ def upgrade():
         sa.ForeignKeyConstraint(['main_label_id'], ['label.id'], ondelete='CASCADE'),
         sa.ForeignKeyConstraint(['project_id'], ['project.id'], ondelete='CASCADE'),
         sa.PrimaryKeyConstraint('id'),
-        sa.UniqueConstraint('project_id', 'name')
-        )
-    op.create_table('proposal_label',
+        sa.UniqueConstraint('project_id', 'name'),
+    )
+    op.create_table(
+        'proposal_label',
         sa.Column('proposal_id', sa.Integer(), nullable=False),
         sa.Column('label_id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=True),
         sa.ForeignKeyConstraint(['label_id'], ['label.id'], ondelete='CASCADE'),
         sa.ForeignKeyConstraint(['proposal_id'], ['proposal.id'], ondelete='CASCADE'),
-        sa.PrimaryKeyConstraint('proposal_id', 'label_id')
-        )
-    op.create_index(op.f('ix_proposal_label_label_id'), 'proposal_label', ['label_id'], unique=False)
+        sa.PrimaryKeyConstraint('proposal_id', 'label_id'),
+    )
+    op.create_index(
+        op.f('ix_proposal_label_label_id'), 'proposal_label', ['label_id'], unique=False
+    )
 
 
 def downgrade():

--- a/migrations/versions/111c9755ae39_switch_to_timestamptz.py
+++ b/migrations/versions/111c9755ae39_switch_to_timestamptz.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Switch to timestamptz
 
 Revision ID: 111c9755ae39
@@ -80,20 +82,24 @@ migrate_table_columns = [
     ('vote', 'updated_at'),
     ('voteset', 'created_at'),
     ('voteset', 'updated_at'),
-    ]
+]
 
 
 def upgrade():
     for table, column in migrate_table_columns:
-        op.execute(sa.DDL(
-            'ALTER TABLE "%(table)s" ALTER COLUMN "%(column)s" TYPE TIMESTAMP WITH TIME ZONE USING "%(column)s" AT TIME ZONE \'UTC\'',
-            context={'table': table, 'column': column}
-            ))
+        op.execute(
+            sa.DDL(
+                'ALTER TABLE "%(table)s" ALTER COLUMN "%(column)s" TYPE TIMESTAMP WITH TIME ZONE USING "%(column)s" AT TIME ZONE \'UTC\'',
+                context={'table': table, 'column': column},
+            )
+        )
 
 
 def downgrade():
     for table, column in reversed(migrate_table_columns):
-        op.execute(sa.DDL(
-            'ALTER TABLE "%(table)s" ALTER COLUMN "%(column)s" TYPE TIMESTAMP WITHOUT TIME ZONE',
-            context={'table': table, 'column': column}
-            ))
+        op.execute(
+            sa.DDL(
+                'ALTER TABLE "%(table)s" ALTER COLUMN "%(column)s" TYPE TIMESTAMP WITHOUT TIME ZONE',
+                context={'table': table, 'column': column},
+            )
+        )

--- a/migrations/versions/1195a2789872_proposal_video_blogp.py
+++ b/migrations/versions/1195a2789872_proposal_video_blogp.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Proposal video blogpost
 
 Revision ID: 1195a2789872
@@ -15,9 +17,15 @@ from alembic import op
 
 
 def upgrade():
-    op.add_column('proposal', sa.Column('blog_post', sa.Unicode(250), server_default=u'', nullable=False))
+    op.add_column(
+        'proposal',
+        sa.Column('blog_post', sa.Unicode(250), server_default=u'', nullable=False),
+    )
     op.alter_column('proposal', 'blog_post', server_default=None)
-    op.add_column('proposal', sa.Column('preview_video', sa.Unicode(250), server_default=u'', nullable=False))
+    op.add_column(
+        'proposal',
+        sa.Column('preview_video', sa.Unicode(250), server_default=u'', nullable=False),
+    )
     op.alter_column('proposal', 'preview_video', server_default=None)
 
 

--- a/migrations/versions/140c9b68d65b_team_model.py
+++ b/migrations/versions/140c9b68d65b_team_model.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Team model
 
 Revision ID: 140c9b68d65b
@@ -15,7 +17,8 @@ from alembic import op
 
 
 def upgrade():
-    op.create_table('team',
+    op.create_table(
+        'team',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
@@ -24,22 +27,28 @@ def upgrade():
         sa.Column('owners', sa.Boolean(), nullable=False),
         sa.Column('orgid', sa.String(length=22), nullable=False),
         sa.PrimaryKeyConstraint('id'),
-        sa.UniqueConstraint('userid')
-        )
-    op.create_table('users_teams',
+        sa.UniqueConstraint('userid'),
+    )
+    op.create_table(
+        'users_teams',
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
         sa.Column('user_id', sa.Integer(), nullable=False),
         sa.Column('team_id', sa.Integer(), nullable=False),
-        sa.ForeignKeyConstraint(['team_id'], ['team.id'], ),
-        sa.ForeignKeyConstraint(['user_id'], ['user.id'], ),
-        sa.PrimaryKeyConstraint('user_id', 'team_id')
-        )
+        sa.ForeignKeyConstraint(['team_id'], ['team.id']),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id']),
+        sa.PrimaryKeyConstraint('user_id', 'team_id'),
+    )
     op.drop_column('user', 'description')
 
 
 def downgrade():
-    op.add_column('user', sa.Column('description', sa.TEXT(), nullable=False, server_default=sa.text(u"''")))
+    op.add_column(
+        'user',
+        sa.Column(
+            'description', sa.TEXT(), nullable=False, server_default=sa.text(u"''")
+        ),
+    )
     op.alter_column('user', 'description', server_default=None)
 
     op.drop_table('users_teams')

--- a/migrations/versions/14d1424b47_rsvp.py
+++ b/migrations/versions/14d1424b47_rsvp.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """RSVP
 
 Revision ID: 14d1424b47
@@ -15,17 +17,26 @@ from alembic import op
 
 
 def upgrade():
-    op.create_table('rsvp',
+    op.create_table(
+        'rsvp',
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
         sa.Column('proposal_space_id', sa.Integer(), nullable=False),
         sa.Column('user_id', sa.Integer(), nullable=False),
-        sa.Column('status', sa.CHAR(length=1), sa.CheckConstraint("status IN ('Y', 'N', 'M', 'A')"), nullable=False),
-        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id'], ),
-        sa.ForeignKeyConstraint(['user_id'], ['user.id'], ),
-        sa.PrimaryKeyConstraint('proposal_space_id', 'user_id')
-        )
-    op.add_column('proposal_space', sa.Column('allow_rsvp', sa.Boolean(), nullable=False, server_default='0'))
+        sa.Column(
+            'status',
+            sa.CHAR(length=1),
+            sa.CheckConstraint("status IN ('Y', 'N', 'M', 'A')"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id']),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id']),
+        sa.PrimaryKeyConstraint('proposal_space_id', 'user_id'),
+    )
+    op.add_column(
+        'proposal_space',
+        sa.Column('allow_rsvp', sa.Boolean(), nullable=False, server_default='0'),
+    )
     op.alter_column('proposal_space', 'allow_rsvp', server_default=None)
 
 

--- a/migrations/versions/14d7082476c0_proposalspace_image_.py
+++ b/migrations/versions/14d7082476c0_proposalspace_image_.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """ProposalSpace image and color
 
 Revision ID: 14d7082476c0
@@ -15,8 +17,12 @@ from alembic import op
 
 
 def upgrade():
-    op.add_column('proposal_space', sa.Column('bg_color', sa.Unicode(length=6), nullable=True))
-    op.add_column('proposal_space', sa.Column('bg_image', sa.Unicode(length=250), nullable=True))
+    op.add_column(
+        'proposal_space', sa.Column('bg_color', sa.Unicode(length=6), nullable=True)
+    )
+    op.add_column(
+        'proposal_space', sa.Column('bg_image', sa.Unicode(length=250), nullable=True)
+    )
 
 
 def downgrade():

--- a/migrations/versions/18052b0cd282_scoped_id_for_propos.py
+++ b/migrations/versions/18052b0cd282_scoped_id_for_propos.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Scoped id for proposals
 
 Revision ID: 18052b0cd282
@@ -16,22 +18,30 @@ from sqlalchemy.sql import column, table
 
 
 def upgrade():
-    proposal_space = table('proposal_space',
+    proposal_space = table(
+        'proposal_space',
         column('name', sa.Unicode(250)),
-        column('legacy_name', sa.Unicode(250)))
+        column('legacy_name', sa.Unicode(250)),
+    )
 
-    proposal = table('proposal',
-        column('id', sa.Integer),
-        column('url_id', sa.Integer))
+    proposal = table('proposal', column('id', sa.Integer), column('url_id', sa.Integer))
 
-    op.add_column('proposal_space', sa.Column('legacy_name', sa.Unicode(250), nullable=True))
+    op.add_column(
+        'proposal_space', sa.Column('legacy_name', sa.Unicode(250), nullable=True)
+    )
     op.execute(proposal_space.update().values({'legacy_name': proposal_space.c.name}))
-    op.create_unique_constraint('proposal_space_legacy_name_key', 'proposal_space', ['legacy_name'])
+    op.create_unique_constraint(
+        'proposal_space_legacy_name_key', 'proposal_space', ['legacy_name']
+    )
 
     op.add_column('proposal', sa.Column('url_id', sa.Integer(), nullable=True))
     op.execute(proposal.update().values({'url_id': proposal.c.id}))
     op.alter_column('proposal', 'url_id', nullable=False)
-    op.create_unique_constraint('proposal_proposal_space_id_url_id_key', 'proposal', ['proposal_space_id', 'url_id'])
+    op.create_unique_constraint(
+        'proposal_proposal_space_id_url_id_key',
+        'proposal',
+        ['proposal_space_id', 'url_id'],
+    )
 
 
 def downgrade():

--- a/migrations/versions/1829e53eba75_add_search_vectors.py
+++ b/migrations/versions/1829e53eba75_add_search_vectors.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Add search vectors
 
 Revision ID: 1829e53eba75
@@ -19,32 +21,64 @@ from sqlalchemy_utils import TSVectorType
 
 def upgrade():
     op.add_column('comment', sa.Column('search_vector', TSVectorType(), nullable=True))
-    op.create_index('ix_comment_search_vector', 'comment', ['search_vector'],
-        unique=False, postgresql_using='gin')
+    op.create_index(
+        'ix_comment_search_vector',
+        'comment',
+        ['search_vector'],
+        unique=False,
+        postgresql_using='gin',
+    )
 
     op.add_column('label', sa.Column('search_vector', TSVectorType(), nullable=True))
-    op.create_index('ix_label_search_vector', 'label', ['search_vector'],
-        unique=False, postgresql_using='gin')
+    op.create_index(
+        'ix_label_search_vector',
+        'label',
+        ['search_vector'],
+        unique=False,
+        postgresql_using='gin',
+    )
 
     op.add_column('profile', sa.Column('search_vector', TSVectorType(), nullable=True))
-    op.create_index('ix_profile_search_vector', 'profile', ['search_vector'],
-        unique=False, postgresql_using='gin')
+    op.create_index(
+        'ix_profile_search_vector',
+        'profile',
+        ['search_vector'],
+        unique=False,
+        postgresql_using='gin',
+    )
 
     op.add_column('project', sa.Column('search_vector', TSVectorType(), nullable=True))
-    op.create_index('ix_project_search_vector', 'project', ['search_vector'],
-        unique=False, postgresql_using='gin')
+    op.create_index(
+        'ix_project_search_vector',
+        'project',
+        ['search_vector'],
+        unique=False,
+        postgresql_using='gin',
+    )
 
     op.add_column('proposal', sa.Column('search_vector', TSVectorType(), nullable=True))
-    op.create_index('ix_proposal_search_vector', 'proposal', ['search_vector'],
-        unique=False, postgresql_using='gin')
+    op.create_index(
+        'ix_proposal_search_vector',
+        'proposal',
+        ['search_vector'],
+        unique=False,
+        postgresql_using='gin',
+    )
 
     op.add_column('session', sa.Column('search_vector', TSVectorType(), nullable=True))
-    op.create_index('ix_session_search_vector', 'session', ['search_vector'],
-        unique=False, postgresql_using='gin')
+    op.create_index(
+        'ix_session_search_vector',
+        'session',
+        ['search_vector'],
+        unique=False,
+        postgresql_using='gin',
+    )
 
     # Update search vectors for existing data
-    op.execute(sa.DDL(dedent(
-        '''
+    op.execute(
+        sa.DDL(
+            dedent(
+                '''
         UPDATE comment SET search_vector = setweight(to_tsvector('english', COALESCE(message_text, '')), 'A');
 
         UPDATE label SET search_vector = setweight(to_tsvector('english', COALESCE(name, '')), 'A') || setweight(to_tsvector('english', COALESCE(title, '')), 'A') || setweight(to_tsvector('english', COALESCE(description, '')), 'B');
@@ -56,11 +90,16 @@ def upgrade():
         UPDATE proposal SET search_vector = setweight(to_tsvector('english', COALESCE(title, '')), 'A') || setweight(to_tsvector('english', COALESCE(abstract_text, '')), 'B') || setweight(to_tsvector('english', COALESCE(outline_text, '')), 'B') || setweight(to_tsvector('english', COALESCE(requirements_text, '')), 'B') || setweight(to_tsvector('english', COALESCE(slides, '')), 'B') || setweight(to_tsvector('english', COALESCE(preview_video, '')), 'C') || setweight(to_tsvector('english', COALESCE(links, '')), 'B') || setweight(to_tsvector('english', COALESCE(bio_text, '')), 'B');
 
         UPDATE session SET search_vector = setweight(to_tsvector('english', COALESCE(title, '')), 'A') || setweight(to_tsvector('english', COALESCE(description_text, '')), 'B') || setweight(to_tsvector('english', COALESCE(speaker_bio_text, '')), 'B') || setweight(to_tsvector('english', COALESCE(speaker, '')), 'A');
-        ''')))
+        '''
+            )
+        )
+    )
 
     # Create trigger functions and add triggers
-    op.execute(sa.DDL(dedent(
-        '''
+    op.execute(
+        sa.DDL(
+            dedent(
+                '''
         CREATE FUNCTION comment_search_vector_update() RETURNS trigger AS $$
         BEGIN
             NEW.search_vector := setweight(to_tsvector('english', COALESCE(NEW.message_text, '')), 'A');
@@ -120,7 +159,10 @@ def upgrade():
 
         CREATE TRIGGER session_search_vector_trigger BEFORE INSERT OR UPDATE ON session
         FOR EACH ROW EXECUTE PROCEDURE session_search_vector_update();
-        ''')))
+        '''
+            )
+        )
+    )
 
     op.alter_column('comment', 'search_vector', nullable=False)
     op.alter_column('label', 'search_vector', nullable=False)
@@ -132,8 +174,10 @@ def upgrade():
 
 def downgrade():
     # Drop triggers and functions
-    op.execute(sa.DDL(dedent(
-        '''
+    op.execute(
+        sa.DDL(
+            dedent(
+                '''
         DROP TRIGGER comment_search_vector_trigger ON comment;
         DROP FUNCTION comment_search_vector_update();
 
@@ -151,7 +195,10 @@ def downgrade():
 
         DROP TRIGGER session_search_vector_trigger ON session;
         DROP FUNCTION session_search_vector_update();
-        ''')))
+        '''
+            )
+        )
+    )
 
     op.drop_index('ix_session_search_vector', table_name='session')
     op.drop_column('session', 'search_vector')

--- a/migrations/versions/1925329c798a_added_venue_room_det.py
+++ b/migrations/versions/1925329c798a_added_venue_room_det.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Added venue, room details
 
 Revision ID: 1925329c798a
@@ -15,7 +17,8 @@ from alembic import op
 
 
 def upgrade():
-    op.create_table('venue',
+    op.create_table(
+        'venue',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
@@ -32,11 +35,12 @@ def upgrade():
         sa.Column('longitude', sa.Numeric(precision=8, scale=5), nullable=True),
         sa.Column('name', sa.Unicode(length=250), nullable=False),
         sa.Column('title', sa.Unicode(length=250), nullable=False),
-        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id'], ),
+        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id']),
         sa.UniqueConstraint('proposal_space_id', 'name'),
-        sa.PrimaryKeyConstraint('id')
-        )
-    op.create_table('venue_room',
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_table(
+        'venue_room',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
@@ -45,10 +49,10 @@ def upgrade():
         sa.Column('description_html', sa.UnicodeText(), nullable=False),
         sa.Column('name', sa.Unicode(length=250), nullable=False),
         sa.Column('title', sa.Unicode(length=250), nullable=False),
-        sa.ForeignKeyConstraint(['venue_id'], ['venue.id'], ),
+        sa.ForeignKeyConstraint(['venue_id'], ['venue.id']),
         sa.PrimaryKeyConstraint('id'),
-        sa.UniqueConstraint('venue_id', 'name')
-        )
+        sa.UniqueConstraint('venue_id', 'name'),
+    )
 
 
 def downgrade():

--- a/migrations/versions/19a1f7f2a365_project_datelocation_drop.py
+++ b/migrations/versions/19a1f7f2a365_project_datelocation_drop.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """project datelocation drop
 
 Revision ID: 19a1f7f2a365
@@ -18,4 +20,13 @@ def upgrade():
 
 
 def downgrade():
-    op.add_column('project', sa.Column('datelocation', sa.VARCHAR(length=50), autoincrement=False, server_default='', nullable=False))
+    op.add_column(
+        'project',
+        sa.Column(
+            'datelocation',
+            sa.VARCHAR(length=50),
+            autoincrement=False,
+            server_default='',
+            nullable=False,
+        ),
+    )

--- a/migrations/versions/1b8fc63c0fb0_remove_and_rename_obsolete_columns.py
+++ b/migrations/versions/1b8fc63c0fb0_remove_and_rename_obsolete_columns.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Remove and rename obsolete columns
 
 Revision ID: 1b8fc63c0fb0
@@ -21,15 +23,15 @@ default_part_labels = {
         "part_a": {
             "title": "Abstract",
             "hint": "Give us a brief description of your talk, key takeaways for the audience and the"
-            " intended audience."
-            },
+            " intended audience.",
+        },
         "part_b": {
             "title": "Outline",
             "hint": "Give us a break-up of your talk either in the form of draft slides, mind-map or"
-            " text description."
-            }
-        }
+            " text description.",
+        },
     }
+}
 
 
 def upgrade():
@@ -43,12 +45,28 @@ def upgrade():
 
 
 def downgrade():
-    op.add_column('proposal', sa.Column('session_type', sa.VARCHAR(length=40), autoincrement=False, nullable=True))
-    op.add_column('proposal', sa.Column('technical_level', sa.VARCHAR(length=40), autoincrement=False, nullable=True))
-    op.add_column('project', sa.Column('labels',
-        postgresql.JSONB(astext_type=sa.Text()),
-        server_default=sa.text("'" + json.dumps(default_part_labels) + "'::jsonb"),
-        autoincrement=False, nullable=False))
+    op.add_column(
+        'proposal',
+        sa.Column(
+            'session_type', sa.VARCHAR(length=40), autoincrement=False, nullable=True
+        ),
+    )
+    op.add_column(
+        'proposal',
+        sa.Column(
+            'technical_level', sa.VARCHAR(length=40), autoincrement=False, nullable=True
+        ),
+    )
+    op.add_column(
+        'project',
+        sa.Column(
+            'labels',
+            postgresql.JSONB(astext_type=sa.Text()),
+            server_default=sa.text("'" + json.dumps(default_part_labels) + "'::jsonb"),
+            autoincrement=False,
+            nullable=False,
+        ),
+    )
     op.alter_column('project', 'labels', server_default=sa.text("'{}'::jsonb"))
     op.alter_column('proposal', 'abstract_text', new_column_name='objective_text')
     op.alter_column('proposal', 'abstract_html', new_column_name='objective_html')

--- a/migrations/versions/1bb2df0df8e2_profiles_and_userbas.py
+++ b/migrations/versions/1bb2df0df8e2_profiles_and_userbas.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Profiles and UserBase2
 
 Revision ID: 1bb2df0df8e2
@@ -15,10 +17,14 @@ from alembic import op
 
 
 def upgrade():
-    op.add_column('user', sa.Column('status', sa.Integer(), nullable=False, server_default=sa.text('0')))
+    op.add_column(
+        'user',
+        sa.Column('status', sa.Integer(), nullable=False, server_default=sa.text('0')),
+    )
     op.alter_column('user', 'status', server_default=None)
 
-    op.create_table('profile',
+    op.create_table(
+        'profile',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
@@ -30,12 +36,16 @@ def upgrade():
         sa.Column('title', sa.Unicode(length=250), nullable=False),
         sa.PrimaryKeyConstraint('id'),
         sa.UniqueConstraint('name'),
-        sa.UniqueConstraint('userid')
-        )
+        sa.UniqueConstraint('userid'),
+    )
 
-    op.add_column('proposal_space', sa.Column('profile_id', sa.Integer(), nullable=True))
+    op.add_column(
+        'proposal_space', sa.Column('profile_id', sa.Integer(), nullable=True)
+    )
     op.drop_constraint('proposal_space_name_key', 'proposal_space')
-    op.create_unique_constraint('proposal_space_profile_id_name_key', 'proposal_space', ['profile_id', 'name'])
+    op.create_unique_constraint(
+        'proposal_space_profile_id_name_key', 'proposal_space', ['profile_id', 'name']
+    )
 
 
 def downgrade():

--- a/migrations/versions/1c496c114b6_set_null_constraint.py
+++ b/migrations/versions/1c496c114b6_set_null_constraint.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Set null constraint
 
 Revision ID: 1c496c114b6
@@ -14,12 +16,27 @@ from alembic import op
 
 
 def upgrade():
-    op.drop_constraint('proposal_space_proposal_space_id_fkey', 'proposal_space', type_='foreignkey')
-    op.create_foreign_key('proposal_space_proposal_space_id_fkey',
-        'proposal_space', 'proposal_space', ['parent_space_id'], ['id'], ondelete='SET NULL')
+    op.drop_constraint(
+        'proposal_space_proposal_space_id_fkey', 'proposal_space', type_='foreignkey'
+    )
+    op.create_foreign_key(
+        'proposal_space_proposal_space_id_fkey',
+        'proposal_space',
+        'proposal_space',
+        ['parent_space_id'],
+        ['id'],
+        ondelete='SET NULL',
+    )
 
 
 def downgrade():
-    op.drop_constraint('proposal_space_proposal_space_id_fkey', 'proposal_space', type_='foreignkey')
-    op.create_foreign_key('proposal_space_proposal_space_id_fkey',
-        'proposal_space', 'proposal_space', ['parent_space_id'], ['id'])
+    op.drop_constraint(
+        'proposal_space_proposal_space_id_fkey', 'proposal_space', type_='foreignkey'
+    )
+    op.create_foreign_key(
+        'proposal_space_proposal_space_id_fkey',
+        'proposal_space',
+        'proposal_space',
+        ['parent_space_id'],
+        ['id'],
+    )

--- a/migrations/versions/1fcee2e6280_added_session.py
+++ b/migrations/versions/1fcee2e6280_added_session.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Added session
 
 Revision ID: 1fcee2e6280
@@ -15,7 +17,8 @@ from alembic import op
 
 
 def upgrade():
-    op.create_table('session',
+    op.create_table(
+        'session',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
@@ -32,13 +35,15 @@ def upgrade():
         sa.Column('url_id', sa.Integer(), nullable=False),
         sa.Column('name', sa.Unicode(length=250), nullable=False),
         sa.Column('title', sa.Unicode(length=250), nullable=False),
-        sa.ForeignKeyConstraint(['proposal_id'], ['proposal.id'], ),
-        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id'], ),
-        sa.ForeignKeyConstraint(['venue_room_id'], ['venue_room.id'], ),
+        sa.ForeignKeyConstraint(['proposal_id'], ['proposal.id']),
+        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id']),
+        sa.ForeignKeyConstraint(['venue_room_id'], ['venue_room.id']),
         sa.PrimaryKeyConstraint('id'),
-        sa.UniqueConstraint('proposal_space_id', 'url_id')
-        )
-    op.add_column('venue_room', sa.Column('bgcolor', sa.Unicode(length=6), nullable=True))
+        sa.UniqueConstraint('proposal_space_id', 'url_id'),
+    )
+    op.add_column(
+        'venue_room', sa.Column('bgcolor', sa.Unicode(length=6), nullable=True)
+    )
 
 
 def downgrade():

--- a/migrations/versions/21a7dfe8ab4d_proposal_redirects.py
+++ b/migrations/versions/21a7dfe8ab4d_proposal_redirects.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Proposal redirects
 
 Revision ID: 21a7dfe8ab4d
@@ -15,16 +17,17 @@ from alembic import op
 
 
 def upgrade():
-    op.create_table('proposal_redirect',
+    op.create_table(
+        'proposal_redirect',
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
         sa.Column('proposal_space_id', sa.Integer(), nullable=False),
         sa.Column('url_id', sa.Integer(), nullable=False),
         sa.Column('proposal_id', sa.Integer(), nullable=True),
         sa.ForeignKeyConstraint(['proposal_id'], ['proposal.id'], ondelete='SET NULL'),
-        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id'], ),
-        sa.PrimaryKeyConstraint('proposal_space_id', 'url_id')
-        )
+        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id']),
+        sa.PrimaryKeyConstraint('proposal_space_id', 'url_id'),
+    )
 
 
 def downgrade():

--- a/migrations/versions/22fb4e1e3139_add_ticket_client.py
+++ b/migrations/versions/22fb4e1e3139_add_ticket_client.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """add ticket client
 
 Revision ID: 22fb4e1e3139
@@ -14,7 +16,8 @@ from alembic import op
 
 
 def upgrade():
-    op.create_table('ticket_client',
+    op.create_table(
+        'ticket_client',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
@@ -24,14 +27,24 @@ def upgrade():
         sa.Column('client_secret', sa.Unicode(length=80), nullable=False),
         sa.Column('client_access_token', sa.Unicode(length=80), nullable=False),
         sa.Column('proposal_space_id', sa.Integer(), nullable=False),
-        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id'], ),
-        sa.PrimaryKeyConstraint('id')
-        )
-    op.add_column(u'sync_ticket', sa.Column('ticket_client_id', sa.Integer(), nullable=True))
-    op.create_foreign_key('sync_ticket_ticket_client_id', 'sync_ticket', 'ticket_client', ['ticket_client_id'], ['id'])
+        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.add_column(
+        u'sync_ticket', sa.Column('ticket_client_id', sa.Integer(), nullable=True)
+    )
+    op.create_foreign_key(
+        'sync_ticket_ticket_client_id',
+        'sync_ticket',
+        'ticket_client',
+        ['ticket_client_id'],
+        ['id'],
+    )
 
 
 def downgrade():
-    op.drop_constraint('sync_ticket_ticket_client_id', 'sync_ticket', type_='foreignkey')
+    op.drop_constraint(
+        'sync_ticket_ticket_client_id', 'sync_ticket', type_='foreignkey'
+    )
     op.drop_column(u'sync_ticket', 'ticket_client_id')
     op.drop_table('ticket_client')

--- a/migrations/versions/2441cb4f44d4_legacy_profile_flag.py
+++ b/migrations/versions/2441cb4f44d4_legacy_profile_flag.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Legacy profile flag
 
 Revision ID: 2441cb4f44d4
@@ -15,8 +17,15 @@ from alembic import op
 
 
 def upgrade():
-    op.add_column('profile', sa.Column('legacy', sa.Boolean(), nullable=False,
-        server_default=sa.sql.expression.true()))
+    op.add_column(
+        'profile',
+        sa.Column(
+            'legacy',
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.sql.expression.true(),
+        ),
+    )
     op.alter_column('profile', 'legacy', server_default=None)
 
 

--- a/migrations/versions/252f9a705901_contact_exchange_cascades.py
+++ b/migrations/versions/252f9a705901_contact_exchange_cascades.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Contact exchange cascades
 
 Revision ID: 252f9a705901
@@ -15,24 +17,65 @@ from alembic import op
 
 
 def upgrade():
-    op.drop_constraint('contact_exchange_user_id_fkey', 'contact_exchange', type_='foreignkey')
-    op.drop_constraint('contact_exchange_project_id_fkey', 'contact_exchange', type_='foreignkey')
-    op.drop_constraint('contact_exchange_participant_id_fkey', 'contact_exchange', type_='foreignkey')
-    op.create_foreign_key('contact_exchange_user_id_fkey', 'contact_exchange',
-        'user', ['user_id'], ['id'], ondelete='CASCADE')
-    op.create_foreign_key('contact_exchange_project_id_fkey', 'contact_exchange',
-        'project', ['project_id'], ['id'], ondelete='CASCADE')
-    op.create_foreign_key('contact_exchange_participant_id_fkey', 'contact_exchange',
-        'participant', ['participant_id'], ['id'], ondelete='CASCADE')
+    op.drop_constraint(
+        'contact_exchange_user_id_fkey', 'contact_exchange', type_='foreignkey'
+    )
+    op.drop_constraint(
+        'contact_exchange_project_id_fkey', 'contact_exchange', type_='foreignkey'
+    )
+    op.drop_constraint(
+        'contact_exchange_participant_id_fkey', 'contact_exchange', type_='foreignkey'
+    )
+    op.create_foreign_key(
+        'contact_exchange_user_id_fkey',
+        'contact_exchange',
+        'user',
+        ['user_id'],
+        ['id'],
+        ondelete='CASCADE',
+    )
+    op.create_foreign_key(
+        'contact_exchange_project_id_fkey',
+        'contact_exchange',
+        'project',
+        ['project_id'],
+        ['id'],
+        ondelete='CASCADE',
+    )
+    op.create_foreign_key(
+        'contact_exchange_participant_id_fkey',
+        'contact_exchange',
+        'participant',
+        ['participant_id'],
+        ['id'],
+        ondelete='CASCADE',
+    )
 
 
 def downgrade():
-    op.drop_constraint('contact_exchange_participant_id_fkey', 'contact_exchange', type_='foreignkey')
-    op.drop_constraint('contact_exchange_project_id_fkey', 'contact_exchange', type_='foreignkey')
-    op.drop_constraint('contact_exchange_user_id_fkey', 'contact_exchange', type_='foreignkey')
-    op.create_foreign_key('contact_exchange_participant_id_fkey', 'contact_exchange',
-        'participant', ['participant_id'], ['id'])
-    op.create_foreign_key('contact_exchange_project_id_fkey', 'contact_exchange',
-        'project', ['project_id'], ['id'])
-    op.create_foreign_key('contact_exchange_user_id_fkey', 'contact_exchange',
-        'user', ['user_id'], ['id'])
+    op.drop_constraint(
+        'contact_exchange_participant_id_fkey', 'contact_exchange', type_='foreignkey'
+    )
+    op.drop_constraint(
+        'contact_exchange_project_id_fkey', 'contact_exchange', type_='foreignkey'
+    )
+    op.drop_constraint(
+        'contact_exchange_user_id_fkey', 'contact_exchange', type_='foreignkey'
+    )
+    op.create_foreign_key(
+        'contact_exchange_participant_id_fkey',
+        'contact_exchange',
+        'participant',
+        ['participant_id'],
+        ['id'],
+    )
+    op.create_foreign_key(
+        'contact_exchange_project_id_fkey',
+        'contact_exchange',
+        'project',
+        ['project_id'],
+        ['id'],
+    )
+    op.create_foreign_key(
+        'contact_exchange_user_id_fkey', 'contact_exchange', 'user', ['user_id'], ['id']
+    )

--- a/migrations/versions/2a5516432f66_use_coordinatesmixin.py
+++ b/migrations/versions/2a5516432f66_use_coordinatesmixin.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Use CoordinatesMixin
 
 Revision ID: 2a5516432f66
@@ -15,10 +17,18 @@ from alembic import op
 
 
 def upgrade():
-    op.alter_column('venue', 'latitude', existing_type=sa.Numeric(8, 5), type_=sa.Numeric())
-    op.alter_column('venue', 'longitude', existing_type=sa.Numeric(8, 5), type_=sa.Numeric())
+    op.alter_column(
+        'venue', 'latitude', existing_type=sa.Numeric(8, 5), type_=sa.Numeric()
+    )
+    op.alter_column(
+        'venue', 'longitude', existing_type=sa.Numeric(8, 5), type_=sa.Numeric()
+    )
 
 
 def downgrade():
-    op.alter_column('venue', 'latitude', existing_type=sa.Numeric(), type_=sa.Numeric(8, 5))
-    op.alter_column('venue', 'longitude', existing_type=sa.Numeric(), type_=sa.Numeric(8, 5))
+    op.alter_column(
+        'venue', 'latitude', existing_type=sa.Numeric(), type_=sa.Numeric(8, 5)
+    )
+    op.alter_column(
+        'venue', 'longitude', existing_type=sa.Numeric(), type_=sa.Numeric(8, 5)
+    )

--- a/migrations/versions/2c64e60b80a_contact_exchange.py
+++ b/migrations/versions/2c64e60b80a_contact_exchange.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """contact_exchange
 
 Revision ID: 2c64e60b80a
@@ -14,19 +16,20 @@ from alembic import op
 
 
 def upgrade():
-    op.create_table('contact_exchange',
+    op.create_table(
+        'contact_exchange',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
         sa.Column('user_id', sa.Integer(), nullable=True),
         sa.Column('proposal_space_id', sa.Integer(), nullable=True),
         sa.Column('participant_id', sa.Integer(), nullable=True),
-        sa.ForeignKeyConstraint(['participant_id'], ['participant.id'], ),
-        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id'], ),
-        sa.ForeignKeyConstraint(['user_id'], ['user.id'], ),
+        sa.ForeignKeyConstraint(['participant_id'], ['participant.id']),
+        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id']),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id']),
         sa.PrimaryKeyConstraint('id'),
-        sa.UniqueConstraint('user_id', 'proposal_space_id', 'participant_id')
-        )
+        sa.UniqueConstraint('user_id', 'proposal_space_id', 'participant_id'),
+    )
 
 
 def downgrade():

--- a/migrations/versions/2cbfbcca4737_uuid_columns_for_proposal_and_session.py
+++ b/migrations/versions/2cbfbcca4737_uuid_columns_for_proposal_and_session.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """UUID columns for Proposal and Session
 
 Revision ID: 2cbfbcca4737
@@ -20,51 +22,57 @@ from sqlalchemy_utils import UUIDType
 import progressbar.widgets
 from progressbar import ProgressBar
 
-proposal = table('proposal',
-    column('id', sa.Integer()),
-    column('uuid', UUIDType(binary=False)),
-    )
+proposal = table(
+    'proposal', column('id', sa.Integer()), column('uuid', UUIDType(binary=False))
+)
 
-session = table('session',
-    column('id', sa.Integer()),
-    column('uuid', UUIDType(binary=False)),
-    )
+session = table(
+    'session', column('id', sa.Integer()), column('uuid', UUIDType(binary=False))
+)
 
 
 def get_progressbar(label, maxval):
-    return ProgressBar(maxval=maxval,
+    return ProgressBar(
+        maxval=maxval,
         widgets=[
-            label, ': ',
-            progressbar.widgets.Percentage(), ' ',
-            progressbar.widgets.Bar(), ' ',
-            progressbar.widgets.ETA(), ' '
-            ])
+            label,
+            ': ',
+            progressbar.widgets.Percentage(),
+            ' ',
+            progressbar.widgets.Bar(),
+            ' ',
+            progressbar.widgets.ETA(),
+            ' ',
+        ],
+    )
 
 
 def upgrade():
     conn = op.get_bind()
 
     op.add_column('proposal', sa.Column('uuid', UUIDType(binary=False), nullable=True))
-    count = conn.scalar(
-        sa.select([sa.func.count('*')]).select_from(proposal))
+    count = conn.scalar(sa.select([sa.func.count('*')]).select_from(proposal))
     progress = get_progressbar("Proposals", count)
     progress.start()
     items = conn.execute(sa.select([proposal.c.id]))
     for counter, item in enumerate(items):
-        conn.execute(sa.update(proposal).where(proposal.c.id == item.id).values(uuid=uuid4()))
+        conn.execute(
+            sa.update(proposal).where(proposal.c.id == item.id).values(uuid=uuid4())
+        )
         progress.update(counter)
     progress.finish()
     op.alter_column('proposal', 'uuid', nullable=False)
     op.create_unique_constraint('proposal_uuid_key', 'proposal', ['uuid'])
 
     op.add_column('session', sa.Column('uuid', UUIDType(binary=False), nullable=True))
-    count = conn.scalar(
-        sa.select([sa.func.count('*')]).select_from(session))
+    count = conn.scalar(sa.select([sa.func.count('*')]).select_from(session))
     progress = get_progressbar("Sessions", count)
     progress.start()
     items = conn.execute(sa.select([session.c.id]))
     for counter, item in enumerate(items):
-        conn.execute(sa.update(session).where(session.c.id == item.id).values(uuid=uuid4()))
+        conn.execute(
+            sa.update(session).where(session.c.id == item.id).values(uuid=uuid4())
+        )
         progress.update(counter)
     progress.finish()
     op.alter_column('session', 'uuid', nullable=False)

--- a/migrations/versions/2d55f804a4ed_remove_proposal_space_id_from_sync_.py
+++ b/migrations/versions/2d55f804a4ed_remove_proposal_space_id_from_sync_.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """remove proposal_space_id from sync_ticket
 
 Revision ID: 2d55f804a4ed
@@ -16,19 +18,57 @@ from sqlalchemy.sql import column, select, table
 
 
 def upgrade():
-    op.drop_constraint('sync_ticket_proposal_space_id_order_no_ticket_no_key', 'sync_ticket', type_='unique')
-    op.create_unique_constraint('sync_ticket_ticket_client_id_order_no_ticket_no_key', 'sync_ticket', ['ticket_client_id', 'order_no', 'ticket_no'])
-    op.drop_constraint('sync_ticket_proposal_space_id_fkey', 'sync_ticket', type_='foreignkey')
+    op.drop_constraint(
+        'sync_ticket_proposal_space_id_order_no_ticket_no_key',
+        'sync_ticket',
+        type_='unique',
+    )
+    op.create_unique_constraint(
+        'sync_ticket_ticket_client_id_order_no_ticket_no_key',
+        'sync_ticket',
+        ['ticket_client_id', 'order_no', 'ticket_no'],
+    )
+    op.drop_constraint(
+        'sync_ticket_proposal_space_id_fkey', 'sync_ticket', type_='foreignkey'
+    )
     op.drop_column('sync_ticket', 'proposal_space_id')
 
 
 def downgrade():
-    op.add_column('sync_ticket', sa.Column('proposal_space_id', sa.INTEGER(), autoincrement=False, nullable=True))
-    op.create_foreign_key('sync_ticket_proposal_space_id_fkey', 'sync_ticket', 'proposal_space', ['proposal_space_id'], ['id'])
-    op.drop_constraint('sync_ticket_ticket_client_id_order_no_ticket_no_key', 'sync_ticket', type_='unique')
-    op.create_unique_constraint('sync_ticket_proposal_space_id_order_no_ticket_no_key', 'sync_ticket', ['proposal_space_id', 'order_no', 'ticket_no'])
+    op.add_column(
+        'sync_ticket',
+        sa.Column(
+            'proposal_space_id', sa.INTEGER(), autoincrement=False, nullable=True
+        ),
+    )
+    op.create_foreign_key(
+        'sync_ticket_proposal_space_id_fkey',
+        'sync_ticket',
+        'proposal_space',
+        ['proposal_space_id'],
+        ['id'],
+    )
+    op.drop_constraint(
+        'sync_ticket_ticket_client_id_order_no_ticket_no_key',
+        'sync_ticket',
+        type_='unique',
+    )
+    op.create_unique_constraint(
+        'sync_ticket_proposal_space_id_order_no_ticket_no_key',
+        'sync_ticket',
+        ['proposal_space_id', 'order_no', 'ticket_no'],
+    )
     # restore proposal_space_ids
-    sync_ticket = table('sync_ticket', column('proposal_space_id'), column('ticket_client_id'))
+    sync_ticket = table(
+        'sync_ticket', column('proposal_space_id'), column('ticket_client_id')
+    )
     ticket_client = table('ticket_client', column('id'), column('proposal_space_id'))
     op.execute(
-        sync_ticket.update().values({'proposal_space_id': select([ticket_client.c.proposal_space_id]).where(ticket_client.c.id == sync_ticket.c.ticket_client_id)}))
+        sync_ticket.update().values(
+            {
+                'proposal_space_id': select([ticket_client.c.proposal_space_id]).where(
+                    ticket_client.c.id == sync_ticket.c.ticket_client_id
+                )
+            }
+        )
+    )

--- a/migrations/versions/2d73dbe935dc_naming_fixes_for_event_models.py
+++ b/migrations/versions/2d73dbe935dc_naming_fixes_for_event_models.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """naming fixes
 
 Revision ID: 2d73dbe935dc
@@ -15,38 +17,94 @@ from alembic import op
 
 
 def upgrade():
-    op.alter_column('ticket_client', 'client_event_id', new_column_name='client_eventid')
+    op.alter_column(
+        'ticket_client', 'client_event_id', new_column_name='client_eventid'
+    )
     op.alter_column('ticket_client', 'client_id', new_column_name='clientid')
 
-    op.drop_constraint('sync_ticket_ticket_client_id', 'sync_ticket', type_='foreignkey')
-    op.create_foreign_key('sync_ticket_ticket_client_id_fkey', 'sync_ticket', 'ticket_client', ['ticket_client_id'], ['id'])
+    op.drop_constraint(
+        'sync_ticket_ticket_client_id', 'sync_ticket', type_='foreignkey'
+    )
+    op.create_foreign_key(
+        'sync_ticket_ticket_client_id_fkey',
+        'sync_ticket',
+        'ticket_client',
+        ['ticket_client_id'],
+        ['id'],
+    )
 
     op.drop_constraint('event_proposal_space_id_name', 'event', type_='unique')
-    op.create_unique_constraint('event_proposal_space_id_name_key', 'event', ['proposal_space_id', 'name'])
+    op.create_unique_constraint(
+        'event_proposal_space_id_name_key', 'event', ['proposal_space_id', 'name']
+    )
 
-    op.drop_constraint(u'contact_exchange_user_id_proposal_space_id_participant_id_pk', 'contact_exchange', type_='unique')
-    op.create_primary_key(u'contact_exchange_user_id_proposal_space_id_participant_id_key', 'contact_exchange', ['user_id', 'proposal_space_id', 'participant_id'])
+    op.drop_constraint(
+        u'contact_exchange_user_id_proposal_space_id_participant_id_pk',
+        'contact_exchange',
+        type_='unique',
+    )
+    op.create_primary_key(
+        u'contact_exchange_user_id_proposal_space_id_participant_id_key',
+        'contact_exchange',
+        ['user_id', 'proposal_space_id', 'participant_id'],
+    )
 
-    op.drop_constraint(u'sync_ticket_proposal_space_id_order_no_ticket_no', 'sync_ticket', type_='unique')
-    op.create_unique_constraint(u'sync_ticket_proposal_space_id_order_no_ticket_no_key', 'sync_ticket', ['proposal_space_id', 'order_no', 'ticket_no'])
+    op.drop_constraint(
+        u'sync_ticket_proposal_space_id_order_no_ticket_no',
+        'sync_ticket',
+        type_='unique',
+    )
+    op.create_unique_constraint(
+        u'sync_ticket_proposal_space_id_order_no_ticket_no_key',
+        'sync_ticket',
+        ['proposal_space_id', 'order_no', 'ticket_no'],
+    )
 
     op.alter_column('participant', 'email', type_=sa.Unicode(length=254))
 
 
 def downgrade():
-    op.alter_column('ticket_client', 'client_eventid', new_column_name='client_event_id')
+    op.alter_column(
+        'ticket_client', 'client_eventid', new_column_name='client_event_id'
+    )
     op.alter_column('ticket_client', 'clientid', new_column_name='client_id')
 
-    op.drop_constraint('sync_ticket_ticket_client_id_fkey', 'sync_ticket', type_='foreignkey')
-    op.create_foreign_key('sync_ticket_ticket_client_id', 'sync_ticket', 'ticket_client', ['ticket_client_id'], ['id'])
+    op.drop_constraint(
+        'sync_ticket_ticket_client_id_fkey', 'sync_ticket', type_='foreignkey'
+    )
+    op.create_foreign_key(
+        'sync_ticket_ticket_client_id',
+        'sync_ticket',
+        'ticket_client',
+        ['ticket_client_id'],
+        ['id'],
+    )
 
     op.drop_constraint('event_proposal_space_id_name_key', 'event', type_='unique')
-    op.create_unique_constraint('event_proposal_space_id_name', 'event', ['proposal_space_id', 'name'])
+    op.create_unique_constraint(
+        'event_proposal_space_id_name', 'event', ['proposal_space_id', 'name']
+    )
 
-    op.drop_constraint(u'contact_exchange_user_id_proposal_space_id_participant_id_key', 'contact_exchange', type_='unique')
-    op.create_primary_key(u'contact_exchange_user_id_proposal_space_id_participant_id_pk', 'contact_exchange', ['user_id', 'proposal_space_id', 'participant_id'])
+    op.drop_constraint(
+        u'contact_exchange_user_id_proposal_space_id_participant_id_key',
+        'contact_exchange',
+        type_='unique',
+    )
+    op.create_primary_key(
+        u'contact_exchange_user_id_proposal_space_id_participant_id_pk',
+        'contact_exchange',
+        ['user_id', 'proposal_space_id', 'participant_id'],
+    )
 
-    op.drop_constraint(u'sync_ticket_proposal_space_id_order_no_ticket_no_key', 'sync_ticket', type_='unique')
-    op.create_unique_constraint(u'sync_ticket_proposal_space_id_order_no_ticket_no', 'sync_ticket', ['proposal_space_id', 'order_no', 'ticket_no'])
+    op.drop_constraint(
+        u'sync_ticket_proposal_space_id_order_no_ticket_no_key',
+        'sync_ticket',
+        type_='unique',
+    )
+    op.create_unique_constraint(
+        u'sync_ticket_proposal_space_id_order_no_ticket_no',
+        'sync_ticket',
+        ['proposal_space_id', 'order_no', 'ticket_no'],
+    )
 
     op.alter_column('participant', 'email', type_=sa.Unicode(length=80))

--- a/migrations/versions/2db4d4be1fdf_proposal_space_redirect.py
+++ b/migrations/versions/2db4d4be1fdf_proposal_space_redirect.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Proposal space redirect
 
 Revision ID: 2db4d4be1fdf
@@ -15,16 +17,19 @@ from alembic import op
 
 
 def upgrade():
-    op.create_table('proposal_space_redirect',
+    op.create_table(
+        'proposal_space_redirect',
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
         sa.Column('profile_id', sa.Integer(), nullable=False),
         sa.Column('name', sa.Unicode(length=250), nullable=False),
         sa.Column('proposal_space_id', sa.Integer(), nullable=True),
-        sa.ForeignKeyConstraint(['profile_id'], ['profile.id'], ),
-        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id'], ondelete='SET NULL'),
-        sa.PrimaryKeyConstraint('profile_id', 'name')
-        )
+        sa.ForeignKeyConstraint(['profile_id'], ['profile.id']),
+        sa.ForeignKeyConstraint(
+            ['proposal_space_id'], ['proposal_space.id'], ondelete='SET NULL'
+        ),
+        sa.PrimaryKeyConstraint('profile_id', 'name'),
+    )
 
 
 def downgrade():

--- a/migrations/versions/31253f116e1e_space_date_upto.py
+++ b/migrations/versions/31253f116e1e_space_date_upto.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """space date upto
 
 Revision ID: 31253f116e1e

--- a/migrations/versions/316aaa757c8c_coaster_models.py
+++ b/migrations/versions/316aaa757c8c_coaster_models.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """coaster_models
 
 Revision ID: 316aaa757c8c
@@ -21,16 +23,27 @@ def upgrade():
 
 
 def downgrade():
-    op.create_table(u'tag',
-        sa.Column(u'id', sa.INTEGER(), server_default="nextval('tag_id_seq'::regclass)", nullable=False),
-        sa.Column(u'created_at', postgresql.TIMESTAMP(), autoincrement=False, nullable=False),
-        sa.Column(u'updated_at', postgresql.TIMESTAMP(), autoincrement=False, nullable=False),
+    op.create_table(
+        u'tag',
+        sa.Column(
+            u'id',
+            sa.INTEGER(),
+            server_default="nextval('tag_id_seq'::regclass)",
+            nullable=False,
+        ),
+        sa.Column(
+            u'created_at', postgresql.TIMESTAMP(), autoincrement=False, nullable=False
+        ),
+        sa.Column(
+            u'updated_at', postgresql.TIMESTAMP(), autoincrement=False, nullable=False
+        ),
         sa.Column(u'name', sa.VARCHAR(length=80), autoincrement=False, nullable=False),
         sa.Column(u'title', sa.VARCHAR(length=80), autoincrement=False, nullable=False),
-        sa.PrimaryKeyConstraint(u'id', name=u'tag_pkey')
-        )
-    op.create_table(u'proposal_tags',
+        sa.PrimaryKeyConstraint(u'id', name=u'tag_pkey'),
+    )
+    op.create_table(
+        u'proposal_tags',
         sa.Column(u'tag_id', sa.INTEGER(), autoincrement=False, nullable=True),
         sa.Column(u'proposal_id', sa.INTEGER(), autoincrement=False, nullable=True),
-        sa.PrimaryKeyConstraint()
-        )
+        sa.PrimaryKeyConstraint(),
+    )

--- a/migrations/versions/380089617763_add_title_to_ticket_type.py
+++ b/migrations/versions/380089617763_add_title_to_ticket_type.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """add_title_to_ticket_type
 
 Revision ID: 380089617763
@@ -15,10 +17,18 @@ from alembic import op
 
 
 def upgrade():
-    op.add_column('ticket_type', sa.Column('title', sa.Unicode(length=250), nullable=True))
-    op.create_unique_constraint("ticket_type_proposal_space_id_name_key", 'ticket_type', ['proposal_space_id', 'name'])
+    op.add_column(
+        'ticket_type', sa.Column('title', sa.Unicode(length=250), nullable=True)
+    )
+    op.create_unique_constraint(
+        "ticket_type_proposal_space_id_name_key",
+        'ticket_type',
+        ['proposal_space_id', 'name'],
+    )
 
 
 def downgrade():
-    op.drop_constraint("ticket_type_proposal_space_id_name_key", 'ticket_type', type_='unique')
+    op.drop_constraint(
+        "ticket_type_proposal_space_id_name_key", 'ticket_type', type_='unique'
+    )
     op.drop_column('ticket_type', 'title')

--- a/migrations/versions/38394aa411d0_remove_usergroup_model.py
+++ b/migrations/versions/38394aa411d0_remove_usergroup_model.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Remove UserGroup model
 
 Revision ID: 38394aa411d0
@@ -21,21 +23,35 @@ def upgrade():
 
 
 def downgrade():
-    op.create_table('user_group',
+    op.create_table(
+        'user_group',
         sa.Column('id', sa.INTEGER(), autoincrement=True, nullable=False),
-        sa.Column('created_at', postgresql.TIMESTAMP(), autoincrement=False, nullable=False),
-        sa.Column('updated_at', postgresql.TIMESTAMP(), autoincrement=False, nullable=False),
+        sa.Column(
+            'created_at', postgresql.TIMESTAMP(), autoincrement=False, nullable=False
+        ),
+        sa.Column(
+            'updated_at', postgresql.TIMESTAMP(), autoincrement=False, nullable=False
+        ),
         sa.Column('project_id', sa.INTEGER(), autoincrement=False, nullable=False),
         sa.Column('name', sa.VARCHAR(length=250), autoincrement=False, nullable=False),
         sa.Column('title', sa.VARCHAR(length=250), autoincrement=False, nullable=False),
         sa.CheckConstraint(u"(name)::text <> ''::text", name=u'user_group_name_check'),
-        sa.ForeignKeyConstraint(['project_id'], [u'project.id'], name=u'user_group_project_id_fkey'),
+        sa.ForeignKeyConstraint(
+            ['project_id'], [u'project.id'], name=u'user_group_project_id_fkey'
+        ),
         sa.PrimaryKeyConstraint('id', name=u'user_group_pkey'),
-        sa.UniqueConstraint('project_id', 'name', name=u'user_group_project_id_name_key')
-        )
-    op.create_table('group_members',
+        sa.UniqueConstraint(
+            'project_id', 'name', name=u'user_group_project_id_name_key'
+        ),
+    )
+    op.create_table(
+        'group_members',
         sa.Column('group_id', sa.INTEGER(), autoincrement=False, nullable=True),
         sa.Column('user_id', sa.INTEGER(), autoincrement=False, nullable=True),
-        sa.ForeignKeyConstraint(['group_id'], [u'user_group.id'], name=u'group_members_group_id_fkey'),
-        sa.ForeignKeyConstraint(['user_id'], [u'user.id'], name=u'group_members_user_id_fkey')
-        )
+        sa.ForeignKeyConstraint(
+            ['group_id'], [u'user_group.id'], name=u'group_members_group_id_fkey'
+        ),
+        sa.ForeignKeyConstraint(
+            ['user_id'], [u'user.id'], name=u'group_members_user_id_fkey'
+        ),
+    )

--- a/migrations/versions/39af75387b10_proposal_location_and_additional_data.py
+++ b/migrations/versions/39af75387b10_proposal_location_and_additional_data.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Proposal location and additional data
 
 Revision ID: 39af75387b10
@@ -17,7 +19,9 @@ from coaster.sqlalchemy import JsonDict
 
 
 def upgrade():
-    op.add_column('proposal', sa.Column('data', JsonDict(), server_default='{}', nullable=False))
+    op.add_column(
+        'proposal', sa.Column('data', JsonDict(), server_default='{}', nullable=False)
+    )
     op.add_column('proposal', sa.Column('latitude', sa.Numeric(), nullable=True))
     op.add_column('proposal', sa.Column('longitude', sa.Numeric(), nullable=True))
 

--- a/migrations/versions/39eed1e99156_add_title_to_event.py
+++ b/migrations/versions/39eed1e99156_add_title_to_event.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """add_title_to_event
 
 Revision ID: 39eed1e99156
@@ -15,7 +17,9 @@ from alembic import op
 
 def upgrade():
     op.add_column('event', sa.Column('title', sa.Unicode(length=250), nullable=True))
-    op.create_unique_constraint("event_proposal_space_id_name", 'event', ['proposal_space_id', 'name'])
+    op.create_unique_constraint(
+        "event_proposal_space_id_name", 'event', ['proposal_space_id', 'name']
+    )
 
 
 def downgrade():

--- a/migrations/versions/3a6b2ab00e3e_session_proposal_one.py
+++ b/migrations/versions/3a6b2ab00e3e_session_proposal_one.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Make session:proposal 1:1
 
 Revision ID: 3a6b2ab00e3e

--- a/migrations/versions/3afa589814a9_remove_sections.py
+++ b/migrations/versions/3afa589814a9_remove_sections.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Remove sections
 
 Revision ID: 3afa589814a9
@@ -23,13 +25,32 @@ def upgrade():
 
 
 def downgrade():
-    op.add_column('project', sa.Column('inherit_sections', sa.BOOLEAN(),
-        autoincrement=False, nullable=False, server_default=sa.sql.expression.true()))
+    op.add_column(
+        'project',
+        sa.Column(
+            'inherit_sections',
+            sa.BOOLEAN(),
+            autoincrement=False,
+            nullable=False,
+            server_default=sa.sql.expression.true(),
+        ),
+    )
     op.alter_column('project', 'inherit_sections', server_default=None)
-    op.create_table('section',
+    op.create_table(
+        'section',
         sa.Column('id', sa.INTEGER(), autoincrement=True, nullable=False),
-        sa.Column('created_at', postgresql.TIMESTAMP(timezone=True), autoincrement=False, nullable=False),
-        sa.Column('updated_at', postgresql.TIMESTAMP(timezone=True), autoincrement=False, nullable=False),
+        sa.Column(
+            'created_at',
+            postgresql.TIMESTAMP(timezone=True),
+            autoincrement=False,
+            nullable=False,
+        ),
+        sa.Column(
+            'updated_at',
+            postgresql.TIMESTAMP(timezone=True),
+            autoincrement=False,
+            nullable=False,
+        ),
         sa.Column('project_id', sa.INTEGER(), autoincrement=False, nullable=False),
         sa.Column('description', sa.TEXT(), autoincrement=False, nullable=False),
         sa.Column('public', sa.BOOLEAN(), autoincrement=False, nullable=False),
@@ -38,11 +59,22 @@ def downgrade():
         sa.Column('name', sa.VARCHAR(length=250), autoincrement=False, nullable=False),
         sa.Column('title', sa.VARCHAR(length=250), autoincrement=False, nullable=False),
         sa.CheckConstraint(u"(name)::text <> ''::text", name=u'section_name_check'),
-        sa.ForeignKeyConstraint(['commentset_id'], [u'commentset.id'], name=u'section_commentset_id_fkey'),
-        sa.ForeignKeyConstraint(['project_id'], [u'project.id'], name=u'section_project_id_fkey'),
-        sa.ForeignKeyConstraint(['voteset_id'], [u'voteset.id'], name=u'section_voteset_id_fkey'),
+        sa.ForeignKeyConstraint(
+            ['commentset_id'], [u'commentset.id'], name=u'section_commentset_id_fkey'
+        ),
+        sa.ForeignKeyConstraint(
+            ['project_id'], [u'project.id'], name=u'section_project_id_fkey'
+        ),
+        sa.ForeignKeyConstraint(
+            ['voteset_id'], [u'voteset.id'], name=u'section_voteset_id_fkey'
+        ),
         sa.PrimaryKeyConstraint('id', name=u'section_pkey'),
-        sa.UniqueConstraint('project_id', 'name', name=u'section_project_id_name_key')
-        )
-    op.add_column('proposal', sa.Column('section_id', sa.INTEGER(), autoincrement=False, nullable=True))
-    op.create_foreign_key(u'proposal_section_id_fkey', 'proposal', 'section', ['section_id'], ['id'])
+        sa.UniqueConstraint('project_id', 'name', name=u'section_project_id_name_key'),
+    )
+    op.add_column(
+        'proposal',
+        sa.Column('section_id', sa.INTEGER(), autoincrement=False, nullable=True),
+    )
+    op.create_foreign_key(
+        u'proposal_section_id_fkey', 'proposal', 'section', ['section_id'], ['id']
+    )

--- a/migrations/versions/3b189f2e5c56_add_inherit_sections_to_proposal_space.py
+++ b/migrations/versions/3b189f2e5c56_add_inherit_sections_to_proposal_space.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """add inherit sections to proposal space
 
 Revision ID: 3b189f2e5c56
@@ -15,7 +17,12 @@ from alembic import op
 
 
 def upgrade():
-    op.add_column(u'proposal_space', sa.Column('inherit_sections', sa.Boolean(), nullable=False, server_default='True'))
+    op.add_column(
+        u'proposal_space',
+        sa.Column(
+            'inherit_sections', sa.Boolean(), nullable=False, server_default='True'
+        ),
+    )
 
 
 def downgrade():

--- a/migrations/versions/3c47ba103724_proposal_status.py
+++ b/migrations/versions/3c47ba103724_proposal_status.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Proposal.status
 
 Revision ID: 3c47ba103724
@@ -29,20 +31,35 @@ class PROPOSALSTATUS:  # NOQA
 
 def upgrade():
     connection = op.get_bind()
-    proposal = table('proposal',
-        column(u'confirmed', sa.BOOLEAN()),
-        column(u'status', sa.Integer))
-    connection.execute(proposal.update().where(proposal.c.confirmed == True).values({proposal.c.status: PROPOSALSTATUS.CONFIRMED}))  # NOQA
-    connection.execute(proposal.update().where(proposal.c.confirmed == False).values({proposal.c.status: PROPOSALSTATUS.SUBMITTED}))  # NOQA
+    proposal = table(
+        'proposal', column(u'confirmed', sa.BOOLEAN()), column(u'status', sa.Integer)
+    )
+    connection.execute(
+        proposal.update()
+        .where(proposal.c.confirmed == True)
+        .values({proposal.c.status: PROPOSALSTATUS.CONFIRMED})
+    )  # NOQA
+    connection.execute(
+        proposal.update()
+        .where(proposal.c.confirmed == False)
+        .values({proposal.c.status: PROPOSALSTATUS.SUBMITTED})
+    )  # NOQA
     op.drop_column('proposal', u'confirmed')
 
 
 def downgrade():
     connection = op.get_bind()
-    proposal = table('proposal',
-        column(u'confirmed', sa.BOOLEAN()),
-        column(u'status', sa.Integer))
-    op.add_column('proposal', sa.Column(u'confirmed', sa.BOOLEAN(), server_default="False", nullable=False))
-    connection.execute(proposal.update().where(proposal.c.status == PROPOSALSTATUS.CONFIRMED).values({proposal.c.confirmed: True}))
+    proposal = table(
+        'proposal', column(u'confirmed', sa.BOOLEAN()), column(u'status', sa.Integer)
+    )
+    op.add_column(
+        'proposal',
+        sa.Column(u'confirmed', sa.BOOLEAN(), server_default="False", nullable=False),
+    )
+    connection.execute(
+        proposal.update()
+        .where(proposal.c.status == PROPOSALSTATUS.CONFIRMED)
+        .values({proposal.c.confirmed: True})
+    )
     connection.execute(proposal.update().values({proposal.c.status: 0}))
     op.alter_column('proposal', u'confirmed', server_default=None)

--- a/migrations/versions/4083b7bd0cc8_remove_id_from_contact_exchange.py
+++ b/migrations/versions/4083b7bd0cc8_remove_id_from_contact_exchange.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """remove_id_from_contact_exchange_use_composite_primary_key
 Revision ID: 4083b7bd0cc8
 Revises: 22fb4e1e3139
@@ -13,12 +15,28 @@ from alembic import op
 
 
 def upgrade():
-    op.drop_constraint(u'contact_exchange_user_id_proposal_space_id_participant_id_key', 'contact_exchange', type_='unique')
+    op.drop_constraint(
+        u'contact_exchange_user_id_proposal_space_id_participant_id_key',
+        'contact_exchange',
+        type_='unique',
+    )
     op.drop_column('contact_exchange', 'id')
-    op.create_primary_key(u'contact_exchange_user_id_proposal_space_id_participant_id_pk', 'contact_exchange', ['user_id', 'proposal_space_id', 'participant_id'])
+    op.create_primary_key(
+        u'contact_exchange_user_id_proposal_space_id_participant_id_pk',
+        'contact_exchange',
+        ['user_id', 'proposal_space_id', 'participant_id'],
+    )
 
 
 def downgrade():
     op.add_column('contact_exchange', sa.Column('id', sa.INTEGER(), nullable=False))
-    op.drop_constraint(u'contact_exchange_user_id_proposal_space_id_participant_id_pk', 'contact_exchange', type_='primary')
-    op.create_unique_constraint(u'contact_exchange_user_id_proposal_space_id_participant_id_key', 'contact_exchange', ['user_id', 'proposal_space_id', 'participant_id'])
+    op.drop_constraint(
+        u'contact_exchange_user_id_proposal_space_id_participant_id_pk',
+        'contact_exchange',
+        type_='primary',
+    )
+    op.create_unique_constraint(
+        u'contact_exchange_user_id_proposal_space_id_participant_id_key',
+        'contact_exchange',
+        ['user_id', 'proposal_space_id', 'participant_id'],
+    )

--- a/migrations/versions/40c4ad7c0909_change_constraint_ticket_no.py
+++ b/migrations/versions/40c4ad7c0909_change_constraint_ticket_no.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """change_constraint_ticket_no
 
 Revision ID: 40c4ad7c0909
@@ -15,10 +17,24 @@ from alembic import op
 
 
 def upgrade():
-    op.drop_constraint(u'sync_ticket_proposal_space_id_ticket_no_key', 'sync_ticket', type_='unique')
-    op.create_unique_constraint(u'sync_ticket_proposal_space_id_order_no_ticket_no', 'sync_ticket', ['proposal_space_id', 'order_no', 'ticket_no'])
+    op.drop_constraint(
+        u'sync_ticket_proposal_space_id_ticket_no_key', 'sync_ticket', type_='unique'
+    )
+    op.create_unique_constraint(
+        u'sync_ticket_proposal_space_id_order_no_ticket_no',
+        'sync_ticket',
+        ['proposal_space_id', 'order_no', 'ticket_no'],
+    )
 
 
 def downgrade():
-    op.drop_constraint(u'sync_ticket_proposal_space_id_order_no_ticket_no', 'sync_ticket', type_='unique')
-    op.create_unique_constraint(u'sync_ticket_proposal_space_id_ticket_no_key', 'sync_ticket', ['proposal_space_id', 'ticket_no'])
+    op.drop_constraint(
+        u'sync_ticket_proposal_space_id_order_no_ticket_no',
+        'sync_ticket',
+        type_='unique',
+    )
+    op.create_unique_constraint(
+        u'sync_ticket_proposal_space_id_ticket_no_key',
+        'sync_ticket',
+        ['proposal_space_id', 'ticket_no'],
+    )

--- a/migrations/versions/411fc4124fb5_index_team_orgid.py
+++ b/migrations/versions/411fc4124fb5_index_team_orgid.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Index Team.orgid
 
 Revision ID: 411fc4124fb5

--- a/migrations/versions/416a2f958279_add_title_index_to_event_and_ticket_type.py
+++ b/migrations/versions/416a2f958279_add_title_index_to_event_and_ticket_type.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """add title index to event and ticket type
 
 Revision ID: 416a2f958279
@@ -14,10 +16,18 @@ from alembic import op
 
 
 def upgrade():
-    op.create_unique_constraint(u'event_proposal_space_id_title_key', 'event', ['proposal_space_id', 'title'])
-    op.create_unique_constraint(u'ticket_type_proposal_space_id_title_key', 'ticket_type', ['proposal_space_id', 'title'])
+    op.create_unique_constraint(
+        u'event_proposal_space_id_title_key', 'event', ['proposal_space_id', 'title']
+    )
+    op.create_unique_constraint(
+        u'ticket_type_proposal_space_id_title_key',
+        'ticket_type',
+        ['proposal_space_id', 'title'],
+    )
 
 
 def downgrade():
-    op.drop_constraint(u'ticket_type_proposal_space_id_title_key', 'ticket_type', type_='unique')
+    op.drop_constraint(
+        u'ticket_type_proposal_space_id_title_key', 'ticket_type', type_='unique'
+    )
     op.drop_constraint(u'event_proposal_space_id_title_key', 'event', type_='unique')

--- a/migrations/versions/436114dffa00_remove_proposalspace_content.py
+++ b/migrations/versions/436114dffa00_remove_proposalspace_content.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Remove ProposalSpace.content
 
 Revision ID: 436114dffa00
@@ -21,5 +23,8 @@ def upgrade():
 
 
 def downgrade():
-    op.add_column('proposal_space', sa.Column('content', JsonDict, server_default='{}', nullable=False))
+    op.add_column(
+        'proposal_space',
+        sa.Column('content', JsonDict, server_default='{}', nullable=False),
+    )
     op.alter_column('proposal_space', 'content', server_default=None)

--- a/migrations/versions/447728ca6d2e_add_buy_tickets_url.py
+++ b/migrations/versions/447728ca6d2e_add_buy_tickets_url.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """empty message
 
 Revision ID: 447728ca6d2e
@@ -15,7 +17,10 @@ from alembic import op
 
 
 def upgrade():
-    op.add_column('proposal_space', sa.Column('buy_tickets_url', sa.Unicode(length=250), nullable=True))
+    op.add_column(
+        'proposal_space',
+        sa.Column('buy_tickets_url', sa.Unicode(length=250), nullable=True),
+    )
 
 
 def downgrade():

--- a/migrations/versions/488077138ee4_correct_database_and_model_.py
+++ b/migrations/versions/488077138ee4_correct_database_and_model_.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Correct database and model inconsistencies
 
 Revision ID: 488077138ee4
@@ -17,9 +19,17 @@ from sqlalchemy.schema import CreateSequence, DropSequence, Sequence
 from coaster.sqlalchemy import JsonDict
 
 tables_with_name_column = [
-    'event', 'profile', 'proposal', 'proposal_space', 'proposal_space_section',
-    'session', 'ticket_type', 'user_group', 'venue', 'venue_room'
-    ]
+    'event',
+    'profile',
+    'proposal',
+    'proposal_space',
+    'proposal_space_section',
+    'session',
+    'ticket_type',
+    'user_group',
+    'venue',
+    'venue_room',
+]
 
 
 def upgrade():
@@ -28,33 +38,97 @@ def upgrade():
         op.create_check_constraint(tablename + '_name_check', tablename, "name <> ''")
 
     # RENAME CONSTRAINT works in PostgreSQL >= 9.2
-    op.execute(sa.DDL('ALTER TABLE comment RENAME CONSTRAINT ck_comment_state_valid TO comment_status_check;'))
-    op.execute(sa.DDL('ALTER TABLE proposal RENAME CONSTRAINT ck_proposal_state_valid TO proposal_status_check;'))
-    op.execute(sa.DDL('ALTER TABLE proposal_space RENAME CONSTRAINT ck_proposal_space_state_valid TO proposal_space_status_check;'))
-    op.execute(sa.DDL('ALTER TABLE rsvp RENAME CONSTRAINT ck_rsvp_state_valid TO rsvp_status_check;'))
-    op.execute(sa.DDL('ALTER TABLE contact_exchange RENAME CONSTRAINT contact_exchange_user_id_proposal_space_id_participant_id_key TO contact_exchange_pkey;'))
-    op.execute(sa.DDL('ALTER TABLE proposal_space RENAME CONSTRAINT proposal_space_proposal_space_id_fkey TO proposal_space_parent_space_id_fkey;'))
+    op.execute(
+        sa.DDL(
+            'ALTER TABLE comment RENAME CONSTRAINT ck_comment_state_valid TO comment_status_check;'
+        )
+    )
+    op.execute(
+        sa.DDL(
+            'ALTER TABLE proposal RENAME CONSTRAINT ck_proposal_state_valid TO proposal_status_check;'
+        )
+    )
+    op.execute(
+        sa.DDL(
+            'ALTER TABLE proposal_space RENAME CONSTRAINT ck_proposal_space_state_valid TO proposal_space_status_check;'
+        )
+    )
+    op.execute(
+        sa.DDL(
+            'ALTER TABLE rsvp RENAME CONSTRAINT ck_rsvp_state_valid TO rsvp_status_check;'
+        )
+    )
+    op.execute(
+        sa.DDL(
+            'ALTER TABLE contact_exchange RENAME CONSTRAINT contact_exchange_user_id_proposal_space_id_participant_id_key TO contact_exchange_pkey;'
+        )
+    )
+    op.execute(
+        sa.DDL(
+            'ALTER TABLE proposal_space RENAME CONSTRAINT proposal_space_proposal_space_id_fkey TO proposal_space_parent_space_id_fkey;'
+        )
+    )
 
-    op.alter_column('proposal_redirect', 'url_id', existing_type=sa.INTEGER(), server_default=None)
+    op.alter_column(
+        'proposal_redirect', 'url_id', existing_type=sa.INTEGER(), server_default=None
+    )
     op.execute(DropSequence(Sequence('proposal_redirect_url_id_seq')))
 
-    op.alter_column('user', 'userinfo', type_=JsonDict(), existing_type=sa.TEXT(), postgresql_using='userinfo::jsonb')
+    op.alter_column(
+        'user',
+        'userinfo',
+        type_=JsonDict(),
+        existing_type=sa.TEXT(),
+        postgresql_using='userinfo::jsonb',
+    )
 
 
 def downgrade():
     op.alter_column('user', 'userinfo', type_=sa.TEXT(), existing_type=JsonDict())
 
     op.execute(CreateSequence(Sequence('proposal_redirect_url_id_seq')))
-    op.execute(sa.DDL('ALTER SEQUENCE proposal_redirect_url_id_seq OWNED BY proposal_redirect.url_id;'))
-    op.execute(sa.DDL("ALTER TABLE ONLY proposal_redirect ALTER COLUMN url_id SET DEFAULT nextval('proposal_redirect_url_id_seq'::regclass);"))
+    op.execute(
+        sa.DDL(
+            'ALTER SEQUENCE proposal_redirect_url_id_seq OWNED BY proposal_redirect.url_id;'
+        )
+    )
+    op.execute(
+        sa.DDL(
+            "ALTER TABLE ONLY proposal_redirect ALTER COLUMN url_id SET DEFAULT nextval('proposal_redirect_url_id_seq'::regclass);"
+        )
+    )
 
     # RENAME CONSTRAINT works in PostgreSQL >= 9.2
-    op.execute(sa.DDL('ALTER TABLE proposal_space RENAME CONSTRAINT proposal_space_parent_space_id_fkey TO proposal_space_proposal_space_id_fkey;'))
-    op.execute(sa.DDL('ALTER TABLE contact_exchange RENAME CONSTRAINT contact_exchange_pkey TO contact_exchange_user_id_proposal_space_id_participant_id_key;'))
-    op.execute(sa.DDL('ALTER TABLE rsvp RENAME CONSTRAINT rsvp_status_check TO ck_rsvp_state_valid;'))
-    op.execute(sa.DDL('ALTER TABLE proposal_space RENAME CONSTRAINT proposal_space_status_check TO ck_proposal_space_state_valid;'))
-    op.execute(sa.DDL('ALTER TABLE proposal RENAME CONSTRAINT proposal_status_check TO ck_proposal_state_valid;'))
-    op.execute(sa.DDL('ALTER TABLE comment RENAME CONSTRAINT comment_status_check TO ck_comment_state_valid;'))
+    op.execute(
+        sa.DDL(
+            'ALTER TABLE proposal_space RENAME CONSTRAINT proposal_space_parent_space_id_fkey TO proposal_space_proposal_space_id_fkey;'
+        )
+    )
+    op.execute(
+        sa.DDL(
+            'ALTER TABLE contact_exchange RENAME CONSTRAINT contact_exchange_pkey TO contact_exchange_user_id_proposal_space_id_participant_id_key;'
+        )
+    )
+    op.execute(
+        sa.DDL(
+            'ALTER TABLE rsvp RENAME CONSTRAINT rsvp_status_check TO ck_rsvp_state_valid;'
+        )
+    )
+    op.execute(
+        sa.DDL(
+            'ALTER TABLE proposal_space RENAME CONSTRAINT proposal_space_status_check TO ck_proposal_space_state_valid;'
+        )
+    )
+    op.execute(
+        sa.DDL(
+            'ALTER TABLE proposal RENAME CONSTRAINT proposal_status_check TO ck_proposal_state_valid;'
+        )
+    )
+    op.execute(
+        sa.DDL(
+            'ALTER TABLE comment RENAME CONSTRAINT comment_status_check TO ck_comment_state_valid;'
+        )
+    )
 
     for tablename in tables_with_name_column:
         # Drop CHECK constraint on name

--- a/migrations/versions/48ce908329c0_add_unique_constraint_to_attendee.py
+++ b/migrations/versions/48ce908329c0_add_unique_constraint_to_attendee.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """add_unique_constraint_to_attendee
 
 Revision ID: 48ce908329c0
@@ -14,8 +16,14 @@ from alembic import op
 
 
 def upgrade():
-    op.create_unique_constraint(u'attendee_event_id_participant_id_key', 'attendee', ['event_id', 'participant_id'])
+    op.create_unique_constraint(
+        u'attendee_event_id_participant_id_key',
+        'attendee',
+        ['event_id', 'participant_id'],
+    )
 
 
 def downgrade():
-    op.drop_constraint(u'attendee_event_id_participant_id_key', 'attendee', type_='unique')
+    op.drop_constraint(
+        u'attendee_event_id_participant_id_key', 'attendee', type_='unique'
+    )

--- a/migrations/versions/4aedc1062818_session_edits.py
+++ b/migrations/versions/4aedc1062818_session_edits.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Session edits
 
 Revision ID: 4aedc1062818
@@ -17,14 +19,14 @@ from alembic import op
 def upgrade():
     op.alter_column('session', 'start_datetime', new_column_name='start')
     op.alter_column('session', 'end_datetime', new_column_name='end')
-    op.alter_column('session', 'venue_room_id',
-               existing_type=sa.INTEGER(),
-               nullable=True)
+    op.alter_column(
+        'session', 'venue_room_id', existing_type=sa.INTEGER(), nullable=True
+    )
 
 
 def downgrade():
-    op.alter_column('session', 'venue_room_id',
-               existing_type=sa.INTEGER(),
-               nullable=False)
+    op.alter_column(
+        'session', 'venue_room_id', existing_type=sa.INTEGER(), nullable=False
+    )
     op.alter_column('session', 'start', new_column_name='start_datetime')
     op.alter_column('session', 'end', new_column_name='end_datetime')

--- a/migrations/versions/4b630fb42760_init.py
+++ b/migrations/versions/4b630fb42760_init.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """init
 
 Revision ID: 4b630fb42760
@@ -15,15 +17,17 @@ from alembic import op
 
 
 def upgrade():
-    op.create_table('votespace',
+    op.create_table(
+        'votespace',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
         sa.Column('type', sa.Integer(), nullable=True),
         sa.Column('count', sa.Integer(), nullable=False),
-        sa.PrimaryKeyConstraint('id')
-        )
-    op.create_table('tag',
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_table(
+        'tag',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
@@ -31,17 +35,19 @@ def upgrade():
         sa.Column('title', sa.Unicode(length=80), nullable=False),
         sa.PrimaryKeyConstraint('id'),
         sa.UniqueConstraint('name'),
-        sa.UniqueConstraint('title')
-        )
-    op.create_table('commentspace',
+        sa.UniqueConstraint('title'),
+    )
+    op.create_table(
+        'commentspace',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
         sa.Column('type', sa.Integer(), nullable=True),
         sa.Column('count', sa.Integer(), nullable=False),
-        sa.PrimaryKeyConstraint('id')
-        )
-    op.create_table('user',
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_table(
+        'user',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
@@ -58,21 +64,23 @@ def upgrade():
         sa.UniqueConstraint('email'),
         sa.UniqueConstraint('lastuser_token'),
         sa.UniqueConstraint('userid'),
-        sa.UniqueConstraint('username')
-        )
-    op.create_table('vote',
+        sa.UniqueConstraint('username'),
+    )
+    op.create_table(
+        'vote',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
         sa.Column('user_id', sa.Integer(), nullable=False),
         sa.Column('votespace_id', sa.Integer(), nullable=False),
         sa.Column('votedown', sa.Boolean(), nullable=False),
-        sa.ForeignKeyConstraint(['user_id'], ['user.id'], ),
-        sa.ForeignKeyConstraint(['votespace_id'], ['votespace.id'], ),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id']),
+        sa.ForeignKeyConstraint(['votespace_id'], ['votespace.id']),
         sa.PrimaryKeyConstraint('id'),
-        sa.UniqueConstraint('user_id', 'votespace_id')
-        )
-    op.create_table('comment',
+        sa.UniqueConstraint('user_id', 'votespace_id'),
+    )
+    op.create_table(
+        'comment',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
@@ -84,13 +92,14 @@ def upgrade():
         sa.Column('status', sa.Integer(), nullable=False),
         sa.Column('votes_id', sa.Integer(), nullable=False),
         sa.Column('edited_at', sa.DateTime(), nullable=True),
-        sa.ForeignKeyConstraint(['commentspace_id'], ['commentspace.id'], ),
-        sa.ForeignKeyConstraint(['parent_id'], ['comment.id'], ),
-        sa.ForeignKeyConstraint(['user_id'], ['user.id'], ),
-        sa.ForeignKeyConstraint(['votes_id'], ['votespace.id'], ),
-        sa.PrimaryKeyConstraint('id')
-        )
-    op.create_table('proposal_space',
+        sa.ForeignKeyConstraint(['commentspace_id'], ['commentspace.id']),
+        sa.ForeignKeyConstraint(['parent_id'], ['comment.id']),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id']),
+        sa.ForeignKeyConstraint(['votes_id'], ['votespace.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_table(
+        'proposal_space',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
@@ -106,23 +115,25 @@ def upgrade():
         sa.Column('status', sa.Integer(), nullable=False),
         sa.Column('votes_id', sa.Integer(), nullable=False),
         sa.Column('comments_id', sa.Integer(), nullable=False),
-        sa.ForeignKeyConstraint(['comments_id'], ['commentspace.id'], ),
-        sa.ForeignKeyConstraint(['user_id'], ['user.id'], ),
-        sa.ForeignKeyConstraint(['votes_id'], ['votespace.id'], ),
+        sa.ForeignKeyConstraint(['comments_id'], ['commentspace.id']),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id']),
+        sa.ForeignKeyConstraint(['votes_id'], ['votespace.id']),
         sa.PrimaryKeyConstraint('id'),
-        sa.UniqueConstraint('name')
-        )
-    op.create_table('user_group',
+        sa.UniqueConstraint('name'),
+    )
+    op.create_table(
+        'user_group',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
         sa.Column('name', sa.Unicode(length=250), nullable=False),
         sa.Column('title', sa.Unicode(length=250), nullable=False),
         sa.Column('proposal_space_id', sa.Integer(), nullable=False),
-        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id'], ),
-        sa.PrimaryKeyConstraint('id')
-        )
-    op.create_table('proposal_space_section',
+        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_table(
+        'proposal_space_section',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
@@ -133,20 +144,22 @@ def upgrade():
         sa.Column('public', sa.Boolean(), nullable=False),
         sa.Column('votes_id', sa.Integer(), nullable=False),
         sa.Column('comments_id', sa.Integer(), nullable=False),
-        sa.ForeignKeyConstraint(['comments_id'], ['commentspace.id'], ),
-        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id'], ),
-        sa.ForeignKeyConstraint(['votes_id'], ['votespace.id'], ),
+        sa.ForeignKeyConstraint(['comments_id'], ['commentspace.id']),
+        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id']),
+        sa.ForeignKeyConstraint(['votes_id'], ['votespace.id']),
         sa.PrimaryKeyConstraint('id'),
-        sa.UniqueConstraint('proposal_space_id', 'name')
-        )
-    op.create_table('group_members',
+        sa.UniqueConstraint('proposal_space_id', 'name'),
+    )
+    op.create_table(
+        'group_members',
         sa.Column('group_id', sa.Integer(), nullable=True),
         sa.Column('user_id', sa.Integer(), nullable=True),
-        sa.ForeignKeyConstraint(['group_id'], ['user_group.id'], ),
-        sa.ForeignKeyConstraint(['user_id'], ['user.id'], ),
-        sa.PrimaryKeyConstraint()
-        )
-    op.create_table('proposal',
+        sa.ForeignKeyConstraint(['group_id'], ['user_group.id']),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id']),
+        sa.PrimaryKeyConstraint(),
+    )
+    op.create_table(
+        'proposal',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
@@ -175,21 +188,22 @@ def upgrade():
         sa.Column('votes_id', sa.Integer(), nullable=False),
         sa.Column('comments_id', sa.Integer(), nullable=False),
         sa.Column('edited_at', sa.DateTime(), nullable=True),
-        sa.ForeignKeyConstraint(['comments_id'], ['commentspace.id'], ),
-        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id'], ),
-        sa.ForeignKeyConstraint(['section_id'], ['proposal_space_section.id'], ),
-        sa.ForeignKeyConstraint(['speaker_id'], ['user.id'], ),
-        sa.ForeignKeyConstraint(['user_id'], ['user.id'], ),
-        sa.ForeignKeyConstraint(['votes_id'], ['votespace.id'], ),
-        sa.PrimaryKeyConstraint('id')
-        )
-    op.create_table('proposal_tags',
+        sa.ForeignKeyConstraint(['comments_id'], ['commentspace.id']),
+        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id']),
+        sa.ForeignKeyConstraint(['section_id'], ['proposal_space_section.id']),
+        sa.ForeignKeyConstraint(['speaker_id'], ['user.id']),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id']),
+        sa.ForeignKeyConstraint(['votes_id'], ['votespace.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_table(
+        'proposal_tags',
         sa.Column('tag_id', sa.Integer(), nullable=True),
         sa.Column('proposal_id', sa.Integer(), nullable=True),
-        sa.ForeignKeyConstraint(['proposal_id'], ['proposal.id'], ),
-        sa.ForeignKeyConstraint(['tag_id'], ['tag.id'], ),
-        sa.PrimaryKeyConstraint()
-        )
+        sa.ForeignKeyConstraint(['proposal_id'], ['proposal.id']),
+        sa.ForeignKeyConstraint(['tag_id'], ['tag.id']),
+        sa.PrimaryKeyConstraint(),
+    )
 
 
 def downgrade():

--- a/migrations/versions/4b7fe9b25c6c_removed_legacy_name_from_project.py
+++ b/migrations/versions/4b7fe9b25c6c_removed_legacy_name_from_project.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """removed legacy_name from project
 
 Revision ID: 4b7fe9b25c6c
@@ -14,24 +16,38 @@ import sqlalchemy as sa  # NOQA
 from alembic import op
 from sqlalchemy.sql import column, table
 
-project = table('project',
+project = table(
+    'project',
     column('profile_id', sa.Integer()),
     column('legacy_name', sa.Unicode(250)),
     column('name', sa.Unicode(250)),
-    )
+)
 
-profile = table('profile',
-    column('id', sa.Integer()),
-    column('name', sa.Unicode(250)),
-    )
+profile = table('profile', column('id', sa.Integer()), column('name', sa.Unicode(250)))
 
 legacy_data = [
     {'legacy_name': u'jsfoo2011', 'name': u'2011', 'profile_name': u'jsfoo'},
     {'legacy_name': u'droidcon2012', 'name': u'2012', 'profile_name': u'droidconin'},
-    {'legacy_name': u'inboxalert', 'name': u'2013-tentative', 'profile_name': u'inboxalert'},
-    {'legacy_name': u'jsfoo-bangalore2012', 'name': u'2012-dummy', 'profile_name': u'jsfoo'},
-    {'legacy_name': u'inbox-alert-2014', 'name': u'2014', 'profile_name': u'inboxalert'},
-    {'legacy_name': u'metarefresh2013', 'name': u'2013', 'profile_name': u'metarefresh'},
+    {
+        'legacy_name': u'inboxalert',
+        'name': u'2013-tentative',
+        'profile_name': u'inboxalert',
+    },
+    {
+        'legacy_name': u'jsfoo-bangalore2012',
+        'name': u'2012-dummy',
+        'profile_name': u'jsfoo',
+    },
+    {
+        'legacy_name': u'inbox-alert-2014',
+        'name': u'2014',
+        'profile_name': u'inboxalert',
+    },
+    {
+        'legacy_name': u'metarefresh2013',
+        'name': u'2013',
+        'profile_name': u'metarefresh',
+    },
     {'legacy_name': u'jsfoo2013', 'name': u'2013', 'profile_name': u'jsfoo'},
     {'legacy_name': u'fifthel2013', 'name': u'2013', 'profile_name': u'fifthelephant'},
     {'legacy_name': u'5el', 'name': u'2012', 'profile_name': u'fifthelephant'},
@@ -41,21 +57,54 @@ legacy_data = [
     {'legacy_name': u'jsfoo', 'name': u'2012', 'profile_name': u'jsfoo'},
     {'legacy_name': u'droidcon', 'name': u'2011', 'profile_name': u'droidconin'},
     {'legacy_name': u'rootconf', 'name': u'2012', 'profile_name': u'rootconf'},
-    {'legacy_name': u'cartonama-workshop', 'name': u'2012-workshop', 'profile_name': u'cartonama'},
+    {
+        'legacy_name': u'cartonama-workshop',
+        'name': u'2012-workshop',
+        'profile_name': u'cartonama',
+    },
     {'legacy_name': u'paystation', 'name': u'paystation', 'profile_name': u'miniconf'},
-    {'legacy_name': u'jsfoo-chennai', 'name': u'2012-chennai', 'profile_name': u'jsfoo'},
-    {'legacy_name': u'css-workshop', 'name': u'2013-css-workshop', 'profile_name': u'metarefresh'},
+    {
+        'legacy_name': u'jsfoo-chennai',
+        'name': u'2012-chennai',
+        'profile_name': u'jsfoo',
+    },
+    {
+        'legacy_name': u'css-workshop',
+        'name': u'2013-css-workshop',
+        'profile_name': u'metarefresh',
+    },
     {'legacy_name': u'phpcloud', 'name': u'2011', 'profile_name': u'phpcloud'},
     {'legacy_name': u'fifthel2014', 'name': u'2014', 'profile_name': u'fifthelephant'},
     {'legacy_name': u'droidcon2014', 'name': u'2014', 'profile_name': u'droidconin'},
     {'legacy_name': u'jsfoo2014', 'name': u'2014', 'profile_name': u'jsfoo'},
-    {'legacy_name': u'metarefresh2015', 'name': u'2015', 'profile_name': u'metarefresh'},
+    {
+        'legacy_name': u'metarefresh2015',
+        'name': u'2015',
+        'profile_name': u'metarefresh',
+    },
     {'legacy_name': u'rootconf2014', 'name': u'2014', 'profile_name': u'rootconf'},
-    {'legacy_name': u'metarefresh2014', 'name': u'2014', 'profile_name': u'metarefresh'},
-    {'legacy_name': u'angularjs-miniconf-2014', 'name': u'2014-angularjs', 'profile_name': u'miniconf'},
+    {
+        'legacy_name': u'metarefresh2014',
+        'name': u'2014',
+        'profile_name': u'metarefresh',
+    },
+    {
+        'legacy_name': u'angularjs-miniconf-2014',
+        'name': u'2014-angularjs',
+        'profile_name': u'miniconf',
+    },
     {'legacy_name': u'droidcon2013', 'name': u'2013', 'profile_name': u'droidconin'},
-    {'legacy_name': u'redis-miniconf-2014', 'name': u'2014-redis', 'profile_name': u'miniconf'},
-    {'legacy_name': u'rootconf-miniconf-2014', 'name': u'2014-rootconf', 'profile_name': u'miniconf'}]
+    {
+        'legacy_name': u'redis-miniconf-2014',
+        'name': u'2014-redis',
+        'profile_name': u'miniconf',
+    },
+    {
+        'legacy_name': u'rootconf-miniconf-2014',
+        'name': u'2014-rootconf',
+        'profile_name': u'miniconf',
+    },
+]
 
 
 def upgrade():
@@ -65,10 +114,21 @@ def upgrade():
 def downgrade():
     conn = op.get_bind()
 
-    op.add_column('project', sa.Column('legacy_name', sa.Unicode(length=250), nullable=True))
+    op.add_column(
+        'project', sa.Column('legacy_name', sa.Unicode(length=250), nullable=True)
+    )
     op.create_unique_constraint('project_legacy_name_key', 'project', ['legacy_name'])
 
     for data in legacy_data:
-        profile_id = conn.execute(sa.select([profile.c.id]).where(profile.c.name == data['profile_name']).limit(1)).fetchone()
+        profile_id = conn.execute(
+            sa.select([profile.c.id])
+            .where(profile.c.name == data['profile_name'])
+            .limit(1)
+        ).fetchone()
         if profile_id:
-            conn.execute(sa.update(project).where(project.c.name == data['name']).where(project.c.profile_id == profile_id[0]).values({'legacy_name': data['legacy_name']}))
+            conn.execute(
+                sa.update(project)
+                .where(project.c.name == data['name'])
+                .where(project.c.profile_id == profile_id[0])
+                .values({'legacy_name': data['legacy_name']})
+            )

--- a/migrations/versions/4b80fb451c8e_project_tri_state_columns.py
+++ b/migrations/versions/4b80fb451c8e_project_tri_state_columns.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Project tri-state columns
 
 Revision ID: 4b80fb451c8e
@@ -15,7 +17,7 @@ from alembic import op
 from sqlalchemy.sql import column, table
 
 
-class OLD_STATE:
+class OLD_STATE:  # NOQA: N801
     DRAFT = 0
     SUBMISSIONS = 1
     VOTING = 2
@@ -25,90 +27,126 @@ class OLD_STATE:
     WITHDRAWN = 6
 
 
-class PROJECT_STATE:
+class PROJECT_STATE:  # NOQA: N801
     DRAFT = 0
     PUBLISHED = 1
     WITHDRAWN = 2
     DELETED = 3
 
 
-class CFP_STATE:
+class CFP_STATE:  # NOQA: N801
     NONE = 0
     PUBLIC = 1
     CLOSED = 2
 
 
-class SCHEDULE_STATE:
+class SCHEDULE_STATE:  # NOQA: N801
     DRAFT = 0
     PUBLISHED = 1
 
 
-project = table('project',
+project = table(
+    'project',
     column('created_at', sa.DateTime()),
     column('old_state', sa.Integer()),
     column('state', sa.Integer()),
     column('cfp_state', sa.Integer()),
     column('cfp_start_at', sa.DateTime()),
     column('schedule_state', sa.Integer()),
-    )
+)
 
 
 upgrade_states = {
     OLD_STATE.DRAFT: (PROJECT_STATE.DRAFT, CFP_STATE.NONE, None),
-    OLD_STATE.SUBMISSIONS: (PROJECT_STATE.PUBLISHED, CFP_STATE.PUBLIC, project.c.created_at),
+    OLD_STATE.SUBMISSIONS: (
+        PROJECT_STATE.PUBLISHED,
+        CFP_STATE.PUBLIC,
+        project.c.created_at,
+    ),
     OLD_STATE.VOTING: (PROJECT_STATE.PUBLISHED, CFP_STATE.CLOSED, None),
     OLD_STATE.JURY: (PROJECT_STATE.PUBLISHED, CFP_STATE.CLOSED, None),
     OLD_STATE.FEEDBACK: (PROJECT_STATE.PUBLISHED, CFP_STATE.CLOSED, None),
     OLD_STATE.CLOSED: (PROJECT_STATE.PUBLISHED, CFP_STATE.CLOSED, None),
     OLD_STATE.WITHDRAWN: (PROJECT_STATE.WITHDRAWN, CFP_STATE.CLOSED, None),
-    }
+}
 
 
 def upgrade():
     # Move `state` out of the way into `old_state`
     op.alter_column('project', 'state', new_column_name='old_state')
     op.execute(
-        sa.DDL('ALTER TABLE project RENAME CONSTRAINT project_state_check TO project_old_state_check'))
+        sa.DDL(
+            'ALTER TABLE project RENAME CONSTRAINT project_state_check TO project_old_state_check'
+        )
+    )
 
     # Create three new columns: `state`, `cfp_state` and `schedule_state`, with matching
     # CHECK constraints
-    op.add_column('project', sa.Column('state', sa.Integer(), nullable=False,
-        server_default=str(PROJECT_STATE.DRAFT)))
+    op.add_column(
+        'project',
+        sa.Column(
+            'state',
+            sa.Integer(),
+            nullable=False,
+            server_default=str(PROJECT_STATE.DRAFT),
+        ),
+    )
     op.alter_column('project', 'state', server_default=None)
     op.create_check_constraint(
-        'project_state_check',
-        'project',
-        'state IN (0, 1, 2, 3)')
+        'project_state_check', 'project', 'state IN (0, 1, 2, 3)'
+    )
 
-    op.add_column('project', sa.Column('cfp_state', sa.Integer(), nullable=False,
-        server_default=str(CFP_STATE.NONE)))
+    op.add_column(
+        'project',
+        sa.Column(
+            'cfp_state',
+            sa.Integer(),
+            nullable=False,
+            server_default=str(CFP_STATE.NONE),
+        ),
+    )
     op.alter_column('project', 'cfp_state', server_default=None)
     op.create_check_constraint(
-        'project_cfp_state_check',
-        'project',
-        'cfp_state IN (0, 1, 2)')
+        'project_cfp_state_check', 'project', 'cfp_state IN (0, 1, 2)'
+    )
 
-    op.add_column('project', sa.Column('schedule_state', sa.Integer(), nullable=False,
-        server_default=str(SCHEDULE_STATE.DRAFT)))
+    op.add_column(
+        'project',
+        sa.Column(
+            'schedule_state',
+            sa.Integer(),
+            nullable=False,
+            server_default=str(SCHEDULE_STATE.DRAFT),
+        ),
+    )
     op.alter_column('project', 'schedule_state', server_default=None)
     op.create_check_constraint(
-        'project_schedule_state_check',
-        'project',
-        'schedule_state IN (0, 1)')
+        'project_schedule_state_check', 'project', 'schedule_state IN (0, 1)'
+    )
 
     op.add_column('project', sa.Column('cfp_start_at', sa.DateTime(), nullable=True))
     op.add_column('project', sa.Column('cfp_end_at', sa.DateTime(), nullable=True))
 
     for old_state, new_state in upgrade_states.items():
         op.execute(
-            project.update().where(project.c.old_state == old_state).values(
-                {'state': new_state[0], 'cfp_state': new_state[1], 'cfp_start_at': new_state[2]}))
+            project.update()
+            .where(project.c.old_state == old_state)
+            .values(
+                {
+                    'state': new_state[0],
+                    'cfp_state': new_state[1],
+                    'cfp_start_at': new_state[2],
+                }
+            )
+        )
 
     # For existing projects, assume the presence of a session to indicate a published schedule.
     # New projects will require explicit publication.
     op.execute(
         sa.DDL(
-            'UPDATE project SET schedule_state=1 WHERE id IN (SELECT DISTINCT(project_id) FROM session)'))
+            'UPDATE project SET schedule_state=1 WHERE id IN (SELECT DISTINCT(project_id) FROM session)'
+        )
+    )
 
 
 def downgrade():
@@ -123,4 +161,7 @@ def downgrade():
 
     op.alter_column('project', 'old_state', new_column_name='state')
     op.execute(
-        sa.DDL('ALTER TABLE project RENAME CONSTRAINT project_old_state_check TO project_state_check'))
+        sa.DDL(
+            'ALTER TABLE project RENAME CONSTRAINT project_old_state_check TO project_state_check'
+        )
+    )

--- a/migrations/versions/4dbf686f4380_added_location_to_pr.py
+++ b/migrations/versions/4dbf686f4380_added_location_to_pr.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Added location to proposal
 
 Revision ID: 4dbf686f4380
@@ -15,7 +17,15 @@ from alembic import op
 
 
 def upgrade():
-    op.add_column('proposal', sa.Column('location', sa.Unicode(length=80), server_default=sa.text(u"''"), nullable=False))
+    op.add_column(
+        'proposal',
+        sa.Column(
+            'location',
+            sa.Unicode(length=80),
+            server_default=sa.text(u"''"),
+            nullable=False,
+        ),
+    )
     op.alter_column('proposal', 'location', server_default=None)
 
 

--- a/migrations/versions/50a8f43b4e5f_remove_blogpost_column.py
+++ b/migrations/versions/50a8f43b4e5f_remove_blogpost_column.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Remove blogpost column
 
 Revision ID: 50a8f43b4e5f
@@ -21,5 +23,13 @@ def upgrade():
 
 def downgrade():
     with op.batch_alter_table('proposal', schema=None) as batch_op:
-        batch_op.add_column(sa.Column('blog_post', sa.VARCHAR(length=250), autoincrement=False, nullable=False, server_default="''"))
+        batch_op.add_column(
+            sa.Column(
+                'blog_post',
+                sa.VARCHAR(length=250),
+                autoincrement=False,
+                nullable=False,
+                server_default="''",
+            )
+        )
         batch_op.alter_column('blog_post', server_default=None)

--- a/migrations/versions/50f58275fc1c_proposal_space_to_profile.py
+++ b/migrations/versions/50f58275fc1c_proposal_space_to_profile.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Proposal space to profile
 
 Revision ID: 50f58275fc1c
@@ -14,8 +16,16 @@ from alembic import op
 
 
 def upgrade():
-    op.create_foreign_key('proposal_space_profile_id_fkey', 'proposal_space', 'profile', ['profile_id'], ['id'])
+    op.create_foreign_key(
+        'proposal_space_profile_id_fkey',
+        'proposal_space',
+        'profile',
+        ['profile_id'],
+        ['id'],
+    )
 
 
 def downgrade():
-    op.drop_constraint('proposal_space_profile_id_fkey', 'proposal_space', type_='foreignkey')
+    op.drop_constraint(
+        'proposal_space_profile_id_fkey', 'proposal_space', type_='foreignkey'
+    )

--- a/migrations/versions/522d776a42ed_event_models.py
+++ b/migrations/versions/522d776a42ed_event_models.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """event_models
 
 Revision ID: 522d776a42ed
@@ -14,25 +16,28 @@ from alembic import op
 
 
 def upgrade():
-    op.create_table('ticket_type',
+    op.create_table(
+        'ticket_type',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
         sa.Column('name', sa.Unicode(length=80), nullable=False),
         sa.Column('proposal_space_id', sa.Integer(), nullable=False),
-        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id'], ),
-        sa.PrimaryKeyConstraint('id')
-        )
-    op.create_table('event',
+        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_table(
+        'event',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
         sa.Column('name', sa.Unicode(length=80), nullable=False),
         sa.Column('proposal_space_id', sa.Integer(), nullable=False),
-        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id'], ),
-        sa.PrimaryKeyConstraint('id')
-        )
-    op.create_table('participant',
+        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_table(
+        'participant',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
@@ -48,25 +53,27 @@ def upgrade():
         sa.Column('badge_printed', sa.Boolean(), nullable=False),
         sa.Column('user_id', sa.Integer(), nullable=True),
         sa.Column('proposal_space_id', sa.Integer(), nullable=False),
-        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id'], ),
-        sa.ForeignKeyConstraint(['user_id'], ['user.id'], ),
+        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id']),
+        sa.ForeignKeyConstraint(['user_id'], ['user.id']),
         sa.PrimaryKeyConstraint('id'),
         sa.UniqueConstraint('key'),
         sa.UniqueConstraint('proposal_space_id', 'email'),
-        sa.UniqueConstraint('puk')
-        )
-    op.create_table('attendee',
+        sa.UniqueConstraint('puk'),
+    )
+    op.create_table(
+        'attendee',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
         sa.Column('participant_id', sa.Integer(), nullable=False),
         sa.Column('event_id', sa.Integer(), nullable=False),
         sa.Column('checked_in', sa.Boolean(), nullable=False),
-        sa.ForeignKeyConstraint(['event_id'], ['event.id'], ),
-        sa.ForeignKeyConstraint(['participant_id'], ['participant.id'], ),
-        sa.PrimaryKeyConstraint('id')
-        )
-    op.create_table('sync_ticket',
+        sa.ForeignKeyConstraint(['event_id'], ['event.id']),
+        sa.ForeignKeyConstraint(['participant_id'], ['participant.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_table(
+        'sync_ticket',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
@@ -75,20 +82,21 @@ def upgrade():
         sa.Column('ticket_type_id', sa.Integer(), nullable=False),
         sa.Column('participant_id', sa.Integer(), nullable=False),
         sa.Column('proposal_space_id', sa.Integer(), nullable=False),
-        sa.ForeignKeyConstraint(['participant_id'], ['participant.id'], ),
-        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id'], ),
-        sa.ForeignKeyConstraint(['ticket_type_id'], ['ticket_type.id'], ),
+        sa.ForeignKeyConstraint(['participant_id'], ['participant.id']),
+        sa.ForeignKeyConstraint(['proposal_space_id'], ['proposal_space.id']),
+        sa.ForeignKeyConstraint(['ticket_type_id'], ['ticket_type.id']),
         sa.PrimaryKeyConstraint('id'),
-        sa.UniqueConstraint('proposal_space_id', 'ticket_no')
-        )
-    op.create_table('event_ticket_type',
+        sa.UniqueConstraint('proposal_space_id', 'ticket_no'),
+    )
+    op.create_table(
+        'event_ticket_type',
         sa.Column('event_id', sa.Integer(), nullable=False),
         sa.Column('ticket_type_id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
-        sa.ForeignKeyConstraint(['event_id'], ['event.id'], ),
-        sa.ForeignKeyConstraint(['ticket_type_id'], ['ticket_type.id'], ),
-        sa.PrimaryKeyConstraint('event_id', 'ticket_type_id')
-        )
+        sa.ForeignKeyConstraint(['event_id'], ['event.id']),
+        sa.ForeignKeyConstraint(['ticket_type_id'], ['ticket_type.id']),
+        sa.PrimaryKeyConstraint('event_id', 'ticket_type_id'),
+    )
 
 
 def downgrade():

--- a/migrations/versions/523c53593e3c_proposalspace_explor.py
+++ b/migrations/versions/523c53593e3c_proposalspace_explor.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """ProposalSpace explore URL
 
 Revision ID: 523c53593e3c
@@ -15,7 +17,10 @@ from alembic import op
 
 
 def upgrade():
-    op.add_column('proposal_space', sa.Column('explore_url', sa.Unicode(length=250), nullable=True))
+    op.add_column(
+        'proposal_space',
+        sa.Column('explore_url', sa.Unicode(length=250), nullable=True),
+    )
 
 
 def downgrade():

--- a/migrations/versions/5290f9238875_feedback.py
+++ b/migrations/versions/5290f9238875_feedback.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """feedback
 
 Revision ID: 5290f9238875
@@ -15,7 +17,8 @@ from alembic import op
 
 
 def upgrade():
-    op.create_table('proposal_feedback',
+    op.create_table(
+        'proposal_feedback',
         sa.Column('id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
@@ -27,10 +30,10 @@ def upgrade():
         sa.Column('max_scale', sa.Integer(), nullable=False),
         sa.Column('content', sa.Integer(), nullable=True),
         sa.Column('presentation', sa.Integer(), nullable=True),
-        sa.ForeignKeyConstraint(['proposal_id'], ['proposal.id'], ),
+        sa.ForeignKeyConstraint(['proposal_id'], ['proposal.id']),
         sa.PrimaryKeyConstraint('id'),
-        sa.UniqueConstraint('proposal_id', 'auth_type', 'id_type', 'userid')
-        )
+        sa.UniqueConstraint('proposal_id', 'auth_type', 'id_type', 'userid'),
+    )
 
 
 def downgrade():

--- a/migrations/versions/55097480a655_event_timezone.py
+++ b/migrations/versions/55097480a655_event_timezone.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Event timezone
 
 Revision ID: 55097480a655
@@ -15,7 +17,12 @@ from alembic import op
 
 
 def upgrade():
-    op.add_column('proposal_space', sa.Column('timezone', sa.Unicode(length=40), nullable=False, server_default=u'UTC'))
+    op.add_column(
+        'proposal_space',
+        sa.Column(
+            'timezone', sa.Unicode(length=40), nullable=False, server_default=u'UTC'
+        ),
+    )
     op.alter_column('proposal_space', 'timezone', server_default=None)
 
 

--- a/migrations/versions/55b1ef63bee_admin_and_review_tea.py
+++ b/migrations/versions/55b1ef63bee_admin_and_review_tea.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Admin and review teams
 
 Revision ID: 55b1ef63bee
@@ -15,9 +17,24 @@ from alembic import op
 
 
 def upgrade():
-    op.add_column('profile', sa.Column('admin_team_id', sa.Integer(), sa.ForeignKey('team.id'), nullable=True))
-    op.add_column('proposal_space', sa.Column('admin_team_id', sa.Integer(), sa.ForeignKey('team.id'), nullable=True))
-    op.add_column('proposal_space', sa.Column('review_team_id', sa.Integer(), sa.ForeignKey('team.id'), nullable=True))
+    op.add_column(
+        'profile',
+        sa.Column(
+            'admin_team_id', sa.Integer(), sa.ForeignKey('team.id'), nullable=True
+        ),
+    )
+    op.add_column(
+        'proposal_space',
+        sa.Column(
+            'admin_team_id', sa.Integer(), sa.ForeignKey('team.id'), nullable=True
+        ),
+    )
+    op.add_column(
+        'proposal_space',
+        sa.Column(
+            'review_team_id', sa.Integer(), sa.ForeignKey('team.id'), nullable=True
+        ),
+    )
 
 
 def downgrade():

--- a/migrations/versions/56ba15eff9ad_saved_projects_and_sessions.py
+++ b/migrations/versions/56ba15eff9ad_saved_projects_and_sessions.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Saved projects and sessions
 
 Revision ID: 56ba15eff9ad
@@ -15,7 +17,8 @@ from alembic import op
 
 
 def upgrade():
-    op.create_table('saved_project',
+    op.create_table(
+        'saved_project',
         sa.Column('user_id', sa.Integer(), nullable=False),
         sa.Column('project_id', sa.Integer(), nullable=False),
         sa.Column('saved_at', sa.TIMESTAMP(timezone=True), nullable=False),
@@ -24,11 +27,17 @@ def upgrade():
         sa.Column('updated_at', sa.TIMESTAMP(timezone=True), nullable=False),
         sa.ForeignKeyConstraint(['project_id'], ['project.id'], ondelete='CASCADE'),
         sa.ForeignKeyConstraint(['user_id'], ['user.id'], ondelete='CASCADE'),
-        sa.PrimaryKeyConstraint('user_id', 'project_id')
-        )
-    op.create_index(op.f('ix_saved_project_project_id'), 'saved_project', ['project_id'], unique=False)
+        sa.PrimaryKeyConstraint('user_id', 'project_id'),
+    )
+    op.create_index(
+        op.f('ix_saved_project_project_id'),
+        'saved_project',
+        ['project_id'],
+        unique=False,
+    )
 
-    op.create_table('saved_session',
+    op.create_table(
+        'saved_session',
         sa.Column('user_id', sa.Integer(), nullable=False),
         sa.Column('session_id', sa.Integer(), nullable=False),
         sa.Column('saved_at', sa.TIMESTAMP(timezone=True), nullable=False),
@@ -37,9 +46,14 @@ def upgrade():
         sa.Column('updated_at', sa.TIMESTAMP(timezone=True), nullable=False),
         sa.ForeignKeyConstraint(['session_id'], ['session.id'], ondelete='CASCADE'),
         sa.ForeignKeyConstraint(['user_id'], ['user.id'], ondelete='CASCADE'),
-        sa.PrimaryKeyConstraint('user_id', 'session_id')
-        )
-    op.create_index(op.f('ix_saved_session_session_id'), 'saved_session', ['session_id'], unique=False)
+        sa.PrimaryKeyConstraint('user_id', 'session_id'),
+    )
+    op.create_index(
+        op.f('ix_saved_session_session_id'),
+        'saved_session',
+        ['session_id'],
+        unique=False,
+    )
 
 
 def downgrade():

--- a/migrations/versions/570f4ea99cda_add_labels_to_proposal_space.py
+++ b/migrations/versions/570f4ea99cda_add_labels_to_proposal_space.py
@@ -1,8 +1,4 @@
-import sqlalchemy as sa  # NOQA
-from alembic import op
-from sqlalchemy.sql import column, table
-
-from coaster.sqlalchemy import JsonDict
+# -*- coding: utf-8 -*-
 
 """add labels to proposal space
 
@@ -16,13 +12,26 @@ Create Date: 2016-02-02 20:45:07.804542
 revision = '570f4ea99cda'
 down_revision = '3b189f2e5c56'
 
+import sqlalchemy as sa  # NOQA
+from alembic import op
+from sqlalchemy.sql import column, table
+
+from coaster.sqlalchemy import JsonDict
+
 
 def upgrade():
     proposal_space = table('proposal_space', column('labels'))
-    op.add_column(u'proposal_space', sa.Column('labels', JsonDict(), server_default='{}', nullable=False))
+    op.add_column(
+        u'proposal_space',
+        sa.Column('labels', JsonDict(), server_default='{}', nullable=False),
+    )
     op.execute(
-        proposal_space.update().values({'labels': '{"proposal": {"part_a": {"title": "Objective", "hint": "What is the expected benefit for someone attending this?"}, "part_b": {"title": "Description", "hint": "A detailed description of the session."}}}'})
+        proposal_space.update().values(
+            {
+                'labels': '{"proposal": {"part_a": {"title": "Objective", "hint": "What is the expected benefit for someone attending this?"}, "part_b": {"title": "Description", "hint": "A detailed description of the session."}}}'
+            }
         )
+    )
 
 
 def downgrade():

--- a/migrations/versions/577689971aa0_space_content.py
+++ b/migrations/versions/577689971aa0_space_content.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Space content
 
 Revision ID: 577689971aa0
@@ -17,7 +19,10 @@ from coaster.sqlalchemy import JsonDict
 
 
 def upgrade():
-    op.add_column('proposal_space', sa.Column('content', JsonDict, server_default='{}', nullable=False))
+    op.add_column(
+        'proposal_space',
+        sa.Column('content', JsonDict, server_default='{}', nullable=False),
+    )
     op.alter_column('proposal_space', 'content', server_default=None)
 
 

--- a/migrations/versions/58588eba8cb8_room_bgcolor_default.py
+++ b/migrations/versions/58588eba8cb8_room_bgcolor_default.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """room bgcolor default
 
 Revision ID: 58588eba8cb8
@@ -19,14 +21,16 @@ from funnel.models import VenueRoom
 def upgrade():
     connection = op.get_bind()
     room = VenueRoom.__table__
-    updt_stmt = room.update().where(room.c.bgcolor == None).values(bgcolor=u'229922')  # NOQA
+    updt_stmt = (
+        room.update().where(room.c.bgcolor == None).values(bgcolor=u'229922')
+    )  # NOQA
     connection.execute(updt_stmt)
-    op.alter_column('venue_room', 'bgcolor',
-               existing_type=sa.VARCHAR(length=6),
-               nullable=False)
+    op.alter_column(
+        'venue_room', 'bgcolor', existing_type=sa.VARCHAR(length=6), nullable=False
+    )
 
 
 def downgrade():
-    op.alter_column('venue_room', 'bgcolor',
-               existing_type=sa.VARCHAR(length=6),
-               nullable=True)
+    op.alter_column(
+        'venue_room', 'bgcolor', existing_type=sa.VARCHAR(length=6), nullable=True
+    )

--- a/migrations/versions/5e06feda611d_session_start_and_end_column_names.py
+++ b/migrations/versions/5e06feda611d_session_start_and_end_column_names.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Session start and end column names
 
 Revision ID: 5e06feda611d
@@ -20,14 +22,20 @@ def upgrade():
     op.create_index(op.f('ix_session_start_at'), 'session', ['start_at'], unique=False)
     op.create_index(op.f('ix_session_end_at'), 'session', ['end_at'], unique=False)
     op.execute(
-        sa.DDL('ALTER TABLE session RENAME CONSTRAINT session_start_end_check '
-        'TO session_start_at_end_at_check'))
+        sa.DDL(
+            'ALTER TABLE session RENAME CONSTRAINT session_start_end_check '
+            'TO session_start_at_end_at_check'
+        )
+    )
 
 
 def downgrade():
     op.execute(
-        sa.DDL('ALTER TABLE session RENAME CONSTRAINT session_start_at_end_at_check '
-        'TO session_start_end_check'))
+        sa.DDL(
+            'ALTER TABLE session RENAME CONSTRAINT session_start_at_end_at_check '
+            'TO session_start_end_check'
+        )
+    )
 
     op.drop_index(op.f('ix_session_end_at'), table_name='session')
     op.drop_index(op.f('ix_session_start_at'), table_name='session')

--- a/migrations/versions/60a132ae73f1_url_field_leng.py
+++ b/migrations/versions/60a132ae73f1_url_field_leng.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """url field leng
 
 Revision ID: 60a132ae73f1
@@ -15,30 +17,90 @@ from alembic import op
 
 
 def upgrade():
-    op.alter_column('project', 'bg_image', existing_type=sa.Unicode(length=250),
-        type_=sa.Unicode(length=2000), existing_nullable=True)
-    op.alter_column('project', 'website', existing_type=sa.Unicode(length=250),
-        type_=sa.Unicode(length=2000), existing_nullable=True)
-    op.alter_column('project', 'buy_tickets_url', existing_type=sa.Unicode(length=250),
-        type_=sa.Unicode(length=2000), existing_nullable=True)
-    op.alter_column('project', 'explore_url', existing_type=sa.Unicode(length=250),
-        type_=sa.Unicode(length=2000), existing_nullable=True)
-    op.alter_column('proposal', 'preview_video', existing_type=sa.Unicode(length=250),
-        type_=sa.Unicode(length=2000), existing_nullable=True)
-    op.alter_column('proposal', 'slides', existing_type=sa.Unicode(length=250),
-        type_=sa.Unicode(length=2000), existing_nullable=True)
+    op.alter_column(
+        'project',
+        'bg_image',
+        existing_type=sa.Unicode(length=250),
+        type_=sa.Unicode(length=2000),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        'project',
+        'website',
+        existing_type=sa.Unicode(length=250),
+        type_=sa.Unicode(length=2000),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        'project',
+        'buy_tickets_url',
+        existing_type=sa.Unicode(length=250),
+        type_=sa.Unicode(length=2000),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        'project',
+        'explore_url',
+        existing_type=sa.Unicode(length=250),
+        type_=sa.Unicode(length=2000),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        'proposal',
+        'preview_video',
+        existing_type=sa.Unicode(length=250),
+        type_=sa.Unicode(length=2000),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        'proposal',
+        'slides',
+        existing_type=sa.Unicode(length=250),
+        type_=sa.Unicode(length=2000),
+        existing_nullable=True,
+    )
 
 
 def downgrade():
-    op.alter_column('proposal', 'slides', existing_type=sa.Unicode(length=2000),
-        type_=sa.Unicode(length=250), existing_nullable=True)
-    op.alter_column('proposal', 'preview_video', existing_type=sa.Unicode(length=2000),
-        type_=sa.Unicode(length=250), existing_nullable=True)
-    op.alter_column('project', 'explore_url', existing_type=sa.Unicode(length=2000),
-        type_=sa.Unicode(length=250), existing_nullable=True)
-    op.alter_column('project', 'buy_tickets_url', existing_type=sa.Unicode(length=2000),
-        type_=sa.Unicode(length=250), existing_nullable=True)
-    op.alter_column('project', 'website', existing_type=sa.Unicode(length=2000),
-        type_=sa.Unicode(length=250), existing_nullable=True)
-    op.alter_column('project', 'bg_image', existing_type=sa.Unicode(length=2000),
-        type_=sa.Unicode(length=250), existing_nullable=True)
+    op.alter_column(
+        'proposal',
+        'slides',
+        existing_type=sa.Unicode(length=2000),
+        type_=sa.Unicode(length=250),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        'proposal',
+        'preview_video',
+        existing_type=sa.Unicode(length=2000),
+        type_=sa.Unicode(length=250),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        'project',
+        'explore_url',
+        existing_type=sa.Unicode(length=2000),
+        type_=sa.Unicode(length=250),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        'project',
+        'buy_tickets_url',
+        existing_type=sa.Unicode(length=2000),
+        type_=sa.Unicode(length=250),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        'project',
+        'website',
+        existing_type=sa.Unicode(length=2000),
+        type_=sa.Unicode(length=250),
+        existing_nullable=True,
+    )
+    op.alter_column(
+        'project',
+        'bg_image',
+        existing_type=sa.Unicode(length=2000),
+        type_=sa.Unicode(length=250),
+        existing_nullable=True,
+    )

--- a/migrations/versions/6f98e24760d_session_speaker.py
+++ b/migrations/versions/6f98e24760d_session_speaker.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """session speaker
 
 Revision ID: 6f98e24760d
@@ -15,7 +17,9 @@ from alembic import op
 
 
 def upgrade():
-    op.add_column('session', sa.Column('speaker', sa.Unicode(length=200), nullable=True))
+    op.add_column(
+        'session', sa.Column('speaker', sa.Unicode(length=200), nullable=True)
+    )
 
 
 def downgrade():

--- a/migrations/versions/70ffbc1bcf88_logo_url_banner_url_hasjob_embed.py
+++ b/migrations/versions/70ffbc1bcf88_logo_url_banner_url_hasjob_embed.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """logo url banner url hasjob embed
 
 Revision ID: 70ffbc1bcf88
@@ -16,11 +18,22 @@ from coaster.sqlalchemy import JsonDict
 
 
 def upgrade():
-    op.add_column('profile', sa.Column('logo_url', sa.Unicode(length=2000), nullable=True))
-    op.add_column('project', sa.Column('banner_video_url', sa.Unicode(length=2000), nullable=True))
-    op.add_column('project', sa.Column('boxoffice_data', JsonDict(), server_default='{}', nullable=False))
-    op.add_column('project', sa.Column('hasjob_embed_limit', sa.Integer(), nullable=True))
-    op.add_column('project', sa.Column('hasjob_embed_url', sa.Unicode(length=2000), nullable=True))
+    op.add_column(
+        'profile', sa.Column('logo_url', sa.Unicode(length=2000), nullable=True)
+    )
+    op.add_column(
+        'project', sa.Column('banner_video_url', sa.Unicode(length=2000), nullable=True)
+    )
+    op.add_column(
+        'project',
+        sa.Column('boxoffice_data', JsonDict(), server_default='{}', nullable=False),
+    )
+    op.add_column(
+        'project', sa.Column('hasjob_embed_limit', sa.Integer(), nullable=True)
+    )
+    op.add_column(
+        'project', sa.Column('hasjob_embed_url', sa.Unicode(length=2000), nullable=True)
+    )
 
 
 def downgrade():

--- a/migrations/versions/71f961809275_add_checkin_team_to_proposal_space.py
+++ b/migrations/versions/71f961809275_add_checkin_team_to_proposal_space.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """add_checkin_team_to_proposal_space
 
 Revision ID: 71f961809275
@@ -15,7 +17,12 @@ from alembic import op
 
 
 def upgrade():
-    op.add_column('proposal_space', sa.Column('checkin_team_id', sa.Integer(), sa.ForeignKey('team.id'), nullable=True))
+    op.add_column(
+        'proposal_space',
+        sa.Column(
+            'checkin_team_id', sa.Integer(), sa.ForeignKey('team.id'), nullable=True
+        ),
+    )
 
 
 def downgrade():

--- a/migrations/versions/752dee4ae101_remove_unused_proposal_data.py
+++ b/migrations/versions/752dee4ae101_remove_unused_proposal_data.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Remove unused proposal.data
 
 Revision ID: 752dee4ae101
@@ -21,9 +23,13 @@ def upgrade():
 
 
 def downgrade():
-    op.add_column('proposal', sa.Column(
-        'data',
-        JsonDict(),
-        server_default=sa.text("'{}'"),
-        autoincrement=False,
-        nullable=False))
+    op.add_column(
+        'proposal',
+        sa.Column(
+            'data',
+            JsonDict(),
+            server_default=sa.text("'{}'"),
+            autoincrement=False,
+            nullable=False,
+        ),
+    )

--- a/migrations/versions/7cd383925de_subspaces.py
+++ b/migrations/versions/7cd383925de_subspaces.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Subspaces
 
 Revision ID: 7cd383925de
@@ -15,11 +17,20 @@ from alembic import op
 
 
 def upgrade():
-    op.add_column('proposal_space', sa.Column('parent_space_id', sa.Integer(), nullable=True))
-    op.create_foreign_key('proposal_space_proposal_space_id_fkey',
-        'proposal_space', 'proposal_space', ['parent_space_id'], ['id'])
+    op.add_column(
+        'proposal_space', sa.Column('parent_space_id', sa.Integer(), nullable=True)
+    )
+    op.create_foreign_key(
+        'proposal_space_proposal_space_id_fkey',
+        'proposal_space',
+        'proposal_space',
+        ['parent_space_id'],
+        ['id'],
+    )
 
 
 def downgrade():
-    op.drop_constraint('proposal_space_proposal_space_id_fkey', 'proposal_space', type_='foreignkey')
+    op.drop_constraint(
+        'proposal_space_proposal_space_id_fkey', 'proposal_space', type_='foreignkey'
+    )
     op.drop_column('proposal_space', 'parent_space_id')

--- a/migrations/versions/90cc904ece17_add_badge_template_to_event.py
+++ b/migrations/versions/90cc904ece17_add_badge_template_to_event.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """add_badge_template_to_event
 
 Revision ID: 90cc904ece17
@@ -15,7 +17,9 @@ from alembic import op
 
 
 def upgrade():
-    op.add_column('event', sa.Column('badge_template', sa.Unicode(length=250), nullable=True))
+    op.add_column(
+        'event', sa.Column('badge_template', sa.Unicode(length=250), nullable=True)
+    )
 
 
 def downgrade():

--- a/migrations/versions/94ce3a9b7a3a_draft_model.py
+++ b/migrations/versions/94ce3a9b7a3a_draft_model.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """draft model
 
 Revision ID: 94ce3a9b7a3a
@@ -17,15 +19,16 @@ from coaster.sqlalchemy.columns import JsonDict
 
 
 def upgrade():
-    op.create_table('draft',
+    op.create_table(
+        'draft',
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
         sa.Column('table', sa.UnicodeText(), nullable=False),
         sa.Column('table_row_id', UUIDType(binary=False), nullable=False),
         sa.Column('body', JsonDict(), server_default='{}', nullable=False),
         sa.Column('revision', UUIDType(binary=False), nullable=True),
-        sa.PrimaryKeyConstraint('table', 'table_row_id')
-        )
+        sa.PrimaryKeyConstraint('table', 'table_row_id'),
+    )
 
 
 def downgrade():

--- a/migrations/versions/9a0d8fa7da29_project_location.py
+++ b/migrations/versions/9a0d8fa7da29_project_location.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """project location
 
 Revision ID: 9a0d8fa7da29
@@ -16,18 +18,29 @@ from coaster.sqlalchemy import JsonDict
 
 
 def upgrade():
-    op.create_table('project_location',
+    op.create_table(
+        'project_location',
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
         sa.Column('project_id', sa.Integer(), nullable=False),
         sa.Column('geonameid', sa.Integer(), nullable=False),
         sa.Column('primary', sa.Boolean(), nullable=False),
-        sa.ForeignKeyConstraint(['project_id'], ['project.id'], ),
-        sa.PrimaryKeyConstraint('project_id', 'geonameid')
-        )
-    op.create_index(op.f('ix_project_location_geonameid'), 'project_location', ['geonameid'], unique=False)
-    op.add_column(u'project', sa.Column('location', sa.Unicode(length=50), nullable=True))
-    op.add_column(u'project', sa.Column('parsed_location', JsonDict(), server_default='{}', nullable=False))
+        sa.ForeignKeyConstraint(['project_id'], ['project.id']),
+        sa.PrimaryKeyConstraint('project_id', 'geonameid'),
+    )
+    op.create_index(
+        op.f('ix_project_location_geonameid'),
+        'project_location',
+        ['geonameid'],
+        unique=False,
+    )
+    op.add_column(
+        u'project', sa.Column('location', sa.Unicode(length=50), nullable=True)
+    )
+    op.add_column(
+        u'project',
+        sa.Column('parsed_location', JsonDict(), server_default='{}', nullable=False),
+    )
 
 
 def downgrade():

--- a/migrations/versions/9aa60ff2a0ea_migrate_to_urltype.py
+++ b/migrations/versions/9aa60ff2a0ea_migrate_to_urltype.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """migrate to urltype
 
 Revision ID: 9aa60ff2a0ea
@@ -17,26 +19,66 @@ from coaster.sqlalchemy import UrlType
 
 
 def upgrade():
-    op.alter_column('profile', 'logo_url', existing_type=sa.Unicode(2000), type_=UrlType())
-    op.alter_column('project', 'website', existing_type=sa.Unicode(2000), type_=UrlType())
-    op.alter_column('project', 'bg_image', existing_type=sa.Unicode(2000), type_=UrlType())
-    op.alter_column('project', 'explore_url', existing_type=sa.Unicode(2000), type_=UrlType())
-    op.alter_column('project', 'buy_tickets_url', existing_type=sa.Unicode(2000), type_=UrlType())
-    op.alter_column('project', 'banner_video_url', existing_type=sa.Unicode(2000), type_=UrlType())
-    op.alter_column('project', 'hasjob_embed_url', existing_type=sa.Unicode(2000), type_=UrlType())
-    op.alter_column('proposal', 'slides', existing_type=sa.Unicode(2000), type_=UrlType())
-    op.alter_column('proposal', 'preview_video', existing_type=sa.Unicode(2000), type_=UrlType())
-    op.alter_column('session', 'banner_image_url', existing_type=sa.Unicode(2000), type_=UrlType())
+    op.alter_column(
+        'profile', 'logo_url', existing_type=sa.Unicode(2000), type_=UrlType()
+    )
+    op.alter_column(
+        'project', 'website', existing_type=sa.Unicode(2000), type_=UrlType()
+    )
+    op.alter_column(
+        'project', 'bg_image', existing_type=sa.Unicode(2000), type_=UrlType()
+    )
+    op.alter_column(
+        'project', 'explore_url', existing_type=sa.Unicode(2000), type_=UrlType()
+    )
+    op.alter_column(
+        'project', 'buy_tickets_url', existing_type=sa.Unicode(2000), type_=UrlType()
+    )
+    op.alter_column(
+        'project', 'banner_video_url', existing_type=sa.Unicode(2000), type_=UrlType()
+    )
+    op.alter_column(
+        'project', 'hasjob_embed_url', existing_type=sa.Unicode(2000), type_=UrlType()
+    )
+    op.alter_column(
+        'proposal', 'slides', existing_type=sa.Unicode(2000), type_=UrlType()
+    )
+    op.alter_column(
+        'proposal', 'preview_video', existing_type=sa.Unicode(2000), type_=UrlType()
+    )
+    op.alter_column(
+        'session', 'banner_image_url', existing_type=sa.Unicode(2000), type_=UrlType()
+    )
 
 
 def downgrade():
-    op.alter_column('profile', 'logo_url', existing_type=UrlType(), type_=sa.Unicode(2000))
-    op.alter_column('project', 'website', existing_type=UrlType(), type_=sa.Unicode(2000))
-    op.alter_column('project', 'bg_image', existing_type=UrlType(), type_=sa.Unicode(2000))
-    op.alter_column('project', 'explore_url', existing_type=UrlType(), type_=sa.Unicode(2000))
-    op.alter_column('project', 'buy_tickets_url', existing_type=UrlType(), type_=sa.Unicode(2000))
-    op.alter_column('project', 'banner_video_url', existing_type=UrlType(), type_=sa.Unicode(2000))
-    op.alter_column('project', 'hasjob_embed_url', existing_type=UrlType(), type_=sa.Unicode(2000))
-    op.alter_column('proposal', 'slides', existing_type=UrlType(), type_=sa.Unicode(2000))
-    op.alter_column('proposal', 'preview_video', existing_type=UrlType(), type_=sa.Unicode(2000))
-    op.alter_column('session', 'banner_image_url', existing_type=UrlType(), type_=sa.Unicode(2000))
+    op.alter_column(
+        'profile', 'logo_url', existing_type=UrlType(), type_=sa.Unicode(2000)
+    )
+    op.alter_column(
+        'project', 'website', existing_type=UrlType(), type_=sa.Unicode(2000)
+    )
+    op.alter_column(
+        'project', 'bg_image', existing_type=UrlType(), type_=sa.Unicode(2000)
+    )
+    op.alter_column(
+        'project', 'explore_url', existing_type=UrlType(), type_=sa.Unicode(2000)
+    )
+    op.alter_column(
+        'project', 'buy_tickets_url', existing_type=UrlType(), type_=sa.Unicode(2000)
+    )
+    op.alter_column(
+        'project', 'banner_video_url', existing_type=UrlType(), type_=sa.Unicode(2000)
+    )
+    op.alter_column(
+        'project', 'hasjob_embed_url', existing_type=UrlType(), type_=sa.Unicode(2000)
+    )
+    op.alter_column(
+        'proposal', 'slides', existing_type=UrlType(), type_=sa.Unicode(2000)
+    )
+    op.alter_column(
+        'proposal', 'preview_video', existing_type=UrlType(), type_=sa.Unicode(2000)
+    )
+    op.alter_column(
+        'session', 'banner_image_url', existing_type=UrlType(), type_=sa.Unicode(2000)
+    )

--- a/migrations/versions/9d513be1a96_markdown_column.py
+++ b/migrations/versions/9d513be1a96_markdown_column.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Migrations for using MarkdownComposite
 
 Revision ID: 9d513be1a96

--- a/migrations/versions/a2115fab4c4_proposal_fields_are_now_optional.py
+++ b/migrations/versions/a2115fab4c4_proposal_fields_are_now_optional.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Proposal fields are now optional
 
 Revision ID: a2115fab4c4
@@ -15,72 +17,77 @@ from alembic import op
 
 
 def upgrade():
-    op.alter_column('proposal', 'description_html',
-               existing_type=sa.TEXT(),
-               nullable=True)
-    op.alter_column('proposal', 'description_text',
-               existing_type=sa.TEXT(),
-               nullable=True)
-    op.alter_column('proposal', 'links',
-               existing_type=sa.TEXT(),
-               nullable=True)
-    op.alter_column('proposal', 'objective_html',
-               existing_type=sa.TEXT(),
-               nullable=True)
-    op.alter_column('proposal', 'objective_text',
-               existing_type=sa.TEXT(),
-               nullable=True)
-    op.alter_column('proposal', 'preview_video',
-               existing_type=sa.VARCHAR(length=250),
-               nullable=True)
-    op.alter_column('proposal', 'requirements_html',
-               existing_type=sa.TEXT(),
-               nullable=True)
-    op.alter_column('proposal', 'requirements_text',
-               existing_type=sa.TEXT(),
-               nullable=True)
-    op.alter_column('proposal', 'session_type',
-               existing_type=sa.VARCHAR(length=40),
-               nullable=True)
-    op.alter_column('proposal', 'slides',
-               existing_type=sa.VARCHAR(length=250),
-               nullable=True)
-    op.alter_column('proposal', 'technical_level',
-               existing_type=sa.VARCHAR(length=40),
-               nullable=True)
+    op.alter_column(
+        'proposal', 'description_html', existing_type=sa.TEXT(), nullable=True
+    )
+    op.alter_column(
+        'proposal', 'description_text', existing_type=sa.TEXT(), nullable=True
+    )
+    op.alter_column('proposal', 'links', existing_type=sa.TEXT(), nullable=True)
+    op.alter_column(
+        'proposal', 'objective_html', existing_type=sa.TEXT(), nullable=True
+    )
+    op.alter_column(
+        'proposal', 'objective_text', existing_type=sa.TEXT(), nullable=True
+    )
+    op.alter_column(
+        'proposal', 'preview_video', existing_type=sa.VARCHAR(length=250), nullable=True
+    )
+    op.alter_column(
+        'proposal', 'requirements_html', existing_type=sa.TEXT(), nullable=True
+    )
+    op.alter_column(
+        'proposal', 'requirements_text', existing_type=sa.TEXT(), nullable=True
+    )
+    op.alter_column(
+        'proposal', 'session_type', existing_type=sa.VARCHAR(length=40), nullable=True
+    )
+    op.alter_column(
+        'proposal', 'slides', existing_type=sa.VARCHAR(length=250), nullable=True
+    )
+    op.alter_column(
+        'proposal',
+        'technical_level',
+        existing_type=sa.VARCHAR(length=40),
+        nullable=True,
+    )
 
 
 def downgrade():
-    op.alter_column('proposal', 'technical_level',
-               existing_type=sa.VARCHAR(length=40),
-               nullable=False)
-    op.alter_column('proposal', 'slides',
-               existing_type=sa.VARCHAR(length=250),
-               nullable=False)
-    op.alter_column('proposal', 'session_type',
-               existing_type=sa.VARCHAR(length=40),
-               nullable=False)
-    op.alter_column('proposal', 'requirements_text',
-               existing_type=sa.TEXT(),
-               nullable=False)
-    op.alter_column('proposal', 'requirements_html',
-               existing_type=sa.TEXT(),
-               nullable=False)
-    op.alter_column('proposal', 'preview_video',
-               existing_type=sa.VARCHAR(length=250),
-               nullable=False)
-    op.alter_column('proposal', 'objective_text',
-               existing_type=sa.TEXT(),
-               nullable=False)
-    op.alter_column('proposal', 'objective_html',
-               existing_type=sa.TEXT(),
-               nullable=False)
-    op.alter_column('proposal', 'links',
-               existing_type=sa.TEXT(),
-               nullable=False)
-    op.alter_column('proposal', 'description_text',
-               existing_type=sa.TEXT(),
-               nullable=False)
-    op.alter_column('proposal', 'description_html',
-               existing_type=sa.TEXT(),
-               nullable=False)
+    op.alter_column(
+        'proposal',
+        'technical_level',
+        existing_type=sa.VARCHAR(length=40),
+        nullable=False,
+    )
+    op.alter_column(
+        'proposal', 'slides', existing_type=sa.VARCHAR(length=250), nullable=False
+    )
+    op.alter_column(
+        'proposal', 'session_type', existing_type=sa.VARCHAR(length=40), nullable=False
+    )
+    op.alter_column(
+        'proposal', 'requirements_text', existing_type=sa.TEXT(), nullable=False
+    )
+    op.alter_column(
+        'proposal', 'requirements_html', existing_type=sa.TEXT(), nullable=False
+    )
+    op.alter_column(
+        'proposal',
+        'preview_video',
+        existing_type=sa.VARCHAR(length=250),
+        nullable=False,
+    )
+    op.alter_column(
+        'proposal', 'objective_text', existing_type=sa.TEXT(), nullable=False
+    )
+    op.alter_column(
+        'proposal', 'objective_html', existing_type=sa.TEXT(), nullable=False
+    )
+    op.alter_column('proposal', 'links', existing_type=sa.TEXT(), nullable=False)
+    op.alter_column(
+        'proposal', 'description_text', existing_type=sa.TEXT(), nullable=False
+    )
+    op.alter_column(
+        'proposal', 'description_html', existing_type=sa.TEXT(), nullable=False
+    )

--- a/migrations/versions/a9cb0e1c52ed_uuid_fields_venue_room.py
+++ b/migrations/versions/a9cb0e1c52ed_uuid_fields_venue_room.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """uuid fields venue_room
 
 Revision ID: a9cb0e1c52ed
@@ -17,19 +19,22 @@ from alembic import op
 from sqlalchemy.sql import column, table
 from sqlalchemy_utils import UUIDType
 
-venue_room = table('venue_room',
-    column('id', sa.Integer()),
-    column('uuid', UUIDType(binary=False)),
-    )
+venue_room = table(
+    'venue_room', column('id', sa.Integer()), column('uuid', UUIDType(binary=False))
+)
 
 
 def upgrade():
     conn = op.get_bind()
 
-    op.add_column('venue_room', sa.Column('uuid', UUIDType(binary=False), nullable=True))
+    op.add_column(
+        'venue_room', sa.Column('uuid', UUIDType(binary=False), nullable=True)
+    )
     items = conn.execute(sa.select([venue_room.c.id]))
     for counter, item in enumerate(items):
-        conn.execute(sa.update(venue_room).where(venue_room.c.id == item.id).values(uuid=uuid4()))
+        conn.execute(
+            sa.update(venue_room).where(venue_room.c.id == item.id).values(uuid=uuid4())
+        )
     op.alter_column('venue_room', 'uuid', nullable=False)
     op.create_unique_constraint('venue_room_uuid_key', 'venue_room', ['uuid'])
 

--- a/migrations/versions/ae68621248af_primary_venue.py
+++ b/migrations/versions/ae68621248af_primary_venue.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Primary venue
 
 Revision ID: ae68621248af
@@ -15,19 +17,22 @@ from alembic import op
 
 
 def upgrade():
-    op.create_table('project_venue_primary',
+    op.create_table(
+        'project_venue_primary',
         sa.Column('project_id', sa.Integer(), nullable=False),
         sa.Column('venue_id', sa.Integer(), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=False),
         sa.Column('updated_at', sa.DateTime(), nullable=False),
         sa.ForeignKeyConstraint(['project_id'], ['project.id'], ondelete='CASCADE'),
         sa.ForeignKeyConstraint(['venue_id'], ['venue.id'], ondelete='CASCADE'),
-        sa.PrimaryKeyConstraint('project_id')
-        )
+        sa.PrimaryKeyConstraint('project_id'),
+    )
     # This SQL function prevents project.primary_venue from pointing to a venue
     # in another project. It does not prevent a venue from being moved to a
     # different project, thereby leaving the primary_venue record invalid.
-    op.execute(sa.DDL('''
+    op.execute(
+        sa.DDL(
+            '''
         CREATE FUNCTION project_venue_primary_validate() RETURNS TRIGGER AS $$
         DECLARE
             target RECORD;
@@ -44,18 +49,28 @@ def upgrade():
         CREATE TRIGGER project_venue_primary_trigger BEFORE INSERT OR UPDATE
         ON project_venue_primary
         FOR EACH ROW EXECUTE PROCEDURE project_venue_primary_validate();
-    '''))
-    op.execute(sa.DDL('''
+    '''
+        )
+    )
+    op.execute(
+        sa.DDL(
+            '''
         INSERT INTO project_venue_primary (project_id, venue_id, created_at, updated_at)
         SELECT DISTINCT ON (project_id) project_id, id, created_at, updated_at
         FROM venue
         ORDER BY project_id, created_at;
-    '''))
+    '''
+        )
+    )
 
 
 def downgrade():
-    op.execute(sa.DDL('''
+    op.execute(
+        sa.DDL(
+            '''
         DROP TRIGGER project_venue_primary_trigger ON project_venue_primary;
         DROP FUNCTION project_venue_primary_validate();
-    '''))
+    '''
+        )
+    )
     op.drop_table('project_venue_primary')

--- a/migrations/versions/b34aa62af7fc_uuid_columns_for_project_profile_user_team.py
+++ b/migrations/versions/b34aa62af7fc_uuid_columns_for_project_profile_user_team.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """UUID columns for Project, Profile, User, Team
 
 Revision ID: b34aa62af7fc
@@ -22,39 +24,46 @@ from progressbar import ProgressBar
 
 from coaster.utils import buid2uuid, uuid2buid
 
-project = table('project',
-    column('id', sa.Integer()),
-    column('uuid', UUIDType(binary=False)),
-    )
+project = table(
+    'project', column('id', sa.Integer()), column('uuid', UUIDType(binary=False))
+)
 
-profile = table('profile',
+profile = table(
+    'profile',
     column('id', sa.Integer()),
     column('uuid', UUIDType(binary=False)),
     column('userid', sa.String(22)),
-    )
+)
 
-user = table('user',
+user = table(
+    'user',
     column('id', sa.Integer()),
     column('uuid', UUIDType(binary=False)),
     column('userid', sa.String(22)),
-    )
+)
 
-team = table('team',
+team = table(
+    'team',
     column('id', sa.Integer()),
     column('uuid', UUIDType(binary=False)),
     column('userid', sa.String(22)),
-    )
+)
 
 
 def get_progressbar(label, maxval):
     return ProgressBar(
         maxval=maxval,
         widgets=[
-            label, ': ',
-            progressbar.widgets.Percentage(), ' ',
-            progressbar.widgets.Bar(), ' ',
-            progressbar.widgets.ETA(), ' '
-            ])
+            label,
+            ': ',
+            progressbar.widgets.Percentage(),
+            ' ',
+            progressbar.widgets.Bar(),
+            ' ',
+            progressbar.widgets.ETA(),
+            ' ',
+        ],
+    )
 
 
 def upgrade():
@@ -62,13 +71,14 @@ def upgrade():
 
     # --- Project
     op.add_column('project', sa.Column('uuid', UUIDType(binary=False), nullable=True))
-    count = conn.scalar(
-        sa.select([sa.func.count('*')]).select_from(project))
+    count = conn.scalar(sa.select([sa.func.count('*')]).select_from(project))
     progress = get_progressbar("Projects", count)
     progress.start()
     items = conn.execute(sa.select([project.c.id]))
     for counter, item in enumerate(items):
-        conn.execute(sa.update(project).where(project.c.id == item.id).values(uuid=uuid4()))
+        conn.execute(
+            sa.update(project).where(project.c.id == item.id).values(uuid=uuid4())
+        )
         progress.update(counter)
     progress.finish()
     op.alter_column('project', 'uuid', nullable=False)
@@ -76,13 +86,16 @@ def upgrade():
 
     # --- Profile
     op.add_column('profile', sa.Column('uuid', UUIDType(binary=False), nullable=True))
-    count = conn.scalar(
-        sa.select([sa.func.count('*')]).select_from(profile))
+    count = conn.scalar(sa.select([sa.func.count('*')]).select_from(profile))
     progress = get_progressbar("Profiles", count)
     progress.start()
     items = conn.execute(sa.select([profile.c.id, profile.c.userid]))
     for counter, item in enumerate(items):
-        conn.execute(sa.update(profile).where(profile.c.id == item.id).values(uuid=buid2uuid(item.userid)))
+        conn.execute(
+            sa.update(profile)
+            .where(profile.c.id == item.id)
+            .values(uuid=buid2uuid(item.userid))
+        )
         progress.update(counter)
     progress.finish()
     op.alter_column('profile', 'uuid', nullable=False)
@@ -92,13 +105,16 @@ def upgrade():
 
     # --- Team
     op.add_column('team', sa.Column('uuid', UUIDType(binary=False), nullable=True))
-    count = conn.scalar(
-        sa.select([sa.func.count('*')]).select_from(team))
+    count = conn.scalar(sa.select([sa.func.count('*')]).select_from(team))
     progress = get_progressbar("Teams", count)
     progress.start()
     items = conn.execute(sa.select([team.c.id, team.c.userid]))
     for counter, item in enumerate(items):
-        conn.execute(sa.update(team).where(team.c.id == item.id).values(uuid=buid2uuid(item.userid)))
+        conn.execute(
+            sa.update(team)
+            .where(team.c.id == item.id)
+            .values(uuid=buid2uuid(item.userid))
+        )
         progress.update(counter)
     progress.finish()
     op.alter_column('team', 'uuid', nullable=False)
@@ -108,13 +124,16 @@ def upgrade():
 
     # --- User
     op.add_column('user', sa.Column('uuid', UUIDType(binary=False), nullable=True))
-    count = conn.scalar(
-        sa.select([sa.func.count('*')]).select_from(user))
+    count = conn.scalar(sa.select([sa.func.count('*')]).select_from(user))
     progress = get_progressbar("Users", count)
     progress.start()
     items = conn.execute(sa.select([user.c.id, user.c.userid]))
     for counter, item in enumerate(items):
-        conn.execute(sa.update(user).where(user.c.id == item.id).values(uuid=buid2uuid(item.userid)))
+        conn.execute(
+            sa.update(user)
+            .where(user.c.id == item.id)
+            .values(uuid=buid2uuid(item.userid))
+        )
         progress.update(counter)
     progress.finish()
     op.alter_column('user', 'uuid', nullable=False)
@@ -129,13 +148,16 @@ def downgrade():
     # --- User
     op.add_column('user', sa.Column('userid', sa.String(22), nullable=True))
     op.create_unique_constraint('user_userid_key', 'user', ['userid'])
-    count = conn.scalar(
-        sa.select([sa.func.count('*')]).select_from(user))
+    count = conn.scalar(sa.select([sa.func.count('*')]).select_from(user))
     progress = get_progressbar("Users", count)
     progress.start()
     items = conn.execute(sa.select([user.c.id, user.c.uuid]))
     for counter, item in enumerate(items):
-        conn.execute(sa.update(user).where(user.c.id == item.id).values(userid=uuid2buid(item.uuid)))
+        conn.execute(
+            sa.update(user)
+            .where(user.c.id == item.id)
+            .values(userid=uuid2buid(item.uuid))
+        )
         progress.update(counter)
     progress.finish()
     op.alter_column('user', 'userid', nullable=False)
@@ -145,13 +167,16 @@ def downgrade():
     # --- Team
     op.add_column('team', sa.Column('userid', sa.String(22), nullable=True))
     op.create_unique_constraint('team_userid_key', 'team', ['userid'])
-    count = conn.scalar(
-        sa.select([sa.func.count('*')]).select_from(team))
+    count = conn.scalar(sa.select([sa.func.count('*')]).select_from(team))
     progress = get_progressbar("Teams", count)
     progress.start()
     items = conn.execute(sa.select([team.c.id, team.c.uuid]))
     for counter, item in enumerate(items):
-        conn.execute(sa.update(team).where(team.c.id == item.id).values(userid=uuid2buid(item.uuid)))
+        conn.execute(
+            sa.update(team)
+            .where(team.c.id == item.id)
+            .values(userid=uuid2buid(item.uuid))
+        )
         progress.update(counter)
     progress.finish()
     op.alter_column('team', 'userid', nullable=False)
@@ -161,13 +186,16 @@ def downgrade():
     # --- Profile
     op.add_column('profile', sa.Column('userid', sa.String(22), nullable=True))
     op.create_unique_constraint('profile_userid_key', 'profile', ['userid'])
-    count = conn.scalar(
-        sa.select([sa.func.count('*')]).select_from(profile))
+    count = conn.scalar(sa.select([sa.func.count('*')]).select_from(profile))
     progress = get_progressbar("Profiles", count)
     progress.start()
     items = conn.execute(sa.select([profile.c.id, profile.c.uuid]))
     for counter, item in enumerate(items):
-        conn.execute(sa.update(profile).where(profile.c.id == item.id).values(userid=uuid2buid(item.uuid)))
+        conn.execute(
+            sa.update(profile)
+            .where(profile.c.id == item.id)
+            .values(userid=uuid2buid(item.uuid))
+        )
         progress.update(counter)
     progress.finish()
     op.alter_column('profile', 'userid', nullable=False)

--- a/migrations/versions/b553db89a76e_fix_column_settings.py
+++ b/migrations/versions/b553db89a76e_fix_column_settings.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Fix column settings
 
 Revision ID: b553db89a76e
@@ -17,12 +19,16 @@ from alembic import op
 def upgrade():
     op.alter_column('project', 'profile_id', existing_type=sa.INTEGER(), nullable=False)
     op.alter_column('project', 'inherit_sections', server_default=None)
-    op.alter_column('ticket_type', 'name', existing_type=sa.String(80), type_=sa.String(250))
+    op.alter_column(
+        'ticket_type', 'name', existing_type=sa.String(80), type_=sa.String(250)
+    )
     op.alter_column('event', 'name', existing_type=sa.String(80), type_=sa.String(250))
 
 
 def downgrade():
     op.alter_column('event', 'name', existing_type=sa.String(250), type_=sa.String(80))
-    op.alter_column('ticket_type', 'name', existing_type=sa.String(250), type_=sa.String(80))
+    op.alter_column(
+        'ticket_type', 'name', existing_type=sa.String(250), type_=sa.String(80)
+    )
     op.alter_column('project', 'inherit_sections', server_default=True)
     op.alter_column('project', 'profile_id', existing_type=sa.INTEGER(), nullable=True)

--- a/migrations/versions/b61a489d34a4_contactexchange_notes_and_metadata.py
+++ b/migrations/versions/b61a489d34a4_contactexchange_notes_and_metadata.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """ContactExchange notes and metadata
 
 Revision ID: b61a489d34a4
@@ -14,24 +16,38 @@ import sqlalchemy as sa  # NOQA
 from alembic import op
 from sqlalchemy.sql import column, table
 
-contact_exchange = table('contact_exchange',
+contact_exchange = table(
+    'contact_exchange',
     column('created_at', sa.TIMESTAMP(timezone=True)),
     column('scanned_at', sa.TIMESTAMP(timezone=True)),
-    )
+)
 
 
 def upgrade():
-    op.add_column('contact_exchange', sa.Column('archived', sa.Boolean(),
-        nullable=False, server_default=sa.sql.expression.false()))
+    op.add_column(
+        'contact_exchange',
+        sa.Column(
+            'archived',
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.sql.expression.false(),
+        ),
+    )
     op.alter_column('contact_exchange', 'archived', server_default=None)
 
-    op.add_column('contact_exchange', sa.Column('scanned_at', sa.TIMESTAMP(timezone=True),
-        nullable=True))
-    op.execute(contact_exchange.update().values({'scanned_at': contact_exchange.c.created_at}))
+    op.add_column(
+        'contact_exchange',
+        sa.Column('scanned_at', sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.execute(
+        contact_exchange.update().values({'scanned_at': contact_exchange.c.created_at})
+    )
     op.alter_column('contact_exchange', 'scanned_at', nullable=False)
 
-    op.add_column('contact_exchange', sa.Column('description', sa.UnicodeText(),
-        nullable=False, server_default=''))
+    op.add_column(
+        'contact_exchange',
+        sa.Column('description', sa.UnicodeText(), nullable=False, server_default=''),
+    )
     op.alter_column('contact_exchange', 'description', server_default=None)
 
 

--- a/migrations/versions/c3069d33419a_comment_uuid_field.py
+++ b/migrations/versions/c3069d33419a_comment_uuid_field.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """comment uuid field
 
 Revision ID: c3069d33419a
@@ -19,20 +21,25 @@ from sqlalchemy_utils import UUIDType
 import progressbar.widgets
 from progressbar import ProgressBar
 
-comment = table('comment',
-    column('id', sa.Integer()),
-    column('uuid', UUIDType(binary=False)),
-    )
+comment = table(
+    'comment', column('id', sa.Integer()), column('uuid', UUIDType(binary=False))
+)
 
 
 def get_progressbar(label, maxval):
-    return ProgressBar(maxval=maxval,
+    return ProgressBar(
+        maxval=maxval,
         widgets=[
-            label, ': ',
-            progressbar.widgets.Percentage(), ' ',
-            progressbar.widgets.Bar(), ' ',
-            progressbar.widgets.ETA(), ' '
-            ])
+            label,
+            ': ',
+            progressbar.widgets.Percentage(),
+            ' ',
+            progressbar.widgets.Bar(),
+            ' ',
+            progressbar.widgets.ETA(),
+            ' ',
+        ],
+    )
 
 
 def upgrade():
@@ -40,13 +47,14 @@ def upgrade():
 
     op.add_column('comment', sa.Column('uuid', UUIDType(binary=False), nullable=True))
 
-    count = conn.scalar(
-        sa.select([sa.func.count('*')]).select_from(comment))
+    count = conn.scalar(sa.select([sa.func.count('*')]).select_from(comment))
     progress = get_progressbar("Comments", count)
     progress.start()
     items = conn.execute(sa.select([comment.c.id]))
     for counter, item in enumerate(items):
-        conn.execute(sa.update(comment).where(comment.c.id == item.id).values(uuid=uuid4()))
+        conn.execute(
+            sa.update(comment).where(comment.c.id == item.id).values(uuid=uuid4())
+        )
         progress.update(counter)
     progress.finish()
     op.alter_column('comment', 'uuid', nullable=False)

--- a/migrations/versions/c38fa391613f_contact_exchange_model_change.py
+++ b/migrations/versions/c38fa391613f_contact_exchange_model_change.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Contact exchange model change
 
 Revision ID: c38fa391613f
@@ -16,43 +18,72 @@ from alembic import op
 
 def upgrade():
     # Remove duplicate entries before dropping the project_id column
-    op.execute(sa.DDL('''
+    op.execute(
+        sa.DDL(
+            '''
         DELETE FROM contact_exchange WHERE (user_id, project_id, participant_id) IN (
             SELECT user_id, project_id, participant_id
             FROM (SELECT user_id, project_id, participant_id, row_number()
                 OVER (partition by user_id, participant_id ORDER BY created_at)
                 FROM contact_exchange) AS duplicates
             WHERE row_number != 1);
-    '''))
+    '''
+        )
+    )
     # Index by participant id
-    op.create_index(op.f('ix_contact_exchange_participant_id'),
-        'contact_exchange', ['participant_id'], unique=False)
+    op.create_index(
+        op.f('ix_contact_exchange_participant_id'),
+        'contact_exchange',
+        ['participant_id'],
+        unique=False,
+    )
     # Drop the primary key
     op.drop_constraint('contact_exchange_pkey', 'contact_exchange', type_='primary')
     # Recreate primary key without project_id
-    op.create_primary_key('contact_exchange_pkey', 'contact_exchange',
-        ['user_id', 'participant_id'])
+    op.create_primary_key(
+        'contact_exchange_pkey', 'contact_exchange', ['user_id', 'participant_id']
+    )
     # Finally, drop the project_id foreign key constraint and then the column itself
-    op.drop_constraint('contact_exchange_project_id_fkey', 'contact_exchange', type_='foreignkey')
+    op.drop_constraint(
+        'contact_exchange_project_id_fkey', 'contact_exchange', type_='foreignkey'
+    )
     op.drop_column('contact_exchange', 'project_id')
 
 
 def downgrade():
     # Re-add project_id column and populate it from participant.project_id,
     # then make it a foreign key
-    op.add_column('contact_exchange',
-        sa.Column('project_id', sa.INTEGER(), autoincrement=False, nullable=True))
-    op.execute(sa.DDL('''
+    op.add_column(
+        'contact_exchange',
+        sa.Column('project_id', sa.INTEGER(), autoincrement=False, nullable=True),
+    )
+    op.execute(
+        sa.DDL(
+            '''
         UPDATE contact_exchange
         SET project_id = participant.project_id
         FROM participant
         WHERE contact_exchange.participant_id = participant.id
-        '''))
+        '''
+        )
+    )
     op.alter_column('contact_exchange', 'project_id', nullable=False)
-    op.create_foreign_key(u'contact_exchange_project_id_fkey', 'contact_exchange', 'project', ['project_id'], ['id'], ondelete=u'CASCADE')
+    op.create_foreign_key(
+        u'contact_exchange_project_id_fkey',
+        'contact_exchange',
+        'project',
+        ['project_id'],
+        ['id'],
+        ondelete=u'CASCADE',
+    )
     # Recreate primary key to include project id
     op.drop_constraint('contact_exchange_pkey', 'contact_exchange', type_='primary')
-    op.create_primary_key('contact_exchange_pkey', 'contact_exchange',
-        ['user_id', 'project_id', 'participant_id'])
+    op.create_primary_key(
+        'contact_exchange_pkey',
+        'contact_exchange',
+        ['user_id', 'project_id', 'participant_id'],
+    )
     # Drop the participant index we created in the upgrade
-    op.drop_index(op.f('ix_contact_exchange_participant_id'), table_name='contact_exchange')
+    op.drop_index(
+        op.f('ix_contact_exchange_participant_id'), table_name='contact_exchange'
+    )

--- a/migrations/versions/ccfad4d5e383_rename_proposalspace_to_project.py
+++ b/migrations/versions/ccfad4d5e383_rename_proposalspace_to_project.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Rename ProposalSpace to Project
 
 Revision ID: ccfad4d5e383
@@ -20,7 +22,7 @@ renamed_tables = [
     ('proposal_space_redirect', 'project_redirect'),
     ('proposal_space_section', 'section'),
     ('votespace', 'voteset'),
-    ]
+]
 
 # (old, new)
 renamed_sequences = [
@@ -28,7 +30,7 @@ renamed_sequences = [
     ('proposal_space_id_seq', 'project_id_seq'),
     ('proposal_space_section_id_seq', 'section_id_seq'),
     ('votespace_id_seq', 'voteset_id_seq'),
-    ]
+]
 
 # (table, old, new)
 renamed_columns = [
@@ -59,7 +61,7 @@ renamed_columns = [
     ('user_group', 'proposal_space_id', 'project_id'),
     ('venue', 'proposal_space_id', 'project_id'),
     ('vote', 'votespace_id', 'voteset_id'),
-    ]
+]
 
 # (table, old, new)
 renamed_constraints = [
@@ -67,12 +69,24 @@ renamed_constraints = [
     ('comment', 'comment_votes_id_fkey', 'comment_voteset_id_fkey'),
     ('comment', 'comment_status_check', 'comment_state_check'),
     ('commentset', 'commentspace_pkey', 'commentset_pkey'),
-    ('contact_exchange', 'contact_exchange_proposal_space_id_fkey', 'contact_exchange_project_id_fkey'),
+    (
+        'contact_exchange',
+        'contact_exchange_proposal_space_id_fkey',
+        'contact_exchange_project_id_fkey',
+    ),
     ('event', 'event_proposal_space_id_name_key', 'event_project_id_name_key'),
     ('event', 'event_proposal_space_id_title_key', 'event_project_id_title_key'),
     ('event', 'event_proposal_space_id_fkey', 'event_project_id_fkey'),
-    ('participant', 'participant_proposal_space_id_email_key', 'participant_project_id_email_key'),
-    ('participant', 'participant_proposal_space_id_fkey', 'participant_project_id_fkey'),
+    (
+        'participant',
+        'participant_proposal_space_id_email_key',
+        'participant_project_id_email_key',
+    ),
+    (
+        'participant',
+        'participant_proposal_space_id_fkey',
+        'participant_project_id_fkey',
+    ),
     ('project', 'proposal_space_name_check', 'project_name_check'),
     ('project', 'proposal_space_status_check', 'project_state_check'),
     ('project', 'proposal_space_legacy_name_key', 'project_legacy_name_key'),
@@ -87,36 +101,88 @@ renamed_constraints = [
     ('project', 'proposal_space_profile_id_fkey', 'project_profile_id_fkey'),
     ('project', 'proposal_space_user_id_fkey', 'project_user_id_fkey'),
     ('project_redirect', 'proposal_space_redirect_pkey', 'project_redirect_pkey'),
-    ('project_redirect', 'proposal_space_redirect_profile_id_fkey', 'project_redirect_profile_id_fkey'),
-    ('project_redirect', 'proposal_space_redirect_proposal_space_id_fkey', 'project_redirect_project_id_fkey'),
+    (
+        'project_redirect',
+        'proposal_space_redirect_profile_id_fkey',
+        'project_redirect_profile_id_fkey',
+    ),
+    (
+        'project_redirect',
+        'proposal_space_redirect_proposal_space_id_fkey',
+        'project_redirect_project_id_fkey',
+    ),
     ('proposal', 'proposal_status_check', 'proposal_state_check'),
-    ('proposal', 'proposal_proposal_space_id_url_id_key', 'proposal_project_id_url_id_key'),
+    (
+        'proposal',
+        'proposal_proposal_space_id_url_id_key',
+        'proposal_project_id_url_id_key',
+    ),
     ('proposal', 'proposal_proposal_space_id_fkey', 'proposal_project_id_fkey'),
     ('proposal', 'proposal_comments_id_fkey', 'proposal_commentset_id_fkey'),
     ('proposal', 'proposal_votes_id_fkey', 'proposal_voteset_id_fkey'),
-    ('proposal_redirect', 'proposal_redirect_proposal_space_id_fkey', 'proposal_redirect_project_id_fkey'),
+    (
+        'proposal_redirect',
+        'proposal_redirect_proposal_space_id_fkey',
+        'proposal_redirect_project_id_fkey',
+    ),
     ('rsvp', 'rsvp_status_check', 'rsvp_state_check'),
     ('rsvp', 'rsvp_proposal_space_id_fkey', 'rsvp_project_id_fkey'),
     ('section', 'proposal_space_section_name_check', 'section_name_check'),
     ('section', 'proposal_space_section_pkey', 'section_pkey'),
-    ('section', 'proposal_space_section_comments_id_fkey', 'section_commentset_id_fkey'),
-    ('section', 'proposal_space_section_proposal_space_id_fkey', 'section_project_id_fkey'),
-    ('section', 'proposal_space_section_proposal_space_id_name_key', 'section_project_id_name_key'),
+    (
+        'section',
+        'proposal_space_section_comments_id_fkey',
+        'section_commentset_id_fkey',
+    ),
+    (
+        'section',
+        'proposal_space_section_proposal_space_id_fkey',
+        'section_project_id_fkey',
+    ),
+    (
+        'section',
+        'proposal_space_section_proposal_space_id_name_key',
+        'section_project_id_name_key',
+    ),
     ('section', 'proposal_space_section_votes_id_fkey', 'section_voteset_id_fkey'),
-    ('session', 'session_proposal_space_id_url_id_key', 'session_project_id_url_id_key'),
+    (
+        'session',
+        'session_proposal_space_id_url_id_key',
+        'session_project_id_url_id_key',
+    ),
     ('session', 'session_proposal_space_id_fkey', 'session_project_id_fkey'),
-    ('ticket_client', 'ticket_client_proposal_space_id_fkey', 'ticket_client_project_id_fkey'),
-    ('ticket_type', 'ticket_type_proposal_space_id_name_key', 'ticket_type_project_id_name_key'),
-    ('ticket_type', 'ticket_type_proposal_space_id_title_key', 'ticket_type_project_id_title_key'),
-    ('ticket_type', 'ticket_type_proposal_space_id_fkey', 'ticket_type_project_id_fkey'),
-    ('user_group', 'user_group_proposal_space_id_name_key', 'user_group_project_id_name_key'),
+    (
+        'ticket_client',
+        'ticket_client_proposal_space_id_fkey',
+        'ticket_client_project_id_fkey',
+    ),
+    (
+        'ticket_type',
+        'ticket_type_proposal_space_id_name_key',
+        'ticket_type_project_id_name_key',
+    ),
+    (
+        'ticket_type',
+        'ticket_type_proposal_space_id_title_key',
+        'ticket_type_project_id_title_key',
+    ),
+    (
+        'ticket_type',
+        'ticket_type_proposal_space_id_fkey',
+        'ticket_type_project_id_fkey',
+    ),
+    (
+        'user_group',
+        'user_group_proposal_space_id_name_key',
+        'user_group_project_id_name_key',
+    ),
     ('user_group', 'user_group_proposal_space_id_fkey', 'user_group_project_id_fkey'),
     ('venue', 'venue_proposal_space_id_name_key', 'venue_project_id_name_key'),
     ('venue', 'venue_proposal_space_id_fkey', 'venue_project_id_fkey'),
     ('vote', 'vote_user_id_votespace_id_key', 'vote_user_id_voteset_id_key'),
     ('vote', 'vote_votespace_id_fkey', 'vote_voteset_id_fkey'),
     ('voteset', 'votespace_pkey', 'voteset_pkey'),
-    ]
+]
 
 
 def upgrade():
@@ -124,28 +190,40 @@ def upgrade():
         op.rename_table(old, new)
 
     for old, new in renamed_sequences:
-        op.execute(sa.DDL('ALTER SEQUENCE {old} RENAME TO {new}'.format(
-            old=old, new=new)))
+        op.execute(
+            sa.DDL('ALTER SEQUENCE {old} RENAME TO {new}'.format(old=old, new=new))
+        )
 
     for table, old, new in renamed_columns:
         op.alter_column(table, old, new_column_name=new)
 
     for table, old, new in renamed_constraints:
-        op.execute(sa.DDL('ALTER TABLE {table} RENAME CONSTRAINT {old} TO {new}'.format(
-            table=table, old=old, new=new)))
+        op.execute(
+            sa.DDL(
+                'ALTER TABLE {table} RENAME CONSTRAINT {old} TO {new}'.format(
+                    table=table, old=old, new=new
+                )
+            )
+        )
 
 
 def downgrade():
     for table, old, new in renamed_constraints:
-        op.execute(sa.DDL('ALTER TABLE {table} RENAME CONSTRAINT {new} TO {old}'.format(
-            table=table, old=old, new=new)))
+        op.execute(
+            sa.DDL(
+                'ALTER TABLE {table} RENAME CONSTRAINT {new} TO {old}'.format(
+                    table=table, old=old, new=new
+                )
+            )
+        )
 
     for table, old, new in renamed_columns:
         op.alter_column(table, new, new_column_name=old)
 
     for old, new in renamed_sequences:
-        op.execute(sa.DDL('ALTER SEQUENCE {new} RENAME TO {old}'.format(
-            old=old, new=new)))
+        op.execute(
+            sa.DDL('ALTER SEQUENCE {new} RENAME TO {old}'.format(old=old, new=new))
+        )
 
     for old, new in renamed_tables:
         op.rename_table(new, old)

--- a/migrations/versions/cd8d073d7557_sync_db_with_models.py
+++ b/migrations/versions/cd8d073d7557_sync_db_with_models.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Sync DB with models
 
 Revision ID: cd8d073d7557
@@ -15,24 +17,24 @@ from alembic import op
 
 
 def upgrade():
-    op.alter_column('event', 'title',
-               existing_type=sa.VARCHAR(length=250),
-               nullable=False)
-    op.alter_column('sync_ticket', 'ticket_client_id',
-               existing_type=sa.INTEGER(),
-               nullable=False)
-    op.alter_column('ticket_type', 'title',
-               existing_type=sa.VARCHAR(length=250),
-               nullable=False)
+    op.alter_column(
+        'event', 'title', existing_type=sa.VARCHAR(length=250), nullable=False
+    )
+    op.alter_column(
+        'sync_ticket', 'ticket_client_id', existing_type=sa.INTEGER(), nullable=False
+    )
+    op.alter_column(
+        'ticket_type', 'title', existing_type=sa.VARCHAR(length=250), nullable=False
+    )
 
 
 def downgrade():
-    op.alter_column('ticket_type', 'title',
-               existing_type=sa.VARCHAR(length=250),
-               nullable=True)
-    op.alter_column('sync_ticket', 'ticket_client_id',
-               existing_type=sa.INTEGER(),
-               nullable=True)
-    op.alter_column('event', 'title',
-               existing_type=sa.VARCHAR(length=250),
-               nullable=True)
+    op.alter_column(
+        'ticket_type', 'title', existing_type=sa.VARCHAR(length=250), nullable=True
+    )
+    op.alter_column(
+        'sync_ticket', 'ticket_client_id', existing_type=sa.INTEGER(), nullable=True
+    )
+    op.alter_column(
+        'event', 'title', existing_type=sa.VARCHAR(length=250), nullable=True
+    )

--- a/migrations/versions/cf775ffe502e_state_check_constraint.py
+++ b/migrations/versions/cf775ffe502e_state_check_constraint.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """state check constraint
 
 Revision ID: cf775ffe502e
@@ -18,44 +20,25 @@ def upgrade():
     op.create_check_constraint(
         'ck_proposal_state_valid',
         'proposal',
-        'status IN (10, 11, 7, 2, 1, 9, 0, 5, 3, 6, 8, 4)'
-        )
+        'status IN (10, 11, 7, 2, 1, 9, 0, 5, 3, 6, 8, 4)',
+    )
     op.create_check_constraint(
-        'ck_comment_state_valid',
-        'comment',
-        'status IN (3, 4, 1, 2, 0)'
-        )
+        'ck_comment_state_valid', 'comment', 'status IN (3, 4, 1, 2, 0)'
+    )
     # rsvp status field already has a constraint, dropping it and creating a new one
-    op.drop_constraint(
-        'rsvp_status_check',
-        'rsvp'
-        )
+    op.drop_constraint('rsvp_status_check', 'rsvp')
     op.create_check_constraint(
-        'ck_rsvp_state_valid',
-        'rsvp',
-        "status IN ('A', 'M', 'N', 'Y')"
-        )
+        'ck_rsvp_state_valid', 'rsvp', "status IN ('A', 'M', 'N', 'Y')"
+    )
     op.create_check_constraint(
         'ck_proposal_space_state_valid',
         'proposal_space',
-        'status IN (3, 4, 0, 5, 2, 1, 6)'
-        )
+        'status IN (3, 4, 0, 5, 2, 1, 6)',
+    )
 
 
 def downgrade():
-    op.drop_constraint(
-        'ck_proposal_state_valid',
-        'proposal'
-        )
-    op.drop_constraint(
-        'ck_comment_state_valid',
-        'comment'
-        )
-    op.drop_constraint(
-        'ck_rsvp_state_valid',
-        'rsvp'
-        )
-    op.drop_constraint(
-        'ck_proposal_space_state_valid',
-        'proposal_space'
-        )
+    op.drop_constraint('ck_proposal_state_valid', 'proposal')
+    op.drop_constraint('ck_comment_state_valid', 'comment')
+    op.drop_constraint('ck_rsvp_state_valid', 'rsvp')
+    op.drop_constraint('ck_proposal_space_state_valid', 'proposal_space')

--- a/migrations/versions/d576f55f9eba_proposal_instructions.py
+++ b/migrations/versions/d576f55f9eba_proposal_instructions.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """proposal instructions
 
 Revision ID: d576f55f9eba
@@ -15,8 +17,14 @@ from alembic import op
 
 
 def upgrade():
-    op.add_column('proposal_space', sa.Column('instructions_html', sa.UnicodeText(), nullable=True))
-    op.add_column('proposal_space', sa.Column('instructions_text', sa.UnicodeText(), nullable=True))
+    op.add_column(
+        'proposal_space',
+        sa.Column('instructions_html', sa.UnicodeText(), nullable=True),
+    )
+    op.add_column(
+        'proposal_space',
+        sa.Column('instructions_text', sa.UnicodeText(), nullable=True),
+    )
 
 
 def downgrade():

--- a/migrations/versions/d62b392b0f25_session_start_end_nullable.py
+++ b/migrations/versions/d62b392b0f25_session_start_end_nullable.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """session's start end fields are nullable
 
 Revision ID: d62b392b0f25
@@ -16,13 +18,24 @@ from sqlalchemy.dialects import postgresql
 
 
 def upgrade():
-    op.alter_column('session', 'end', existing_type=postgresql.TIMESTAMP(), nullable=True)
-    op.alter_column('session', 'start', existing_type=postgresql.TIMESTAMP(), nullable=True)
-    op.create_check_constraint(u'session_start_end_check', 'session',
-        u'("start" IS NULL AND "end" IS NULL) OR ("start" IS NOT NULL AND "end" IS NOT NULL)')
+    op.alter_column(
+        'session', 'end', existing_type=postgresql.TIMESTAMP(), nullable=True
+    )
+    op.alter_column(
+        'session', 'start', existing_type=postgresql.TIMESTAMP(), nullable=True
+    )
+    op.create_check_constraint(
+        u'session_start_end_check',
+        'session',
+        u'("start" IS NULL AND "end" IS NULL) OR ("start" IS NOT NULL AND "end" IS NOT NULL)',
+    )
 
 
 def downgrade():
     op.drop_constraint(u'session_start_end_check', 'session')
-    op.alter_column('session', 'start', existing_type=postgresql.TIMESTAMP(), nullable=False)
-    op.alter_column('session', 'end', existing_type=postgresql.TIMESTAMP(), nullable=False)
+    op.alter_column(
+        'session', 'start', existing_type=postgresql.TIMESTAMP(), nullable=False
+    )
+    op.alter_column(
+        'session', 'end', existing_type=postgresql.TIMESTAMP(), nullable=False
+    )

--- a/migrations/versions/d6b1904bea0e_add_session_featured_field.py
+++ b/migrations/versions/d6b1904bea0e_add_session_featured_field.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """add session featured field
 
 Revision ID: d6b1904bea0e
@@ -14,7 +16,15 @@ from alembic import op
 
 
 def upgrade():
-    op.add_column('session', sa.Column('featured', sa.Boolean(), nullable=False, server_default=sa.sql.expression.false()))
+    op.add_column(
+        'session',
+        sa.Column(
+            'featured',
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.sql.expression.false(),
+        ),
+    )
     op.alter_column('session', 'featured', server_default=None)
 
 

--- a/migrations/versions/e2be4ab896d3_migrate_old_labels.py
+++ b/migrations/versions/e2be4ab896d3_migrate_old_labels.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """migrate old labels
 
 Revision ID: e2be4ab896d3
@@ -14,30 +16,30 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql import column, table
 
-proposal = table('proposal',
+proposal = table(
+    'proposal',
     column('id', sa.Integer()),
     column('project_id', sa.Integer()),
     column('technical_level', sa.Unicode(40)),
     column('session_type', sa.Unicode(40)),
     column('section_id', sa.Integer()),
-    )
+)
 
-project = table('project',
-    column('id', sa.Integer()),
-    column('name', sa.Unicode(250))
-    )
+project = table('project', column('id', sa.Integer()), column('name', sa.Unicode(250)))
 
-section = table('section',
+section = table(
+    'section',
     column('id', sa.Integer()),
     column('project_id', sa.Integer()),
     column('name', sa.Unicode(250)),
     column('title', sa.Unicode(250)),
     column('description', sa.UnicodeText()),
     column('created_at', sa.DateTime()),
-    column('updated_at', sa.DateTime())
-    )
+    column('updated_at', sa.DateTime()),
+)
 
-label = table('label',
+label = table(
+    'label',
     column('id', sa.Integer()),
     column('name', sa.Unicode(250)),
     column('title', sa.Unicode(250)),
@@ -50,14 +52,15 @@ label = table('label',
     column('required', sa.Boolean()),
     column('archived', sa.Boolean()),
     column('created_at', sa.DateTime()),
-    column('updated_at', sa.DateTime())
-    )
+    column('updated_at', sa.DateTime()),
+)
 
-proposal_label = table('proposal_label',
+proposal_label = table(
+    'proposal_label',
     column('proposal_id', sa.Integer()),
     column('label_id', sa.Integer()),
-    column('created_at', sa.DateTime())
-    )
+    column('created_at', sa.DateTime()),
+)
 
 
 def upgrade():
@@ -66,89 +69,210 @@ def upgrade():
     projects = conn.execute(project.select())
     for proj in projects:
         sec_count = conn.scalar(
-            sa.select([sa.func.count('*')]).select_from(section).where(section.c.project_id == proj['id'])
-            )
+            sa.select([sa.func.count('*')])
+            .select_from(section)
+            .where(section.c.project_id == proj['id'])
+        )
         if sec_count > 0:
             # the project has some sections
             # create section labelset for the project
-            sections_label = conn.execute(label.insert().values({
-                'project_id': proj['id'], 'name': u"section", 'title': u"Section",
-                'seq': 1, 'description': u"", 'restricted': False, 'archived': False,
-                'required': True, 'created_at': sa.func.now(), 'updated_at': sa.func.now()
-                }).returning(label.c.id)).first()
+            sections_label = conn.execute(
+                label.insert()
+                .values(
+                    {
+                        'project_id': proj['id'],
+                        'name': u"section",
+                        'title': u"Section",
+                        'seq': 1,
+                        'description': u"",
+                        'restricted': False,
+                        'archived': False,
+                        'required': True,
+                        'created_at': sa.func.now(),
+                        'updated_at': sa.func.now(),
+                    }
+                )
+                .returning(label.c.id)
+            ).first()
 
-            sections = conn.execute(section.select().where(section.c.project_id == proj['id']))
+            sections = conn.execute(
+                section.select().where(section.c.project_id == proj['id'])
+            )
             for index, sec in enumerate(sections, start=1):
-                lab = conn.execute(label.insert().values({
-                    'main_label_id': sections_label[0],
-                    'project_id': proj['id'], 'name': sec['name'], 'title': sec['title'],
-                    'seq': index, 'description': u"", 'restricted': False, 'archived': False,
-                    'required': True, 'created_at': sa.func.now(), 'updated_at': sa.func.now()
-                    }).returning(label.c.id, label.c.name)).first()
+                lab = conn.execute(
+                    label.insert()
+                    .values(
+                        {
+                            'main_label_id': sections_label[0],
+                            'project_id': proj['id'],
+                            'name': sec['name'],
+                            'title': sec['title'],
+                            'seq': index,
+                            'description': u"",
+                            'restricted': False,
+                            'archived': False,
+                            'required': True,
+                            'created_at': sa.func.now(),
+                            'updated_at': sa.func.now(),
+                        }
+                    )
+                    .returning(label.c.id, label.c.name)
+                ).first()
 
                 # FIXME: This will miss proposals in a project linked to sections in another project
                 # -- an error condition resulting from proposals that have been moved around
                 proposals = conn.execute(
-                    proposal.select().where(proposal.c.section_id == sec['id']).where(proposal.c.project_id == sec['project_id'])
-                    )
+                    proposal.select()
+                    .where(proposal.c.section_id == sec['id'])
+                    .where(proposal.c.project_id == sec['project_id'])
+                )
                 for prop in proposals:
-                    conn.execute(proposal_label.insert().values({
-                        'proposal_id': prop['id'], 'label_id': lab['id'], 'created_at': sa.func.now()
-                        }))
+                    conn.execute(
+                        proposal_label.insert().values(
+                            {
+                                'proposal_id': prop['id'],
+                                'label_id': lab['id'],
+                                'created_at': sa.func.now(),
+                            }
+                        )
+                    )
 
         # technical level
-        techlevel_label = conn.execute(label.insert().values({
-            'project_id': proj['id'], 'name': u"technical-level", 'title': u"Technical level",
-            'seq': 2, 'description': u"", 'restricted': False, 'archived': False,
-            'required': True, 'created_at': sa.func.now(), 'updated_at': sa.func.now()
-            }).returning(label.c.id)).first()
-        tl_list = [(u'beginner', u"Beginner"), (u'intermediate', u"Intermediate"), (u'advanced', u"Advanced")]
+        techlevel_label = conn.execute(
+            label.insert()
+            .values(
+                {
+                    'project_id': proj['id'],
+                    'name': u"technical-level",
+                    'title': u"Technical level",
+                    'seq': 2,
+                    'description': u"",
+                    'restricted': False,
+                    'archived': False,
+                    'required': True,
+                    'created_at': sa.func.now(),
+                    'updated_at': sa.func.now(),
+                }
+            )
+            .returning(label.c.id)
+        ).first()
+        tl_list = [
+            (u'beginner', u"Beginner"),
+            (u'intermediate', u"Intermediate"),
+            (u'advanced', u"Advanced"),
+        ]
         for index, tl in enumerate(tl_list, start=1):
             tl_name, tl_title = tl
-            lab = conn.execute(label.insert().values({
-                'project_id': proj['id'], 'name': tl_name, 'title': tl_title, 'main_label_id': techlevel_label[0],
-                'seq': index, 'description': u"", 'restricted': False, 'archived': False,
-                'required': True, 'created_at': sa.func.now(), 'updated_at': sa.func.now()
-                }).returning(label.c.id, label.c.name)).first()
+            lab = conn.execute(
+                label.insert()
+                .values(
+                    {
+                        'project_id': proj['id'],
+                        'name': tl_name,
+                        'title': tl_title,
+                        'main_label_id': techlevel_label[0],
+                        'seq': index,
+                        'description': u"",
+                        'restricted': False,
+                        'archived': False,
+                        'required': True,
+                        'created_at': sa.func.now(),
+                        'updated_at': sa.func.now(),
+                    }
+                )
+                .returning(label.c.id, label.c.name)
+            ).first()
 
             proposals = conn.execute(
-                proposal.select().where(proposal.c.project_id == proj['id']).where(proposal.c.technical_level == tl_title)
-                )
+                proposal.select()
+                .where(proposal.c.project_id == proj['id'])
+                .where(proposal.c.technical_level == tl_title)
+            )
             for prop in proposals:
-                conn.execute(proposal_label.insert().values({
-                    'proposal_id': prop['id'], 'label_id': lab['id'], 'created_at': sa.func.now()
-                    }))
+                conn.execute(
+                    proposal_label.insert().values(
+                        {
+                            'proposal_id': prop['id'],
+                            'label_id': lab['id'],
+                            'created_at': sa.func.now(),
+                        }
+                    )
+                )
 
         # session type
-        sessiontype_label = conn.execute(label.insert().values({
-            'project_id': proj['id'], 'name': u"session-type", 'title': u"Session type",
-            'seq': 3, 'description': u"", 'restricted': False, 'archived': False,
-            'required': False, 'created_at': sa.func.now(), 'updated_at': sa.func.now()
-            }).returning(label.c.id)).first()
+        sessiontype_label = conn.execute(
+            label.insert()
+            .values(
+                {
+                    'project_id': proj['id'],
+                    'name': u"session-type",
+                    'title': u"Session type",
+                    'seq': 3,
+                    'description': u"",
+                    'restricted': False,
+                    'archived': False,
+                    'required': False,
+                    'created_at': sa.func.now(),
+                    'updated_at': sa.func.now(),
+                }
+            )
+            .returning(label.c.id)
+        ).first()
 
-        st_list = [(u'lecture', u"Lecture"), (u'demo', u"Demo"), (u'tutorial', u"Tutorial"),
-            (u'workshop', u"Workshop"), (u'discussion', u"Discussion"), (u'panel', u"Panel")]
+        st_list = [
+            (u'lecture', u"Lecture"),
+            (u'demo', u"Demo"),
+            (u'tutorial', u"Tutorial"),
+            (u'workshop', u"Workshop"),
+            (u'discussion', u"Discussion"),
+            (u'panel', u"Panel"),
+        ]
 
         for index, st in enumerate(st_list, start=1):
             st_name, st_title = st
             duplicate_count = conn.scalar(
-                sa.select([sa.func.count('*')]).select_from(label).where(label.c.name == st_name).where(label.c.project_id == proj['id'])
-                )
+                sa.select([sa.func.count('*')])
+                .select_from(label)
+                .where(label.c.name == st_name)
+                .where(label.c.project_id == proj['id'])
+            )
             if duplicate_count > 0:
                 st_name = st_name + "2"
-            lab = conn.execute(label.insert().values({
-                'project_id': proj['id'], 'name': st_name, 'title': st_title, 'main_label_id': sessiontype_label[0],
-                'seq': index, 'description': u"", 'restricted': False, 'archived': False,
-                'required': True, 'created_at': sa.func.now(), 'updated_at': sa.func.now()
-                }).returning(label.c.id, label.c.name)).first()
+            lab = conn.execute(
+                label.insert()
+                .values(
+                    {
+                        'project_id': proj['id'],
+                        'name': st_name,
+                        'title': st_title,
+                        'main_label_id': sessiontype_label[0],
+                        'seq': index,
+                        'description': u"",
+                        'restricted': False,
+                        'archived': False,
+                        'required': True,
+                        'created_at': sa.func.now(),
+                        'updated_at': sa.func.now(),
+                    }
+                )
+                .returning(label.c.id, label.c.name)
+            ).first()
 
             proposals = conn.execute(
-                proposal.select().where(proposal.c.project_id == proj['id']).where(proposal.c.session_type == st_title)
-                )
+                proposal.select()
+                .where(proposal.c.project_id == proj['id'])
+                .where(proposal.c.session_type == st_title)
+            )
             for prop in proposals:
-                conn.execute(proposal_label.insert().values({
-                    'proposal_id': prop['id'], 'label_id': lab['id'], 'created_at': sa.func.now()
-                    }))
+                conn.execute(
+                    proposal_label.insert().values(
+                        {
+                            'proposal_id': prop['id'],
+                            'label_id': lab['id'],
+                            'created_at': sa.func.now(),
+                        }
+                    )
+                )
 
 
 def downgrade():

--- a/migrations/versions/e3bf172763bc_use_timezone_type.py
+++ b/migrations/versions/e3bf172763bc_use_timezone_type.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Use timezone type
 
 Revision ID: e3bf172763bc
@@ -17,9 +19,17 @@ from sqlalchemy_utils import TimezoneType
 
 def upgrade():
     op.alter_column(
-        'project', 'timezone', existing_type=sa.Unicode(40), type_=TimezoneType(backend='pytz'))
+        'project',
+        'timezone',
+        existing_type=sa.Unicode(40),
+        type_=TimezoneType(backend='pytz'),
+    )
 
 
 def downgrade():
     op.alter_column(
-        'project', 'timezone', existing_type=TimezoneType(backend='pytz'), type_=sa.Unicode(40))
+        'project',
+        'timezone',
+        existing_type=TimezoneType(backend='pytz'),
+        type_=sa.Unicode(40),
+    )

--- a/migrations/versions/e417a13e136d_venue_venueroom_sequence.py
+++ b/migrations/versions/e417a13e136d_venue_venueroom_sequence.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """added sequence to venue and venue_room
 
 Revision ID: e417a13e136d
@@ -13,23 +15,23 @@ import sqlalchemy as sa  # NOQA
 from alembic import op
 from sqlalchemy.sql import column, table
 
-project = table('project',
-    column('id', sa.Integer())
-    )
+project = table('project', column('id', sa.Integer()))
 
-venue = table('venue',
+venue = table(
+    'venue',
     column('id', sa.Integer()),
     column('project_id', sa.Integer()),
     column('seq', sa.Integer()),
-    column('created_at', sa.DateTime())
-    )
+    column('created_at', sa.DateTime()),
+)
 
-venue_room = table('venue_room',
+venue_room = table(
+    'venue_room',
     column('id', sa.Integer()),
     column('venue_id', sa.Integer()),
     column('seq', sa.Integer()),
-    column('created_at', sa.DateTime())
-    )
+    column('created_at', sa.DateTime()),
+)
 
 
 def upgrade():
@@ -43,17 +45,31 @@ def upgrade():
     project_ids = [proj_tuple[0] for proj_tuple in projects]
 
     for project_id in project_ids:
-        venues = connection.execute(sa.select([venue.c.id]).where(venue.c.project_id == project_id).order_by('created_at'))
+        venues = connection.execute(
+            sa.select([venue.c.id])
+            .where(venue.c.project_id == project_id)
+            .order_by('created_at')
+        )
         venue_ids = [venue_tuple[0] for venue_tuple in venues]
         for idx, venue_id in enumerate(venue_ids):
-            op.execute(venue.update().where(venue.c.id == venue_id).values({'seq': idx + 1}))
+            op.execute(
+                venue.update().where(venue.c.id == venue_id).values({'seq': idx + 1})
+            )
 
             # update venue_room sequences
-            venue_rooms = connection.execute(sa.select([venue_room.c.id]).where(venue_room.c.venue_id == venue_id).order_by('created_at'))
+            venue_rooms = connection.execute(
+                sa.select([venue_room.c.id])
+                .where(venue_room.c.venue_id == venue_id)
+                .order_by('created_at')
+            )
             room_ids = [venue_room_tuple[0] for venue_room_tuple in venue_rooms]
 
             for idx2, room_id in enumerate(room_ids):
-                op.execute(venue_room.update().where(venue_room.c.id == room_id).values({'seq': idx2 + 1}))
+                op.execute(
+                    venue_room.update()
+                    .where(venue_room.c.id == room_id)
+                    .values({'seq': idx2 + 1})
+                )
 
     op.alter_column('venue', 'seq', existing_type=sa.Integer(), nullable=False)
     op.alter_column('venue_room', 'seq', existing_type=sa.Integer(), nullable=False)

--- a/migrations/versions/e679554261b2_main_label_index.py
+++ b/migrations/versions/e679554261b2_main_label_index.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Main label index
 
 Revision ID: e679554261b2
@@ -15,7 +17,9 @@ from alembic import op
 
 
 def upgrade():
-    op.create_index(op.f('ix_label_main_label_id'), 'label', ['main_label_id'], unique=False)
+    op.create_index(
+        op.f('ix_label_main_label_id'), 'label', ['main_label_id'], unique=False
+    )
 
 
 def downgrade():

--- a/migrations/versions/ea20c403b240_featured_project_flag.py
+++ b/migrations/versions/ea20c403b240_featured_project_flag.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Featured project flag
 
 Revision ID: ea20c403b240
@@ -15,8 +17,15 @@ from alembic import op
 
 
 def upgrade():
-    op.add_column('project', sa.Column('featured', sa.Boolean(),
-        nullable=False, server_default=sa.sql.expression.false()))
+    op.add_column(
+        'project',
+        sa.Column(
+            'featured',
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.sql.expression.false(),
+        ),
+    )
     op.alter_column('project', 'featured', server_default=None)
 
 

--- a/migrations/versions/eec2fad0f3e9_venue_uuid_field.py
+++ b/migrations/versions/eec2fad0f3e9_venue_uuid_field.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """venue uuid field
 
 Revision ID: eec2fad0f3e9
@@ -19,28 +21,32 @@ from sqlalchemy_utils import UUIDType
 import progressbar.widgets
 from progressbar import ProgressBar
 
-venue = table('venue',
-    column('id', sa.Integer()),
-    column('uuid', UUIDType(binary=False)),
-    )
+venue = table(
+    'venue', column('id', sa.Integer()), column('uuid', UUIDType(binary=False))
+)
 
 
 def get_progressbar(label, maxval):
-    return ProgressBar(maxval=maxval,
+    return ProgressBar(
+        maxval=maxval,
         widgets=[
-            label, ': ',
-            progressbar.widgets.Percentage(), ' ',
-            progressbar.widgets.Bar(), ' ',
-            progressbar.widgets.ETA(), ' '
-            ])
+            label,
+            ': ',
+            progressbar.widgets.Percentage(),
+            ' ',
+            progressbar.widgets.Bar(),
+            ' ',
+            progressbar.widgets.ETA(),
+            ' ',
+        ],
+    )
 
 
 def upgrade():
     conn = op.get_bind()
 
     op.add_column('venue', sa.Column('uuid', UUIDType(binary=False), nullable=True))
-    count = conn.scalar(
-        sa.select([sa.func.count('*')]).select_from(venue))
+    count = conn.scalar(sa.select([sa.func.count('*')]).select_from(venue))
     progress = get_progressbar("Venues", count)
     progress.start()
     items = conn.execute(sa.select([venue.c.id]))

--- a/migrations/versions/ef93d256a8cf_add_cascade_to_project_model_fks.py
+++ b/migrations/versions/ef93d256a8cf_add_cascade_to_project_model_fks.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """add cascade to project model fks
 
 Revision ID: ef93d256a8cf
@@ -15,29 +17,57 @@ from alembic import op
 
 def upgrade():
     op.drop_constraint('project_admin_team_id_fkey', 'project', type_='foreignkey')
-    op.create_foreign_key('project_admin_team_id_fkey',
-        'project', 'team', ['admin_team_id'], ['id'], ondelete='SET NULL')
+    op.create_foreign_key(
+        'project_admin_team_id_fkey',
+        'project',
+        'team',
+        ['admin_team_id'],
+        ['id'],
+        ondelete='SET NULL',
+    )
     op.drop_constraint('project_review_team_id_fkey', 'project', type_='foreignkey')
-    op.create_foreign_key('project_review_team_id_fkey',
-        'project', 'team', ['review_team_id'], ['id'], ondelete='SET NULL')
+    op.create_foreign_key(
+        'project_review_team_id_fkey',
+        'project',
+        'team',
+        ['review_team_id'],
+        ['id'],
+        ondelete='SET NULL',
+    )
     op.drop_constraint('project_checkin_team_id_fkey', 'project', type_='foreignkey')
-    op.create_foreign_key('project_checkin_team_id_fkey',
-        'project', 'team', ['checkin_team_id'], ['id'], ondelete='SET NULL')
+    op.create_foreign_key(
+        'project_checkin_team_id_fkey',
+        'project',
+        'team',
+        ['checkin_team_id'],
+        ['id'],
+        ondelete='SET NULL',
+    )
     op.drop_constraint('profile_admin_team_id_fkey', 'profile', type_='foreignkey')
-    op.create_foreign_key('profile_admin_team_id_fkey',
-        'profile', 'team', ['admin_team_id'], ['id'], ondelete='SET NULL')
+    op.create_foreign_key(
+        'profile_admin_team_id_fkey',
+        'profile',
+        'team',
+        ['admin_team_id'],
+        ['id'],
+        ondelete='SET NULL',
+    )
 
 
 def downgrade():
     op.drop_constraint('project_admin_team_id_fkey', 'project', type_='foreignkey')
-    op.create_foreign_key('project_admin_team_id_fkey',
-        'project', 'team', ['admin_team_id'], ['id'])
+    op.create_foreign_key(
+        'project_admin_team_id_fkey', 'project', 'team', ['admin_team_id'], ['id']
+    )
     op.drop_constraint('project_review_team_id_fkey', 'project', type_='foreignkey')
-    op.create_foreign_key('project_review_team_id_fkey',
-        'project', 'team', ['review_team_id'], ['id'])
+    op.create_foreign_key(
+        'project_review_team_id_fkey', 'project', 'team', ['review_team_id'], ['id']
+    )
     op.drop_constraint('project_checkin_team_id_fkey', 'project', type_='foreignkey')
-    op.create_foreign_key('project_checkin_team_id_fkey',
-        'project', 'team', ['checkin_team_id'], ['id'])
+    op.create_foreign_key(
+        'project_checkin_team_id_fkey', 'project', 'team', ['checkin_team_id'], ['id']
+    )
     op.drop_constraint('profile_admin_team_id_fkey', 'profile', type_='foreignkey')
-    op.create_foreign_key('profile_admin_team_id_fkey',
-        'profile', 'team', ['admin_team_id'], ['id'])
+    op.create_foreign_key(
+        'profile_admin_team_id_fkey', 'profile', 'team', ['admin_team_id'], ['id']
+    )

--- a/migrations/versions/f8204bcd438_move_content_into_description.py
+++ b/migrations/versions/f8204bcd438_move_content_into_description.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """Move content into description
 
 Revision ID: f8204bcd438
@@ -20,34 +22,50 @@ from coaster.sqlalchemy import JsonDict
 
 def upgrade():
     connection = op.get_bind()
-    proposal_space = table('proposal_space',
+    proposal_space = table(
+        'proposal_space',
         column(u'id', sa.INTEGER()),
         column(u'description_text', sa.TEXT()),
         column(u'description_html', sa.TEXT()),
-        column(u'content', JsonDict()))
+        column(u'content', JsonDict()),
+    )
 
     results = connection.execute(proposal_space.select())
     for space in results:
         if space['content']:
             for (section, title) in [
-                    ('format', u"Format"),
-                    ('criteria', u"Criteria for proposals"),
-                    ('panel', u"Editorial panel"),
-                    ('dates', u"Important dates"),
-                    ('open_source', u"Commitment to Open Source"),
-                    ('themes', u"Theme")
-                    ]:
+                ('format', u"Format"),
+                ('criteria', u"Criteria for proposals"),
+                ('panel', u"Editorial panel"),
+                ('dates', u"Important dates"),
+                ('open_source', u"Commitment to Open Source"),
+                ('themes', u"Theme"),
+            ]:
                 modified = False
                 text = space['description_text']
                 if space['content'].get(section):
                     modified = True
-                    text = text + '\r\n\r\n' + u"## " + title + '\r\n\r\n' + space['content'][section]
+                    text = (
+                        text
+                        + '\r\n\r\n'
+                        + u"## "
+                        + title
+                        + '\r\n\r\n'
+                        + space['content'][section]
+                    )
                 if modified:
                     html = markdown(text)
                     connection.execute(
-                        proposal_space.update().where(
-                            proposal_space.c.id == space['id']).values(
-                            {'description_text': text, 'description_html': html, 'content': {}}))
+                        proposal_space.update()
+                        .where(proposal_space.c.id == space['id'])
+                        .values(
+                            {
+                                'description_text': text,
+                                'description_html': html,
+                                'content': {},
+                            }
+                        )
+                    )
 
 
 def downgrade():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,19 @@ exclude = '''
   | funnel/assets
 )/
 '''
+
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+line_length = 88
+order_by_type = true
+use_parentheses = true
+known_future_library = ['six', 'future']
+known_first_party = ['coaster', 'baseframe', 'flask_lastuser', 'funnel']
+known_sqlalchemy = ['alembic', 'sqlalchemy', 'sqlalchemy_utils']
+known_flask = [
+  'flask', 'werkzeug', 'itsdangerous', 'wtforms',
+  'flask_flatpages', 'flask_mail', 'flask_migrate', 'flask_rq2'
+]
+default_section = 'THIRDPARTY'
+sections = ['FUTURE', 'STDLIB', 'SQLALCHEMY', 'FLASK', 'THIRDPARTY', 'FIRSTPARTY', 'LOCALFOLDER']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,19 +23,3 @@ exclude = '''
   | funnel/assets
 )/
 '''
-
-[tool.isort]
-multi_line_output = 3
-include_trailing_comma = true
-line_length = 88
-order_by_type = true
-use_parentheses = true
-known_future_library = ["six", "future"]
-known_first_party = ["coaster", "baseframe", "flask_lastuser", "funnel"]
-known_sqlalchemy = ["alembic", "sqlalchemy", "sqlalchemy_utils"]
-known_flask = [
-  "flask", "werkzeug", "itsdangerous", "wtforms",
-  "flask_flatpages", "flask_mail", "flask_migrate", "flask_rq2",
-]
-default_section = "THIRDPARTY"
-sections = ["FUTURE", "STDLIB", "SQLALCHEMY", "FLASK", "THIRDPARTY", "FIRSTPARTY", "LOCALFOLDER"]

--- a/rqinit.py
+++ b/rqinit.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from urlparse import urlparse
 
 from funnel import app

--- a/runfunnel.py
+++ b/runfunnel.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import sys
 

--- a/runserver.py
+++ b/runserver.py
@@ -1,4 +1,5 @@
 #! /usr/bin/env python
+# -*- coding: utf-8 -*-
 
 import sys
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,14 +1,25 @@
 # Config for tools that don't yet support pyproject.toml
 
-[nosetests]
-match=^test
-nocapture=1
-cover-package=funnel
-with-coverage=1
-cover-erase=1
-with-doctest=1
-
 [flake8]
-ignore = I100, I201, E501, E124, E128, E402, W503
+ignore = I100, I201, E501, E124, E128, E402, W503, D100, D101, D102, D103, D104, D107
 max-line-length = 88
 exclude = funnel/assets/node_modules
+enable-extensions = G
+accept-encodings = utf-8
+classmethod-decorators=classmethod, declared_attr
+
+[pydocstyle]
+ignore = D100, D101, D102, D103, D104, D107
+
+[isort]
+multi_line_output = 3
+include_trailing_comma = true
+line_length = 88
+order_by_type = true
+use_parentheses = true
+known_future_library = six, future
+known_first_party = coaster, baseframe, flask_lastuser, funnel
+known_sqlalchemy = alembic, sqlalchemy, sqlalchemy_utils
+known_flask = flask, werkzeug, itsdangerous, wtforms, flask_flatpages, flask_mail, flask_migrate, flask_rq2
+default_section = THIRDPARTY
+sections = FUTURE, STDLIB, SQLALCHEMY, FLASK, THIRDPARTY, FIRSTPARTY, LOCALFOLDER

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,16 +10,3 @@ classmethod-decorators=classmethod, declared_attr
 
 [pydocstyle]
 ignore = D100, D101, D102, D103, D104, D107
-
-[isort]
-multi_line_output = 3
-include_trailing_comma = true
-line_length = 88
-order_by_type = true
-use_parentheses = true
-known_future_library = six, future
-known_first_party = coaster, baseframe, flask_lastuser, funnel
-known_sqlalchemy = alembic, sqlalchemy, sqlalchemy_utils
-known_flask = flask, werkzeug, itsdangerous, wtforms, flask_flatpages, flask_mail, flask_migrate, flask_rq2
-default_section = THIRDPARTY
-sections = FUTURE, STDLIB, SQLALCHEMY, FLASK, THIRDPARTY, FIRSTPARTY, LOCALFOLDER

--- a/tests/event_models_fixtures.py
+++ b/tests/event_models_fixtures.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 from funnel.util import extract_twitter_handle
 
 event_ticket_types = [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+
 from flask import current_app
 
 from funnel.util import (

--- a/website.py
+++ b/website.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import os.path
 import sys
 


### PR DESCRIPTION
In addition:

* Migrations reformatted using `black`
* ~~`isort` config moved from `pyproject.toml` to `setup.cfg`, for compatibility with `pre-commit`~~
* ~~Stub `bandit` config to turn off spurious warnings from DeepSource~~
* Some reformatting and config for `pydocstyle`, which has been left out of requirements as it's not particularly relevant in an app

Todo:

* Update README to explain how to use `pre-commit`