### PR TITLE
Hide labels form if none are available

### DIFF
--- a/funnel/forms/proposal.py
+++ b/funnel/forms/proposal.py
@@ -48,6 +48,8 @@ def proposal_label_form(project, proposal):
                     ],
                 ),
             )
+    if not project.labels:
+        return None
 
     form = ProposalLabelForm(
         obj=proposal.formlabels if proposal else None, meta={'csrf': False}
@@ -228,9 +230,15 @@ class ProposalForm(forms.Form):
     formlabels = forms.FormField(forms.Form, __("Labels"))
 
     def set_queries(self):
-        self.formlabels.form = proposal_label_form(
+        label_form = proposal_label_form(
             project=self.edit_parent, proposal=self.edit_obj
         )
+        if label_form:
+            self.formlabels.form = proposal_label_form(
+                project=self.edit_parent, proposal=self.edit_obj
+            )
+        else:
+            del self.formlabels
 
 
 @Proposal.forms('transition')

--- a/funnel/forms/proposal.py
+++ b/funnel/forms/proposal.py
@@ -25,6 +25,9 @@ __all__ = [
 def proposal_label_form(project, proposal):
     """Return a label form for the given project and proposal."""
 
+    if not project.labels:
+        return
+
     class ProposalLabelForm(forms.Form):
         pass
 
@@ -48,8 +51,6 @@ def proposal_label_form(project, proposal):
                     ],
                 ),
             )
-    if not project.labels:
-        return None
 
     form = ProposalLabelForm(
         obj=proposal.formlabels if proposal else None, meta={'csrf': False}
@@ -234,9 +235,7 @@ class ProposalForm(forms.Form):
             project=self.edit_parent, proposal=self.edit_obj
         )
         if label_form:
-            self.formlabels.form = proposal_label_form(
-                project=self.edit_parent, proposal=self.edit_obj
-            )
+            self.formlabels.form = label_form
         else:
             del self.formlabels
 

--- a/funnel/forms/proposal.py
+++ b/funnel/forms/proposal.py
@@ -234,7 +234,7 @@ class ProposalForm(forms.Form):
         label_form = proposal_label_form(
             project=self.edit_parent, proposal=self.edit_obj
         )
-        if label_form:
+        if label_form is not None:
             self.formlabels.form = label_form
         else:
             del self.formlabels


### PR DESCRIPTION
Hide labels form on proposal submission page if none are available in the project