### PR TITLE
Set default value for 'is session a break period?' to false

### DIFF
--- a/funnel/views/session.py
+++ b/funnel/views/session.py
@@ -62,7 +62,7 @@ def session_form(project, proposal=None, session=None):
         del form.venue_room_id
     if request.method == 'GET':
         if not (session or proposal):
-            form.is_break.data = True
+            form.is_break.data = False
         return render_template(
             'session_form.html.jinja2',
             form=form,

--- a/funnel/views/session.py
+++ b/funnel/views/session.py
@@ -61,8 +61,6 @@ def session_form(project, proposal=None, session=None):
     if not form.venue_room_id.choices:
         del form.venue_room_id
     if request.method == 'GET':
-        if not (session or proposal):
-            form.is_break.data = False
         return render_template(
             'session_form.html.jinja2',
             form=form,


### PR DESCRIPTION
When editing schedules, each new session by default has the 'Is this session a break period?' radio button ticked. This pull request sets the default value for `is_break` to `False`.