### PR TITLE
Remove modal state from window.history

### DIFF
--- a/funnel/assets/js/project.js
+++ b/funnel/assets/js/project.js
@@ -138,7 +138,7 @@ const Ticketing = {
   },
 
   hideTicketModal() {
-    window.history.pushState(
+    window.history.replaceState(
       '',
       '',
       window.location.pathname + window.location.search

--- a/funnel/assets/js/schedule_view.js
+++ b/funnel/assets/js/schedule_view.js
@@ -94,20 +94,15 @@ const Schedule = {
           // On closing modal, update browser history
           $('#session-modal').on($.modal.CLOSE, () => {
             this.modalHtml = '';
-            window.history.pushState('', '', this.pageDetails.url);
+            window.history.replaceState('', '', this.pageDetails.url);
             this.updateMetaTags(this.pageDetails);
           });
           // Event listener for back key press since opening modal update browser history
           $(window).on('popstate', () => {
             if (this.modalHtml) {
               $.modal.close();
-            } else if (window.history.state) {
-              // Open the modal with previous session viewed
-              this.openModal(
-                window.history.state.html,
-                window.history.state.backPage,
-                window.history.state.pageDetails
-              );
+            } else if (!window.history.state) {
+              window.history.back(-1);
             }
           });
         },

--- a/funnel/assets/js/util.js
+++ b/funnel/assets/js/util.js
@@ -40,6 +40,13 @@ export const Utils = {
   smoothScroll() {
     $('a.js-smooth-scroll').on('click', function clickHandler(event) {
       event.preventDefault();
+      window.history.pushState(
+        {
+          openModal: true,
+        },
+        '',
+        $(this).attr('href')
+      );
       Utils.animateScrollTo($(this.hash).offset().top);
     });
   },

--- a/funnel/templates/project.html.jinja2
+++ b/funnel/templates/project.html.jinja2
@@ -101,9 +101,9 @@
         </div>
       </div>
     {%- endif %}
-    <div class="about__details" id="about">
+    <div class="about__details">
       <h2 class="mui--text-display1 mui--text-left about__details__headline">{% trans %}About{% endtrans %}</h2>
-      <div class="about__details__description">{{ project.description }}</div>
+      <div class="about__details__description" id="about">{{ project.description }}</div>
       {%- if project.subprojects %}
         <hr class="mui-divider">
         <h2 class="mui--text-display1 mui--text-left mui--text-bold">{% trans %}Related events{% endtrans %}</h2>


### PR DESCRIPTION
1. Fixes #550
2. On schedule page when a session modal is opened, it was added to browser history which caused user to cycle between schedule and popup on pressing device back button. Fixed this ny removing session popup from window history on exiting modal.