### PR TITLE
Drop support for 128-bit blake2b hash in UserEmailClaim

### DIFF
--- a/funnel/views/account.py
+++ b/funnel/views/account.py
@@ -2,7 +2,6 @@ from collections import Counter, namedtuple
 
 from flask import Markup, abort, current_app, escape, flash, redirect, request, url_for
 
-import base58
 import geoip2.errors
 import user_agents
 
@@ -94,20 +93,6 @@ def send_phone_verify_code(phoneclaim):
         db.session.add(msg)
     except TransportConnectionError:
         flash(_("Unable to send a message right now. Please try again"))
-
-
-def blake2b_b58(text):
-    """
-    Determine if given text is a 128 or 160-bit BLAKE2b hash (rendered in UUID58).
-
-    Returns a dict that can be passed as kwargs to model loader. This function is
-    temporary until the switch to email_hash-based lookup in a few days (in June 2020).
-    """
-    try:
-        hash_bytes = base58.b58decode(text.encode())
-        return {('blake2b' if len(hash_bytes) == 16 else 'blake2b160'): hash_bytes}
-    except ValueError:
-        abort(400)  # Parameter isn't valid Base58
 
 
 @User.views()
@@ -607,8 +592,12 @@ def account_edit(newprofile=False):
 @lastuserapp.route('/confirm/<email_hash>/<secret>')
 @requires_login
 def confirm_email(email_hash, secret):
-    kwargs = blake2b_b58(email_hash)
-    emailclaim = UserEmailClaim.get_by(verification_code=secret, **kwargs)
+    try:
+        emailclaim = UserEmailClaim.get_by(
+            verification_code=secret, email_hash=email_hash
+        )
+    except ValueError:
+        abort(404)
     if emailclaim is not None:
         emailclaim.email_address.mark_active()
         if 'verify' in emailclaim.permissions(current_auth.user):
@@ -802,13 +791,16 @@ def make_phone_primary():
 @app.route('/account/email/<email_hash>/remove', methods=['GET', 'POST'])
 @requires_sudo
 def remove_email(email_hash):
-    useremail = UserEmail.get_for(user=current_auth.user, email_hash=email_hash)
-    if not useremail:
-        useremail = UserEmailClaim.get_for(
-            user=current_auth.user, email_hash=email_hash
-        )
+    try:
+        useremail = UserEmail.get_for(user=current_auth.user, email_hash=email_hash)
+        if not useremail:
+            useremail = UserEmailClaim.get_for(
+                user=current_auth.user, email_hash=email_hash
+            )
         if not useremail:
             abort(404)
+    except ValueError:
+        abort(404)
     if (
         isinstance(useremail, UserEmail)
         and current_auth.user.verified_contact_count == 1
@@ -847,7 +839,10 @@ def verify_email(email_hash):
     send themselves another verification email. This endpoint is only linked to from
     the account page under the list of email addresses pending verification.
     """
-    useremail = UserEmail.get(email_hash=email_hash)
+    try:
+        useremail = UserEmail.get(email_hash=email_hash)
+    except ValueError:
+        abort(404)
     if useremail and useremail.user == current_auth.user:
         # If an email address is already verified (this should not happen unless the
         # user followed a stale link), tell them it's done -- but only if the email
@@ -857,7 +852,12 @@ def verify_email(email_hash):
         return render_redirect(url_for('account'), code=303)
 
     # Get the existing email claim that we're resending a verification link for
-    emailclaim = UserEmailClaim.get_for(user=current_auth.user, email_hash=email_hash)
+    try:
+        emailclaim = UserEmailClaim.get_for(
+            user=current_auth.user, email_hash=email_hash
+        )
+    except ValueError:
+        abort(404)
     if not emailclaim:
         abort(404)
     verify_form = VerifyEmailForm()

--- a/migrations/versions/5f1ab3e04f73_drop_support_for_128_bit_blake2b_hash_.py
+++ b/migrations/versions/5f1ab3e04f73_drop_support_for_128_bit_blake2b_hash_.py
@@ -1,0 +1,90 @@
+"""Drop support for 128-bit blake2b hash in email
+
+Revision ID: 5f1ab3e04f73
+Revises: 3847982f1472
+Create Date: 2020-10-07 10:24:32.491617
+
+"""
+
+import hashlib
+
+from alembic import op
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.sql import column, table
+import sqlalchemy as sa
+
+from progressbar import ProgressBar
+import progressbar.widgets
+
+# revision identifiers, used by Alembic.
+revision = '5f1ab3e04f73'
+down_revision = '3847982f1472'
+branch_labels = None
+depends_on = None
+
+user_email_claim = table(
+    'user_email_claim',
+    column('id', sa.Integer),
+    column('email_address_id', sa.Integer),
+    column('blake2b', sa.LargeBinary),
+)
+
+email_address = table(
+    'email_address',
+    column('id', sa.Integer),
+    column('email', sa.Unicode),
+)
+
+
+def get_progressbar(label, maxval):
+    return ProgressBar(
+        maxval=maxval,
+        widgets=[
+            label,
+            ': ',
+            progressbar.widgets.Percentage(),
+            ' ',
+            progressbar.widgets.Bar(),
+            ' ',
+            progressbar.widgets.ETA(),
+            ' ',
+        ],
+    )
+
+
+def upgrade():
+    op.drop_index('ix_user_email_claim_blake2b', table_name='user_email_claim')
+    op.drop_column('user_email_claim', 'blake2b')
+
+
+def downgrade():
+    conn = op.get_bind()
+    op.add_column(
+        'user_email_claim',
+        sa.Column('blake2b', postgresql.BYTEA(), autoincrement=False, nullable=True),
+    )
+    # Recalculate blake2b hashes
+    count = conn.scalar(sa.select([sa.func.count('*')]).select_from(user_email_claim))
+    progress = get_progressbar("Email claims", count)
+    progress.start()
+    items = conn.execute(
+        sa.select([user_email_claim.c.id, email_address.c.email]).where(
+            user_email_claim.c.email_address_id == email_address.c.id
+        )
+    )
+    for counter, item in enumerate(items):
+        conn.execute(
+            user_email_claim.update()
+            .where(user_email_claim.c.id == item.id)
+            .values(
+                blake2b=hashlib.blake2b(
+                    item.email.lower().encode('utf-8'), digest_size=16
+                ).digest(),
+            )
+        )
+        progress.update(counter)
+    progress.finish()
+    op.alter_column('user_email_claim', 'blake2b', nullable=False)
+    op.create_index(
+        'ix_user_email_claim_blake2b', 'user_email_claim', ['blake2b'], unique=False
+    )

--- a/tests/unit/models/test_email_address.py
+++ b/tests/unit/models/test_email_address.py
@@ -285,6 +285,12 @@ def test_email_address_get(clean_db):
     assert EmailAddress.get('unknown@example.com') is None
 
 
+def test_email_address_invalid_hash_raises_error(clean_db):
+    """Retrieving an email address with an invalid hash will raise ValueError"""
+    with pytest.raises(ValueError):
+        EmailAddress.get(email_hash='invalid')
+
+
 def test_email_address_get_canonical(clean_db):
     """EmailAddress.get_canonical returns all matching records"""
     db = clean_db


### PR DESCRIPTION
128-bit hashes were used for about a week in June 2020, during the transition from MD5 to 160-bit Blake2b hashes.

Also checks for ValueError from invalid hashes in all views that accept email_hash.