### PR TITLE
XHR support for requires_sudo

### DIFF
--- a/funnel/assets/js/membership.js
+++ b/funnel/assets/js/membership.js
@@ -70,6 +70,9 @@ const Membership = {
                 app.memberForm = vueFormHtml.replace(/\bscript\b/g, 'script2');
                 $('#member-form').modal('show');
               },
+              error(response) {
+                Utils.getResponseError(response);
+              },
             });
           }
         },

--- a/funnel/assets/js/util.js
+++ b/funnel/assets/js/util.js
@@ -186,8 +186,13 @@ export const Utils = {
       if (response.status === 500) {
         errorMsg =
           'An internal server error occurred. Our support team has been notified and will investigate.';
+      } else if (
+        response.status === 422 &&
+        response.responseJSON.error === 'requires_sudo'
+      ) {
+        window.location.href = `${window.Hasgeek.config.accountSudo}?next=${window.location.href}`;
       } else {
-        errorMsg = JSON.parse(response.responseText).error_description;
+        errorMsg = response.responseJSON.error_description;
       }
     } else {
       errorMsg = 'Unable to connect. Please reload and try again.';

--- a/funnel/assets/js/util.js
+++ b/funnel/assets/js/util.js
@@ -190,7 +190,9 @@ export const Utils = {
         response.status === 422 &&
         response.responseJSON.error === 'requires_sudo'
       ) {
-        window.location.href = `${window.Hasgeek.config.accountSudo}?next=${window.location.href}`;
+        window.location.href = `${
+          window.Hasgeek.config.accountSudo
+        }?next=${encodeURIComponent(window.location.href)}`;
       } else {
         errorMsg = response.responseJSON.error_description;
       }

--- a/funnel/templates/layout.html.jinja2
+++ b/funnel/templates/layout.html.jinja2
@@ -209,10 +209,11 @@
   {%- endassets -%}
   <script type="text/javascript">
     $(document).ready(function() {
-        window.Hasgeek = {};
-        window.Hasgeek.config = {};
+      window.Hasgeek = {};
+      window.Hasgeek.config = {};
       window.Hasgeek.config.svgIconUrl = {% assets "fa5-sprite" %}"{{ ASSET_URL|make_relative_url }}"{% endassets %};
       window.Hasgeek.config.notificationCount = {{ url_for('notifications_count')|tojson }};
+      window.Hasgeek.config.accountSudo = {{ url_for('account_sudo')|tojson }};
     });
   </script>
   <script src="{{ url_for('static', filename=asset_path('app')) }}" type="text/javascript"></script>

--- a/funnel/templates/redirect.html.jinja2
+++ b/funnel/templates/redirect.html.jinja2
@@ -1,4 +1,4 @@
-<p>{% trans %}Loading...{% trans %} <span class="loading">&nbsp;</span></p>
+<p>{% trans %}Loading...{% endtrans %} <span class="loading">&nbsp;</span></p>
 <script type="text/javascript">
   location.href={{ url|tojson }};
 </script>

--- a/funnel/templates/redirect.html.jinja2
+++ b/funnel/templates/redirect.html.jinja2
@@ -1,4 +1,4 @@
 <p>{% trans %}Loading...{% trans %} <span class="loading">&nbsp;</span></p>
 <script type="text/javascript">
-  location.href={{ quoted_url }};
+  location.href={{ url|tojson }};
 </script>

--- a/funnel/views/account.py
+++ b/funnel/views/account.py
@@ -333,6 +333,11 @@ class AccountView(ClassView):
             'login_registry': login_registry,
         }
 
+    @route('sudo', endpoint='account_sudo', methods=['GET', 'POST'])
+    @requires_sudo
+    def sudo(self):
+        return redirect(get_next_url(), code=303)
+
     @route('saved', endpoint='saved')
     @requires_login
     @render_with('account_saved.html.jinja2')

--- a/funnel/views/login_session.py
+++ b/funnel/views/login_session.py
@@ -6,6 +6,7 @@ from flask import (
     current_app,
     flash,
     jsonify,
+    make_response,
     redirect,
     render_template,
     request,
@@ -401,12 +402,15 @@ def requires_sudo(f):
 
                     # TODO: Remove this line before merging PR
                     app.logger.debug("Raising requires_sudo error over JSON")
-                    return jsonify(
-                        status='error',
-                        error='requires_sudo',
-                        error_description=_(
-                            "This request must be confirmed with your password"
+                    return make_response(
+                        jsonify(
+                            status='error',
+                            error='requires_sudo',
+                            error_description=_(
+                                "This request must be confirmed with your password"
+                            ),
                         ),
+                        422,
                     )
                 else:
                     # TODO: Remove this line before merging PR

--- a/funnel/views/login_session.py
+++ b/funnel/views/login_session.py
@@ -1,11 +1,21 @@
 from datetime import datetime, timedelta
 from functools import wraps
 
-from flask import Response, current_app, flash, redirect, request, session, url_for
+from flask import (
+    Response,
+    current_app,
+    flash,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
 import itsdangerous
 
-from baseframe import _, statsd
-from baseframe.forms import render_form
+from baseframe import _, request_is_xhr, statsd
+from baseframe.forms import render_form, render_redirect
 from coaster.auth import add_auth_attribute, current_auth, request_has_auth
 from coaster.utils import utcnow
 from coaster.views import get_current_url
@@ -352,7 +362,7 @@ def requires_sudo(f):
         if not current_auth.is_authenticated:
             flash(_("You need to be logged in for that page"), 'info')
             session['next'] = get_current_url()
-            return redirect(url_for('login'))
+            return render_redirect(url_for('login'))
         # If the user has not authenticated in some time, ask for the password again
         if not current_auth.session.has_sudo:
             # If the user doesn't have a password, ask them to set one first
@@ -366,7 +376,7 @@ def requires_sudo(f):
                     'info',
                 )
                 session['next'] = get_current_url()
-                return redirect(url_for('change_password'))
+                return render_redirect(url_for('change_password'))
             # A future version of this form may accept password or 2FA (U2F or TOTP)
             form = PasswordForm(edit_user=current_auth.user)
             if form.validate_on_submit():
@@ -375,7 +385,33 @@ def requires_sudo(f):
                 # render its own form
                 current_auth.session.set_sudo()
                 db.session.commit()
-                return redirect(request.url, code=303)
+                continue_url = session.pop('next', request.url)
+                return redirect(continue_url, code=303)
+
+            if request_is_xhr():
+                # We can't render a form if it's an XHR request, so we need to ask for
+                # the page to be loaded afresh
+                if request.accept_mimetypes.best == 'application/json':
+                    # A JSON-only endpoint can't render a form, so we have to redirect
+                    # the browser to the account_sudo endpoint, asking it to redirect
+                    # back here after getting the user's password. That will be:
+                    # `url_for('account_sudo', next=request.url)`. Ideally, a fragment
+                    # identifier should be included to reload to the same dialog the
+                    # user was sent away from.
+
+                    # TODO: Remove this line before merging PR
+                    app.logger.debug("Raising requires_sudo error over JSON")
+                    return jsonify(
+                        status='error',
+                        error='requires_sudo',
+                        error_description=_(
+                            "This request must be confirmed with your password"
+                        ),
+                    )
+                else:
+                    # TODO: Remove this line before merging PR
+                    app.logger.debug("Redirecting user to this page for requires_sudo")
+                    return render_template('redirect.html.jinja2', url=request.url)
 
             return render_form(
                 form=form,

--- a/funnel/views/membership.py
+++ b/funnel/views/membership.py
@@ -255,8 +255,8 @@ class OrganizationMembershipView(UrlChangeCheck, UrlForView, ModelView):
     @requires_roles({'profile_owner'})
     def delete(self):
         form = Form()
-        if request.method == 'POST':
-            if form.validate_on_submit():
+        if form.is_submitted():
+            if form.validate():
                 previous_membership = self.obj
                 if previous_membership.user == current_auth.user:
                     return {
@@ -508,16 +508,16 @@ class ProjectCrewMembershipView(
     @requires_roles({'profile_admin'})
     def edit(self):
         previous_membership = self.obj
-        membership_form = ProjectCrewMembershipForm(obj=previous_membership)
+        form = ProjectCrewMembershipForm(obj=previous_membership)
 
-        if request.method == 'POST':
-            if membership_form.validate_on_submit():
+        if form.is_submitted():
+            if form.validate():
                 try:
                     previous_membership.replace(
                         actor=current_auth.user,
-                        is_editor=membership_form.is_editor.data,
-                        is_concierge=membership_form.is_concierge.data,
-                        is_usher=membership_form.is_usher.data,
+                        is_editor=form.is_editor.data,
+                        is_concierge=form.is_concierge.data,
+                        is_usher=form.is_usher.data,
                     )
                 except MembershipRevokedError:
                     return (
@@ -527,7 +527,7 @@ class ProjectCrewMembershipView(
                                 "The member’s record was edited elsewhere."
                                 " Please refresh the page"
                             ),
-                            'form_nonce': membership_form.form_nonce.data,
+                            'form_nonce': form.form_nonce.data,
                         },
                         400,
                     )
@@ -547,14 +547,14 @@ class ProjectCrewMembershipView(
                     {
                         'status': 'error',
                         'error_description': _("Please pick one or more roles"),
-                        'errors': membership_form.errors,
-                        'form_nonce': membership_form.form_nonce.data,
+                        'errors': form.errors,
+                        'form_nonce': form.form_nonce.data,
                     },
                     400,
                 )
 
         membership_form_html = render_form(
-            form=membership_form,
+            form=form,
             title='',
             submit=u'Edit membership',
             ajax=False,


### PR DESCRIPTION
A page with a `@requires_sudo` decorator may be loaded in an XHR request, which inhibits rendering a password dialog.

1. If the page is loaded as XHR HTML, which is typical with legacy jQuery Form endpoints, it will render a HTML+JS redirect to itself, thereby loading the page full screen.

2. If the page is expecting a JSON response, it will return `{"status": "error", "error": "requires_sudo",  "error_description": "User friendly message"}`. The caller must then redirect the user to the `account_sudo` endpoint, with a `next` parameter that points back to the current page and dialog. This endpoint is at `/account/sudo`.

3. If sudo mode is currently active (authentication was performed in the last 15 minutes), the request is passed through uninterrupted.

The first commit in this draft PR includes this infrastructure. The membership JS however fails to account for an error response when removing a member. @vidya-ram this needs to be fixed in JS.