### PR TITLE
Add avatar_initials, remove unused name renderings

### DIFF
--- a/funnel/models/user.py
+++ b/funnel/models/user.py
@@ -241,6 +241,7 @@ class User(SharedProfileMixin, UuidMixin, BaseMixin, db.Model):
         else:
             return self.fullname
 
+    @with_roles(read={'all'})
     @property
     def initials(self):
         """

--- a/funnel/models/user.py
+++ b/funnel/models/user.py
@@ -231,15 +231,6 @@ class User(SharedProfileMixin, UuidMixin, BaseMixin, db.Model):
             username=self.username or self.buid, fullname=self.fullname
         )
 
-    def profileid(self):
-        if self.username:
-            return self.username
-        else:
-            return self.buid
-
-    def displayname(self):
-        return self.fullname or self.username or self.buid
-
     @with_roles(read={'all'})
     @property
     def pickername(self):
@@ -249,6 +240,16 @@ class User(SharedProfileMixin, UuidMixin, BaseMixin, db.Model):
             )
         else:
             return self.fullname
+
+    @property
+    def avatar_initials(self):
+        """
+        Return up to two initials from the user's fullname, for use as avatar stand-in.
+        """
+        # Combine using Zero Width Non Joiner (ZWNJ) to prevent ligature rendering
+        return '\u200c'.join(
+            word[0].upper() for word in self.fullname.split(maxsplit=1)
+        )
 
     def add_email(self, email, primary=False, type=None, private=False):  # NOQA: A002
         useremail = UserEmail(user=self, email=email, type=type, private=private)

--- a/funnel/models/user.py
+++ b/funnel/models/user.py
@@ -242,14 +242,12 @@ class User(SharedProfileMixin, UuidMixin, BaseMixin, db.Model):
             return self.fullname
 
     @property
-    def avatar_initials(self):
+    def initials(self):
         """
         Return up to two initials from the user's fullname, for use as avatar stand-in.
         """
         # Combine using Zero Width Non Joiner (ZWNJ) to prevent ligature rendering
-        return '\u200c'.join(
-            word[0].upper() for word in self.fullname.split(maxsplit=1)
-        )
+        return ''.join(word[0] for word in self.fullname.split(maxsplit=1) if word)
 
     def add_email(self, email, primary=False, type=None, private=False):  # NOQA: A002
         useremail = UserEmail(user=self, email=email, type=type, private=private)

--- a/funnel/templates/organization_index.html.jinja2
+++ b/funnel/templates/organization_index.html.jinja2
@@ -25,7 +25,7 @@
         <td data-th="Admins"><a href="{{ link }}" title="org.title">
           {%- for user in org.admin_users %}
             {%- if not loop.first %}, {% endif -%}
-            {{ user.displayname() }}
+            {{ user.pickername }}
           {%- endfor -%}
         </a></td>
       </tr>

--- a/tests/unit/lastuser_core/test_model_user_User.py
+++ b/tests/unit/lastuser_core/test_model_user_User.py
@@ -40,30 +40,6 @@ class TestUser(TestDatabaseFixture):
         batdog = self.fixtures.batdog
         self.assertFalse(crusoe.is_valid_name(batdog.name))
 
-    def test_user_profileid(self):
-        """
-        Test to verify profileid (same as username) if any
-        """
-        crusoe = self.fixtures.crusoe
-        # scenario 1: when username is given
-        self.assertEqual(crusoe.profileid(), crusoe.username)
-        # scenario 2: when username doesn't exist
-        mollie = models.User(fullname='Mollie')
-        self.assertEqual(len(mollie.profileid()), 22)
-
-    def test_user_displayname(self):
-        """
-        Test to verify any fullname or username or buid for displayname
-        """
-        crusoe = self.fixtures.crusoe
-        oakley = self.fixtures.oakley
-        self.assertEqual(crusoe.displayname(), crusoe.fullname)
-        self.assertEqual(oakley.displayname(), oakley.username)
-        lena = models.User()
-        db.session.add(lena)
-        db.session.commit()
-        self.assertEqual(lena.displayname(), lena.buid)
-
     def test_user_pickername(self):
         """
         Test to verify fullname and username (if any)


### PR DESCRIPTION
I've used ZWNJ to join the initials to prevent ligature rendering, but this may be a bad decision.