### PR TITLE
Disable logger init for secondary apps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ baseframe-packed.*
 
 # Log files
 error.log
+error.log.*
 ghostdriver.log
 
 # Instance Files that should not be checked-in.

--- a/funnel/__init__.py
+++ b/funnel/__init__.py
@@ -53,8 +53,8 @@ from .models import db  # isort:skip
 
 # --- Configuration------------------------------------------------------------
 coaster.app.init_app(app)
-coaster.app.init_app(funnelapp)
-coaster.app.init_app(lastuserapp)
+coaster.app.init_app(funnelapp, init_logging=False)
+coaster.app.init_app(lastuserapp, init_logging=False)
 
 # These are app specific confguration files that must exist
 # inside the `instance/` directory. Sample config files are


### PR DESCRIPTION
Requires the latest update to Coaster.