### PR TITLE
Log active user sessions to statsd

### DIFF
--- a/funnel/models/user_session.py
+++ b/funnel/models/user_session.py
@@ -105,7 +105,11 @@ class UserSession(UuidMixin, BaseMixin, db.Model):
             else:
                 self.ipaddr = request.remote_addr or ''
                 self.user_agent = str(request.user_agent.string[:250]) or ''
-        statsd.set('users.active_sessions', self.user.uuid_b58, rate=1)
+
+        # Use integer id instead of uuid_b58 here because statsd documentation is
+        # unclear on what data types a set accepts. Applies to both etsy's and telegraf.
+        statsd.set('users.active_sessions', self.id, rate=1)
+        statsd.set('users.active_users', self.user.id, rate=1)
 
     def user_agent_details(self):
         ua = user_agents.parse(self.user_agent)

--- a/funnel/models/user_session.py
+++ b/funnel/models/user_session.py
@@ -6,7 +6,7 @@ from flask import request
 
 import user_agents
 
-from baseframe import _
+from baseframe import _, statsd
 from coaster.utils import buid as make_buid
 from coaster.utils import utcnow
 
@@ -105,6 +105,7 @@ class UserSession(UuidMixin, BaseMixin, db.Model):
             else:
                 self.ipaddr = request.remote_addr or ''
                 self.user_agent = str(request.user_agent.string[:250]) or ''
+        statsd.set('users.active_sessions', self.user.uuid_b58, rate=1)
 
     def user_agent_details(self):
         ua = user_agents.parse(self.user_agent)

--- a/funnel/views/auth_resource.py
+++ b/funnel/views/auth_resource.py
@@ -411,12 +411,10 @@ def user_autocomplete():
     validate_rate_limit(
         # As this endpoint accepts client_id+user_session in lieu of login cookie,
         # we may not have an authenticatd user. Use the user_session's user in that case
-        'user_autocomplete/'
-        + (
-            current_auth.actor.uuid_b58
-            if current_auth.actor
-            else current_auth.session.user.uuid_b58
-        ),
+        'user_autocomplete',
+        current_auth.actor.uuid_b58
+        if current_auth.actor
+        else current_auth.session.user.uuid_b58,
         # Limit 20 attempts
         20,
         # Per half hour (60s * 30m = 1800s)

--- a/funnel/views/login.py
+++ b/funnel/views/login.py
@@ -110,12 +110,10 @@ def login():
             # The rate limit explicitly blocks successful validation, to discourage
             # password guessing.
             validate_rate_limit(
-                'login/'
-                + (
-                    ('user/' + loginform.user.uuid_b58)
-                    if loginform.user
-                    else ('username/' + loginform.username.data)
-                ),
+                'login',
+                ('user/' + loginform.user.uuid_b58)
+                if loginform.user
+                else ('username/' + loginform.username.data),
                 10,
                 3600,
             )
@@ -378,7 +376,7 @@ def reset():
                     ),
                 )
         # Allow only two reset attempts per hour to discourage abuse
-        validate_rate_limit('email_reset/' + user.uuid_b58, 2, 3600)
+        validate_rate_limit('email_reset', user.uuid_b58, 2, 3600)
         resetreq = AuthPasswordResetRequest(user=user)
         db.session.add(resetreq)
         send_password_reset_link(email=email, user=user, secret=resetreq.reset_code)


### PR DESCRIPTION
This call belongs in a view, not model. The `access` method has other view-like behaviour such as the reliance on `request` to retrieve IP address and user agent. These parts should also be moved out into a view, and perhaps made available at `user_session.views.access()` rather than `user_session.access()`