### PR TITLE
Fix for claiming an existing but unclaimed email address

### DIFF
--- a/runtests.sh
+++ b/runtests.sh
@@ -7,5 +7,5 @@ fi
 if [ $# -eq 0 ]; then
     pytest --cov=funnel
 else
-    pytest --no-cov "$@"
+    pytest "$@"
 fi

--- a/tests/unit/models/test_email_address.py
+++ b/tests/unit/models/test_email_address.py
@@ -676,6 +676,19 @@ def test_email_address_validate_for(email_models, clean_mixin_db):
     assert EmailAddress.validate_for(anon_user, 'invalid') == 'invalid'
 
 
+def test_email_address_existing_but_unused_validate_for(email_models, clean_mixin_db):
+    """An unused but existing email address should be available to claim."""
+    db = clean_mixin_db
+    models = email_models
+    user = models.EmailUser()
+    email_address = EmailAddress.add('unclaimed@example.com')
+    db.session.add_all([user, email_address])
+    db.session.commit()
+
+    assert EmailAddress.validate_for(user, 'unclaimed@example.com', new=True) is True
+    assert EmailAddress.validate_for(user, 'unclaimed@example.com') is True
+
+
 def test_email_address_validate_for_check_dns(email_models, clean_mixin_db):
     """Validate_for with check_dns=True. Separate test as DNS lookup may fail."""
     db = clean_mixin_db


### PR DESCRIPTION
This fixes a situation when an EmailAddress record exists without a corresponding UserEmail or UserEmailClaim record. Previously we assumed a UserEmailClaim must exist. However, it is possible to get an email address into the database from TicketParticipant, so now we explicitly check for UserEmailClaim existing.