### PR TITLE
Abort null bytes

### DIFF
--- a/funnel/utils.py
+++ b/funnel/utils.py
@@ -3,7 +3,7 @@ import six
 import re
 import urllib.parse
 
-from flask import current_app
+from flask import current_app, abort
 
 import qrcode
 import qrcode.image.svg
@@ -19,10 +19,10 @@ PHONE_VALID_RE = re.compile(r'^\+[0-9]+$')
 # --- Utilities ---------------------------------------------------------------
 
 
-def strip_null(text):
+def abort_null(text):
     # Removes null byte from given text
-    if text is not None:
-        return text.replace('\x00', '')
+    if text is not None and '\x00' in text:
+        abort(400)
 
 
 def make_redirect_url(url, use_fragment=False, **params):

--- a/funnel/views/account.py
+++ b/funnel/views/account.py
@@ -44,7 +44,7 @@ from ..models import (
 )
 from ..registry import login_registry
 from ..signals import user_data_changed
-from ..utils import strip_null
+from ..utils import abort_null
 from .email import send_email_verify_link
 from .helpers import app_url_for, login_internal, logout_internal, requires_login
 from .sms import send_phone_verify_code
@@ -97,7 +97,7 @@ class AccountView(ClassView):
     @route('siteadmin/comments', endpoint='siteadmin_comments', methods=['GET', 'POST'])
     @requires_login
     @render_with('siteadmin_comments.html.jinja2')
-    @requestargs(('query', strip_null), ('page', int), ('per_page', int))
+    @requestargs(('query', abort_null), ('page', int), ('per_page', int))
     def siteadmin_comments(self, query='', page=None, per_page=100):
         if not (
             current_auth.user.is_comment_moderator

--- a/funnel/views/auth_oauth.py
+++ b/funnel/views/auth_oauth.py
@@ -16,7 +16,7 @@ from ..models import (
     getuser,
 )
 from ..registry import resource_registry
-from ..utils import make_redirect_url, strip_null
+from ..utils import make_redirect_url, abort_null
 from .auth_resource import get_userinfo
 from .helpers import requires_client_login, requires_login_no_message
 
@@ -442,17 +442,17 @@ def oauth_token():
     OAuth2 server -- token endpoint (confidential clients only)
     """
     # Always required parameters
-    grant_type = strip_null(request.form.get('grant_type'))
+    grant_type = abort_null(request.form.get('grant_type'))
     auth_client = current_auth.auth_client  # Provided by @requires_client_login
-    scope = strip_null(request.form.get('scope', '')).split(' ')
+    scope = abort_null(request.form.get('scope', '')).split(' ')
     # if grant_type == 'authorization_code' (POST)
-    code = strip_null(request.form.get('code'))
-    redirect_uri = strip_null(request.form.get('redirect_uri'))
+    code = abort_null(request.form.get('code'))
+    redirect_uri = abort_null(request.form.get('redirect_uri'))
     # if grant_type == 'password' (POST)
-    username = strip_null(request.form.get('username'))
-    password = strip_null(request.form.get('password'))
+    username = abort_null(request.form.get('username'))
+    password = abort_null(request.form.get('password'))
     # if grant_type == 'client_credentials'
-    buid = strip_null(
+    buid = abort_null(
         request.form.get('buid') or request.form.get('userid')
     )  # XXX: Deprecated userid parameter
 

--- a/funnel/views/auth_resource.py
+++ b/funnel/views/auth_resource.py
@@ -21,7 +21,7 @@ from ..models import (
     getuser,
 )
 from ..registry import resource_registry
-from ..utils import strip_null
+from ..utils import abort_null
 from .helpers import (
     requires_client_id_or_user_or_client_login,
     requires_client_login,
@@ -130,8 +130,8 @@ def api_result(status, _jsonp=False, **params):
 @lastuserapp.route('/api/1/token/verify', methods=['POST'])
 @requires_client_login
 def token_verify():
-    token = strip_null(request.form.get('access_token'))
-    client_resource = strip_null(
+    token = abort_null(request.form.get('access_token'))
+    client_resource = abort_null(
         request.form.get('resource')
     )  # Can only be a single resource
     if not client_resource:
@@ -185,7 +185,7 @@ def token_verify():
 @lastuserapp.route('/api/1/token/get_scope', methods=['POST'])
 @requires_client_login
 def token_get_scope():
-    token = strip_null(request.form.get('access_token'))
+    token = abort_null(request.form.get('access_token'))
     if not token:
         # No token specified by caller
         return resource_error('no_token')
@@ -238,7 +238,7 @@ def user_get_by_userid():
     """
     Returns user or organization with the given userid (Lastuser internal buid)
     """
-    buid = strip_null(request.values.get('userid'))
+    buid = abort_null(request.values.get('userid'))
     if not buid:
         return api_result('error', error='no_userid_provided')
     user = User.get(buid=buid, defercols=True)
@@ -277,7 +277,7 @@ def user_get_by_userid():
 @app.route('/api/1/user/get_by_userids', methods=['GET', 'POST'])
 @lastuserapp.route('/api/1/user/get_by_userids', methods=['GET', 'POST'])
 @requires_client_id_or_user_or_client_login
-@requestargs(('userid[]', strip_null))
+@requestargs(('userid[]', abort_null))
 def user_get_by_userids(userid):
     """
     Returns users and organizations with the given userids (Lastuser internal userid).
@@ -324,7 +324,7 @@ def user_get_by_userids(userid):
 @app.route('/api/1/user/get', methods=['GET', 'POST'])
 @lastuserapp.route('/api/1/user/get', methods=['GET', 'POST'])
 @requires_user_or_client_login
-@requestargs(('name', strip_null))
+@requestargs(('name', abort_null))
 def user_get(name):
     """
     Returns user with the given username, email address or Twitter id
@@ -353,7 +353,7 @@ def user_get(name):
 @app.route('/api/1/user/getusers', methods=['GET', 'POST'])
 @lastuserapp.route('/api/1/user/getusers', methods=['GET', 'POST'])
 @requires_user_or_client_login
-@requestargs(('name[]', strip_null))
+@requestargs(('name[]', abort_null))
 def user_getall(name):
     """
     Returns users with the given username, email address or Twitter id
@@ -394,7 +394,7 @@ def user_autocomplete():
     """
     Returns users (buid, username, fullname, twitter, github or email) matching the search term.
     """
-    q = strip_null(request.values.get('q', ''))
+    q = abort_null(request.values.get('q', ''))
     if not q:
         return api_result('error', error='no_query_provided')
     # Limit length of query to User.fullname limit
@@ -449,7 +449,7 @@ def user_autocomplete():
 
 @app.route('/api/1/login/beacon.html')
 @lastuserapp.route('/api/1/login/beacon.html')
-@requestargs(('client_id', strip_null), ('login_url', strip_null))
+@requestargs(('client_id', abort_null), ('login_url', abort_null))
 def login_beacon_iframe(client_id, login_url):
     cred = AuthClientCredential.get(client_id)
     auth_client = cred.auth_client if cred else None
@@ -471,7 +471,7 @@ def login_beacon_iframe(client_id, login_url):
 
 @app.route('/api/1/login/beacon.json')
 @lastuserapp.route('/api/1/login/beacon.json')
-@requestargs(('client_id', strip_null))
+@requestargs(('client_id', abort_null))
 def login_beacon_json(client_id):
     cred = AuthClientCredential.get(client_id)
     auth_client = cred.auth_client if cred else None
@@ -514,7 +514,7 @@ def resource_id(authtoken, args, files=None):
 @lastuserapp.route('/api/1/session/verify', methods=['POST'])
 @resource_registry.resource('session/verify', __("Verify user session"), scope='id')
 def session_verify(authtoken, args, files=None):
-    sessionid = strip_null(args['sessionid'])
+    sessionid = abort_null(args['sessionid'])
     session = UserSession.authenticate(buid=sessionid)
     if session and session.user == authtoken.user:
         session.access(auth_client=authtoken.auth_client)
@@ -538,7 +538,7 @@ def resource_avatar_edit(authtoken, args, files=None):
     """
     Set a user's avatar image
     """
-    avatar = strip_null(args['avatar'])
+    avatar = abort_null(args['avatar'])
     parsed = urlparse(avatar)
     if parsed.scheme == 'https' and parsed.netloc:
         # Accept any properly formatted URL.
@@ -592,7 +592,7 @@ def resource_login_providers(authtoken, args, files=None):
     """
     Return user's login providers' data.
     """
-    service = strip_null(args.get('service'))
+    service = abort_null(args.get('service'))
     response = {}
     for extid in authtoken.user.externalids:
         if service is None or extid.service == service:

--- a/funnel/views/contact.py
+++ b/funnel/views/contact.py
@@ -14,7 +14,7 @@ from coaster.views import ClassView, render_with, requestargs, route
 
 from .. import app, funnelapp
 from ..models import ContactExchange, Participant, Project, db
-from ..utils import format_twitter_handle, strip_null
+from ..utils import format_twitter_handle, abort_null
 from .helpers import app_url_for, requires_login
 
 
@@ -144,7 +144,7 @@ class ContactView(ClassView):
 
     @route('scan/connect', endpoint='scan_connect', methods=['POST'])
     @requires_login
-    @requestargs(('puk', strip_null), ('key', strip_null))
+    @requestargs(('puk', abort_null), ('key', abort_null))
     def connect(self, puk, key):
         """Scan verification"""
         participant = Participant.query.filter_by(puk=puk, key=key).first()

--- a/funnel/views/helpers.py
+++ b/funnel/views/helpers.py
@@ -30,7 +30,7 @@ from coaster.views import get_current_url
 from .. import app, funnelapp, lastuserapp, mail
 from ..models import AuthClientCredential, User, UserSession, db
 from ..signals import user_login, user_registered
-from ..utils import strip_null
+from ..utils import abort_null
 
 valid_timezones = set(common_timezones)
 
@@ -409,13 +409,13 @@ def requires_client_id_or_user_or_client_login(f):
             and request.referrer
         ):
             client_cred = AuthClientCredential.get(
-                strip_null(request.values['client_id'])
+                abort_null(request.values['client_id'])
             )
             if client_cred is not None and get_scheme_netloc(
                 client_cred.auth_client.website
             ) == get_scheme_netloc(request.referrer):
                 user_session = UserSession.authenticate(
-                    buid=strip_null(request.values['session'])
+                    buid=abort_null(request.values['session'])
                 )
                 if user_session is not None:
                     # Add this user session to current_auth so the wrapped function

--- a/funnel/views/label.py
+++ b/funnel/views/label.py
@@ -7,7 +7,7 @@ from coaster.views import ModelView, UrlForView, render_with, requires_roles, ro
 from .. import app, funnelapp
 from ..forms import LabelForm, LabelOptionForm
 from ..models import Label, Profile, Project, db
-from ..utils import strip_null
+from ..utils import abort_null
 from .decorators import legacy_redirect
 from .helpers import requires_login
 from .mixins import ProjectViewMixin
@@ -25,7 +25,7 @@ class ProjectLabelView(ProjectViewMixin, UrlForView, ModelView):
     def labels(self):
         form = forms.Form()
         if form.validate_on_submit():
-            namelist = [strip_null(x) for x in request.values.getlist('name')]
+            namelist = [abort_null(x) for x in request.values.getlist('name')]
             for idx, lname in enumerate(namelist, start=1):
                 lbl = Label.query.filter_by(project=self.obj, name=lname).first()
                 if lbl is not None:
@@ -47,8 +47,8 @@ class ProjectLabelView(ProjectViewMixin, UrlForView, ModelView):
             # and those values are also available at `form.data`.
             # But in case there are options, the option values are in the list
             # in the order they appeared on the create form.
-            titlelist = [strip_null(x) for x in request.values.getlist('title')]
-            emojilist = [strip_null(x) for x in request.values.getlist('icon_emoji')]
+            titlelist = [abort_null(x) for x in request.values.getlist('title')]
+            emojilist = [abort_null(x) for x in request.values.getlist('icon_emoji')]
             # first values of both lists belong to the parent label
             titlelist.pop(0)
             emojilist.pop(0)
@@ -140,9 +140,9 @@ class LabelView(UrlForView, ModelView):
             return redirect(self.obj.project.url_for('labels'), code=303)
 
         if form.validate_on_submit():
-            namelist = [strip_null(x) for x in request.values.getlist('name')]
-            titlelist = [strip_null(x) for x in request.values.getlist('title')]
-            emojilist = [strip_null(x) for x in request.values.getlist('icon_emoji')]
+            namelist = [abort_null(x) for x in request.values.getlist('name')]
+            titlelist = [abort_null(x) for x in request.values.getlist('title')]
+            emojilist = [abort_null(x) for x in request.values.getlist('icon_emoji')]
 
             namelist.pop(0)
             titlelist.pop(0)

--- a/funnel/views/login.py
+++ b/funnel/views/login.py
@@ -47,7 +47,7 @@ from ..models import (
 )
 from ..registry import LoginCallbackError, LoginInitError, login_registry
 from ..signals import user_data_changed
-from ..utils import mask_email, strip_null
+from ..utils import mask_email, abort_null
 from .email import send_email_verify_link, send_password_reset_link
 from .helpers import (
     app_url_for,
@@ -97,7 +97,7 @@ def login():
     if request.method == 'GET':
         loginmethod = request.cookies.get('login')
 
-    formid = strip_null(request.form.get('form.id'))
+    formid = abort_null(request.form.get('form.id'))
     if request.method == 'POST' and formid == 'passwordlogin':
         try:
             success = loginform.validate()
@@ -222,7 +222,7 @@ def logout_client():
     """
     Client-initiated logout
     """
-    cred = AuthClientCredential.get(strip_null(request.args['client_id']))
+    cred = AuthClientCredential.get(abort_null(request.args['client_id']))
     auth_client = cred.auth_client if cred else None
 
     if (
@@ -326,7 +326,7 @@ def reset():
         message = None
 
     if request.method == 'GET':
-        form.username.data = strip_null(request.args.get('username'))
+        form.username.data = abort_null(request.args.get('username'))
 
     if form.validate_on_submit():
         username = form.username.data

--- a/funnel/views/participant.py
+++ b/funnel/views/participant.py
@@ -19,7 +19,7 @@ from coaster.views import (
 from .. import app, funnelapp
 from ..forms import ParticipantForm
 from ..models import Attendee, Event, Participant, Profile, Project, SyncTicket, db
-from ..utils import format_twitter_handle, make_qrcode, split_name, strip_null
+from ..utils import format_twitter_handle, make_qrcode, split_name, abort_null
 from ..views.helpers import mask_email
 from .decorators import legacy_redirect
 from .helpers import requires_login
@@ -224,7 +224,7 @@ class EventParticipantView(EventViewMixin, UrlForView, ModelView):
         form = forms.Form()
         if form.validate_on_submit():
             checked_in = getbool(request.form.get('checkin'))
-            participant_ids = [strip_null(x) for x in request.form.getlist('puuid_b58')]
+            participant_ids = [abort_null(x) for x in request.form.getlist('puuid_b58')]
             for participant_id in participant_ids:
                 attendee = Attendee.get(self.obj, participant_id)
                 attendee.checked_in = checked_in

--- a/funnel/views/search.py
+++ b/funnel/views/search.py
@@ -19,7 +19,7 @@ from ..models import (
     User,
     db,
 )
-from ..utils import strip_null
+from ..utils import abort_null
 
 # --- Definitions -------------------------------------------------------------
 
@@ -205,10 +205,10 @@ def search_results(squery, stype, page=1, per_page=20):
 class SearchView(ClassView):
     @route('/search')
     @render_with('search.html.jinja2', json=True)
-    @requestargs(('q', strip_null), ('page', int), ('per_page', int))
+    @requestargs(('q', abort_null), ('page', int), ('per_page', int))
     def search(self, q=None, page=1, per_page=20):
         squery = for_tsquery(q or '')
-        stype = strip_null(
+        stype = abort_null(
             request.args.get('type')
         )  # Can't use requestargs as it doesn't support name changes
         if not squery:

--- a/funnel/views/session.py
+++ b/funnel/views/session.py
@@ -23,7 +23,7 @@ from ..models import (
     Session,
     db,
 )
-from ..utils import strip_null
+from ..utils import abort_null
 from .decorators import legacy_redirect
 from .helpers import localize_date, requires_login
 from .mixins import ProjectViewMixin, SessionViewMixin
@@ -218,8 +218,8 @@ class SessionView(SessionViewMixin, UrlForView, ModelView):
     @route('feedback', methods=['POST'])
     @requires_permission('view')
     @requestargs(
-        ('id_type', strip_null),
-        ('userid', strip_null),
+        ('id_type', abort_null),
+        ('userid', abort_null),
         ('content', int),
         ('presentation', int),
         ('min_scale', int),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,11 @@
 from flask import current_app
 
+import pytest
+
+from werkzeug.exceptions import BadRequest
+
 from funnel.utils import (
+    abort_null,
     extract_twitter_handle,
     format_twitter_handle,
     geonameid_from_location,
@@ -33,3 +38,8 @@ class TestUtils(object):
 
     def test_format_twitter_handle(self):
         assert format_twitter_handle("testusername") == "@testusername"
+
+    def test_null_abort(self, test_client):
+        with current_app.test_request_context('/'):
+            with pytest.raises(expected_exception=BadRequest):
+                abort_null('\x00')


### PR DESCRIPTION
Replaces `strip_null` with `abort_null`, throwing `abort(400)` instead of stripping null bytes from user input