### PR TITLE
Fix usability of featured project flag setter

### DIFF
--- a/funnel/models/project.py
+++ b/funnel/models/project.py
@@ -264,6 +264,7 @@ class Project(UuidMixin, BaseScopedNameMixin, db.Model):
                 'hasjob_embed_url',
                 'hasjob_embed_limit',
                 'profile',
+                'featured',
                 'featured_sessions',
             },
             'call': {
@@ -311,6 +312,7 @@ class Project(UuidMixin, BaseScopedNameMixin, db.Model):
             'schedule_end_at_localized',
             'cfp_start_at_localized',
             'cfp_end_at_localized',
+            'featured',
             'profile',
         },
         'without_parent': {
@@ -335,6 +337,7 @@ class Project(UuidMixin, BaseScopedNameMixin, db.Model):
             'schedule_end_at_localized',
             'cfp_start_at_localized',
             'cfp_end_at_localized',
+            'featured',
         },
         'related': {
             'name',

--- a/funnel/templates/macros.html.jinja2
+++ b/funnel/templates/macros.html.jinja2
@@ -105,24 +105,18 @@
             <a href="#featured-form-modal" rel="modal:open" class="mui--text-light mui--text-subhead"></a>
             <div class="mui-checkbox">
               <label class="mui--text-light mui--text-subhead">
-                <input type="checkbox" {% if project.featured %}checked{% endif %} onclick="$('#featured-form-modal').modal()">
+                <input type="checkbox" {% if project.featured %}checked{% endif %} onclick="event.preventDefault(); $('#featured-form-modal').modal()">
                 {% trans %}Featured project{% endtrans %}
               </label>
             </div>
             <div class="modal" id="featured-form-modal">
               <div class="modal__header">
                 <a class="modal__close mui--text-dark" href="javascript:void(0);" data-target="close cancel register modal" aria-label="{% trans %}Close{% endtrans %}" rel="modal:close">{{ faicon(icon='times', icon_size='title') }}</a>
-                <p class="mui--text-title mui--text-bold mui--text-dark">
-                  {% if project.featured %}
-                    {% trans %}Do you want to change this project's state to unfeatured?{% endtrans %}
-                  {% else %}
-                    {% trans %}Do you want to update this project's state to featured?{% endtrans %}
-                  {% endif %}
-                </p>
               </div>
               <div class="modal__body">
                 <form action="{{ project.url_for('toggle_featured') }}" method="post">
                   {{ csrf_form.hidden_tag() }}
+                  <span class="mui--text-title mui--text-bold mui--text-dark">Confirmation</span>
                   <button name="transition" class="mui-btn mui-btn--accent mui-btn--flat mui--pull-right">
                     {% if project.featured %}
                       {% trans %}Remove featured{% endtrans %}

--- a/funnel/views/project.py
+++ b/funnel/views/project.py
@@ -775,8 +775,6 @@ class ProjectView(
         if featured_form.validate_on_submit():
             self.obj.featured = not self.obj.featured
             db.session.commit()
-            if self.obj.featured:
-                flash(_("Your project is now a spotlight on homepage"), 'info')
         return redirect(get_next_url(referrer=True), 303)
 
 


### PR DESCRIPTION
The featured project flag setter for projects was not working when the page used `current_access()`. This fixes it and also simplifies the modal.

However, the layout of the modal is still wonky, with all three elements misaligned. This needs to be redone. I'm going ahead with a merge because the main functionality is currently broken.

![Confirmation modal](https://user-images.githubusercontent.com/26695/88716437-b00b6080-d13c-11ea-8edb-9b2364bbb82a.png)
