### PR TITLE
Add data-cy value to notifications page

### DIFF
--- a/funnel/assets/cypress/integration/02_verifyAdminRoles.js
+++ b/funnel/assets/cypress/integration/02_verifyAdminRoles.js
@@ -29,6 +29,6 @@ describe('Profile admin roles', function () {
     cy.get('#member-form', { timeout: 10000 }).should('not.be.visible');
     cy.wait(1000);
     cy.visit('/updates');
-    cy.contains('Your role was changed to admin of');
+    cy.get('[data-cy="notification-box"]').contains(profile.title);
   });
 });

--- a/funnel/assets/cypress/integration/10_addProposal.js
+++ b/funnel/assets/cypress/integration/10_addProposal.js
@@ -65,6 +65,6 @@ describe('Add a new proposal', function () {
     cy.login('/' + profile.title, editor.username, editor.password);
     cy.visit('/updates');
     cy.wait('@fetch-updates');
-    cy.contains('has received a new proposal');
+    cy.get('[data-cy="notification-box"]').contains(proposal.title);
   });
 });

--- a/funnel/assets/cypress/integration/11_confirmProposal.js
+++ b/funnel/assets/cypress/integration/11_confirmProposal.js
@@ -64,7 +64,7 @@ describe('Confirm proposal', function () {
     cy.login('/' + profile.title, member.username, member.password);
     cy.visit('/updates');
     cy.wait('@fetch-updates');
-    cy.contains(proposal.title);
-    cy.contains(proposal.comment);
+    cy.get('[data-cy="notification-box"]').contains(proposal.title);
+    cy.get('[data-cy="notification-box"]').contains(proposal.comment);
   });
 });

--- a/funnel/assets/cypress/integration/29_postComment.js
+++ b/funnel/assets/cypress/integration/29_postComment.js
@@ -96,6 +96,6 @@ describe('Test comments feature', function () {
     cy.login('/', editor.username, editor.password);
     cy.visit('/updates');
     cy.wait('@fetch-updates');
-    cy.contains('left comments');
+    cy.get('[data-cy="notification-box"]').contains(project.title);
   });
 });

--- a/funnel/assets/cypress/integration/31_postUpdate.js
+++ b/funnel/assets/cypress/integration/31_postUpdate.js
@@ -63,6 +63,6 @@ describe('Test updates feature', function () {
     cy.login('/', user.username, user.password);
     cy.visit('/updates');
     cy.wait(1000);
-    cy.contains('posted an update in');
+    cy.get('[data-cy="notification-box"]').contains(project.update_title);
   });
 });

--- a/funnel/templates/notifications/layout_web.html.jinja2
+++ b/funnel/templates/notifications/layout_web.html.jinja2
@@ -1,10 +1,10 @@
 {%- from "macros.html.jinja2" import useravatar %}
 {%- block update %}
   <div class="user">
-    <div class="user__box user__box--topalign" data-cy="notification-box">
+    <div class="user__box user__box--topalign">
       {% block avatar %}{% if view.actor %}{{ useravatar(view.actor) }}{% endif %}{% endblock %}
       <div class="user__box__header">
-        <div class="mui--text-subhead">{% block content %}{% trans %}(This template is missing content){% endtrans %}{% endblock %}</div>
+        <div class="mui--text-subhead" data-cy="notification-box">{% block content %}{% trans %}(This template is missing content){% endtrans %}{% endblock %}</div>
         {% if not view.is_rollup %}<p class="mui--text-body2 zero-bottom-margin">{{ view.user_notification.created_at|age }}</p>{% endif %}
       </div>
     </div>

--- a/funnel/templates/notifications/layout_web.html.jinja2
+++ b/funnel/templates/notifications/layout_web.html.jinja2
@@ -1,7 +1,7 @@
 {%- from "macros.html.jinja2" import useravatar %}
 {%- block update %}
   <div class="user">
-    <div class="user__box user__box--topalign">
+    <div class="user__box user__box--topalign" data-cy="notification-box">
       {% block avatar %}{% if view.actor %}{{ useravatar(view.actor) }}{% endif %}{% endblock %}
       <div class="user__box__header">
         <div class="mui--text-subhead">{% block content %}{% trans %}(This template is missing content){% endtrans %}{% endblock %}</div>


### PR DESCRIPTION
In cypress tests for notifications, look for `data-cy="notification-box"` value and object `(proposal.title, project.update_text ...)` instead of looking for English language text strings.