### PR TITLE
Don't allow case change in `EmailAddress.add` (only in `add_for`)

### DIFF
--- a/funnel/models/email_address.py
+++ b/funnel/models/email_address.py
@@ -454,12 +454,14 @@ class EmailAddress(BaseMixin, db.Model):
         """
         Create a new :class:`EmailAddress` after validation.
 
-        Raises an exception if the address is blocked from use or the email address
+        Raises an exception if the address is blocked from use, or the email address
         is syntactically invalid.
         """
         existing = cls._get_existing(email)
         if existing:
-            existing.email = email
+            # Restore the email column if it's not present. Do not modify it otherwise
+            if not existing.email:
+                existing.email = email
             return existing
         new_email = EmailAddress(email)
         db.session.add(new_email)

--- a/tests/unit/models/test_email_address.py
+++ b/tests/unit/models/test_email_address.py
@@ -313,15 +313,16 @@ def test_email_address_add(clean_db):
     assert ea3 != ea1
     assert ea4 == ea1
 
-    # Email casing was amended by the call to EmailAddress.add
-    assert ea1.email == 'Example@example.com'
+    # Email casing will not be amended by the call to EmailAddress.add
+    assert ea1.email == 'example@example.com'
 
     # A forgotten email address will be restored by calling EmailAddress.add
+    # Since it was forgotten, email casing will also be amended (we don't have a choice)
     ea3.email = None
     assert ea3.email is None
-    ea5 = EmailAddress.add('other@example.com')
+    ea5 = EmailAddress.add('Other@example.com')
     assert ea5 == ea3
-    assert ea5.email == ea3.email == 'other@example.com'
+    assert ea5.email == ea3.email == 'Other@example.com'
 
     # Adding an invalid email address will raise an error
     with pytest.raises(ValueError):


### PR DESCRIPTION
This patch exposes a vulnerability in the design of the `EmailAddress` model. Since the email address is only stored here and not in any of the other linked models (`UserEmail`, etc), there can only be one case-preserving representation of it. This is normally not a problem when email addresses are limited to a specific user account. It breaks down when an email can be used in two separate user accounts. Examples of how this can happen:

1. `UserEmailClaim`
2. Future mailing list functionality

Take the first:

1. Rogue User claims an email address, giving it an unusual case (say, randomly capitalized letters)
2. Real User claims the same email address. The existing case representation in the db will not be amended, so the will get the weird casing as well.
3. Real User happened to be the real owner and confirmed ownership, so it gets added to their account as a UserEmail object, but preserves the weird casing acquired from Rogue User.
4. Real User can't change the case in the UI. If they remove and re-add the email, they can use use any casing they like, but if it was their only contact detail, the UI won't allow removing.

In the second case, a mailing list entry will affect the casing of a future user's email address, and does not even require a rogue user, just someone using the functionality as intended. It also works in reverse: if the owner changes casing, it will reflect in mailing lists owned by others.

Should we ever implement a mailing list (there's a half-baked version in the [listman](/hasgeek/listman) project, which was was meant to add mailing list functionality to [hasmail](/hasgeek/hasmail)), we have to ensure the list entry's `email` column is a case-preserving dupe of the `EmailAddress.email` column. This will be a setback from the goal of having a single point of storage for email addresses, and will require coordination between models for things like enforcing blockage.