### PR TITLE
Fix login related flash messages on account page

### DIFF
--- a/funnel/assets/js/app.js
+++ b/funnel/assets/js/app.js
@@ -14,6 +14,7 @@ $(() => {
   Utils.collapse();
   Utils.smoothScroll();
   Utils.navSearchForm();
+  Utils.scrollTabs();
   Utils.truncate();
   Utils.showTimeOnCalendar();
 

--- a/funnel/templates/account.html.jinja2
+++ b/funnel/templates/account.html.jinja2
@@ -16,7 +16,7 @@
 {% block headline -%}
 {%- endblock %}
 
-{% block basecontentbox %}
+{% block basecontent %}
   <div class="tabs-wrapper tabs-wrapper--sticky">
     <div class="mui-container">
       <div class="grid">

--- a/funnel/templates/account_saved.html.jinja2
+++ b/funnel/templates/account_saved.html.jinja2
@@ -16,7 +16,7 @@
 {% block headline -%}
 {%- endblock %}
 
-{% block basecontentbox %}
+{% block basecontent %}
   <div class="tabs-wrapper tabs-wrapper--sticky">
     <div class="mui-container">
       <div class="grid">

--- a/funnel/templates/contacts.html.jinja2
+++ b/funnel/templates/contacts.html.jinja2
@@ -15,7 +15,7 @@
 {% block headline -%}
 {%- endblock %}
 
-{% block basecontentbox %}
+{% block basecontent %}
   <div class="tabs-wrapper tabs-wrapper--sticky">
     <div class="mui-container">
       <div class="grid">

--- a/funnel/templates/macros.html.jinja2
+++ b/funnel/templates/macros.html.jinja2
@@ -56,7 +56,7 @@
         <input type="hidden" name="save" value="">
         <button type="submit" value="true" class="mui-btn mui-btn--nostyle animate-btn {% if not project.is_saved_by(current_auth.user) %} animate-btn--show {% endif %}" data-action="Save {{project.title}}" onclick="this.form.save.value=this.value" data-cy="bookmark">{% if txt %}<span class="mui--text-body1 mui--text-light txt">{% trans %}Save <span class="mui--hidden-xs mui--hidden-sm">this project</span>{% endtrans %}</span>{% endif %}{{ faicon(icon='bookmark', baseline=false, css_class='mui--text-light') }}
         </button>
-        <button type="submit" value="false" class="mui-btn mui-btn--nostyle animate-btn animate-btn--saved{% if project.is_saved_by(current_auth.user) %} animate-btn--show {% endif %}" data-action="Unsave {{project.title}}" onclick="this.form.save.value=this.value" data-cy="bookmarked">{% if txt %}<span class="mui--text-body1 mui--text-light txt">{% trans %}Unsave <span class="mui--hidden-xs mui--hidden-sm">this project</span>{% endtrans %}</span>{% endif %}{{ faicon(icon='bookmark',  baseline=false, css_class='bookmarked') }}</button>
+        <button type="submit" value="false" class="mui-btn mui-btn--nostyle animate-btn animate-btn--saved{% if project.is_saved_by(current_auth.user) %} animate-btn--show {% endif %}" data-action="Unsave {{project.title}}" onclick="this.form.save.value=this.value" data-cy="bookmarked">{% if txt %}<span class="mui--text-body1 mui--text-light txt">{% trans %}Unsave <span class="mui--hidden-xs mui--hidden-sm">this project</span>{% endtrans %}</span>{% endif %}{{ faicon(icon='bookmark-solid',  baseline=false, css_class='bookmarked') }}</button>
       {%- endif %}
     </p>
   </form>
@@ -79,7 +79,7 @@
     {% endif %}
     <div class="mui-dropdown">
       <a href="javascript:void(0)" class="details__box__control__link mui--text-subhead share" data-mui-toggle="dropdown" data-action="Share dropdown" data-cy="share-project"><span class="mui--text-body1 mui--text-light txt">{% trans %}Share <span class="mui--hidden-xs mui--hidden-sm">this project</span>{% endtrans %}</span>{{ faicon(icon='share-square', icon_size='subhead', baseline=false, css_class='mui--text-light') }}</a>
-      {{ share_dropdown(url, title) }}
+      {{ share_dropdown(project.url_for(_external=true), project.title) }}
     </div>
   </div>
 {% endmacro %}

--- a/funnel/templates/scan_badge.html.jinja2
+++ b/funnel/templates/scan_badge.html.jinja2
@@ -16,7 +16,7 @@
 {% block headline -%}
 {%- endblock %}
 
-{% block basecontentbox %}
+{% block basecontent %}
   <div id="scan-badge-wrapper">
     {% raw %}
       <script id='scan-badge-template' type='text/ractive'>

--- a/funnel/templates/scan_contact.html.jinja2
+++ b/funnel/templates/scan_contact.html.jinja2
@@ -23,7 +23,7 @@
 {% block headline -%}
 {%- endblock %}
 
-{% block basecontentbox %}
+{% block basecontent %}
   <div class="tabs-wrapper tabs-wrapper--sticky">
     <div class="mui-container">
       <div class="grid">

--- a/funnel/templates/search.html.jinja2
+++ b/funnel/templates/search.html.jinja2
@@ -14,7 +14,7 @@
 {% block headline -%}
 {%- endblock %}
 
-{% block basecontentbox %}
+{% block basecontent %}
     <div class="js-lazyload-results">
       <div id="search-wrapper">
         {% raw %}


### PR DESCRIPTION
1. Use block `basecontent` from layout to include  block `messages`.
2. Tab scroll function call was included back that removed accidentally in a previous PR.
3. Fix share url and title. 
4. Change bookmark to solid icon