### PR TITLE
Sitemap in robots.txt must be a full URL

### DIFF
--- a/funnel/templates/robots.txt.jinja2
+++ b/funnel/templates/robots.txt.jinja2
@@ -1,6 +1,7 @@
 # www.robotstxt.org/
 # www.google.com/support/webmasters/bin/answer.py?hl=en&answer=156449
 
+Sitemap: {{ url_for('SitemapView_index', _external=true) }}
 User-agent: *
 Disallow: /account
 Disallow: /login

--- a/funnel/views/index.py
+++ b/funnel/views/index.py
@@ -241,6 +241,11 @@ def opensearch():
     )
 
 
+@app.route('/robots.txt')
+def robotstxt():
+    return Response(render_template('robots.txt.jinja2'), mimetype='text/plain')
+
+
 # --- Lastuser legacy routes -----------------------------------------------------------
 
 


### PR DESCRIPTION
We can't have a static URL in robots.txt because the same file is served for Talkfunnel and Lastuser. This requires a live view.