### PR TITLE
Switch to Argon2 password hashing, via passlib

### DIFF
--- a/funnel/forms/login.py
+++ b/funnel/forms/login.py
@@ -48,7 +48,7 @@ class LoginForm(forms.Form):
             return
         if not self.user.pw_hash:
             raise LoginPasswordResetException()
-        if not self.user.password_is(field.data):
+        if not self.user.password_is(field.data, upgrade_hash=True):
             if not self.username.errors:
                 raise forms.ValidationError(_("Incorrect password"))
 

--- a/funnel/views/auth_oauth.py
+++ b/funnel/views/auth_oauth.py
@@ -551,7 +551,7 @@ def oauth_token():
             return oauth_token_error(
                 'invalid_client', _("No such user")
             )  # XXX: invalid_client doesn't seem right
-        if not user.password_is(password):
+        if not user.password_is(password, upgrade_hash=True):
             return oauth_token_error('invalid_client', _("Password mismatch"))
         # Validations 4.3: verify scope
         try:

--- a/funnel/views/login.py
+++ b/funnel/views/login.py
@@ -137,6 +137,24 @@ def login():
                         render_redirect(url_for('change_password'), code=303),
                         'password',
                     )
+                elif user.password_has_expired():
+                    current_app.logger.info(
+                        "Login successful for %r, but password has expired. "
+                        "Possible redirect URL is '%s' after password change",
+                        user,
+                        session.get('next', ''),
+                    )
+                    flash(
+                        _(
+                            "Your password is a year old. To ensure the safety of "
+                            "your account, please choose a new password"
+                        ),
+                        category='warning',
+                    )
+                    return set_loginmethod_cookie(
+                        render_redirect(url_for('change_password'), code=303),
+                        'password',
+                    )
                 else:
                     current_app.logger.info(
                         "Login successful for %r, possible redirect URL is '%s'",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 alembic==1.4.2
+argon2-cffi==20.1.0
 Babel==2.8.0
 git+https://github.com/hasgeek/baseframe.git#egg=baseframe
-bcrypt>=2.0.0
+bcrypt==3.1.7
 blinker==1.4
 git+https://github.com/hasgeek/coaster.git#egg=coaster
 Flask==1.1.2
@@ -19,6 +20,7 @@ icalendar==4.0.6
 itsdangerous==1.1.0
 jsmin==2.2.2
 oauth2client==4.1.3
+passlib==1.7.2
 password-strength==0.0.3.post2
 phonenumbers==8.12.4
 progressbar2==3.51.3


### PR DESCRIPTION
Also:

* Transparently upgrades bcrypt hashes to Argon2 at login
* Drops SHA1 password support (deprecated in 2015)
* Prompts user to change password if expired (currently 1 year after being set)
