### PR TITLE
Simplified Proposal body content (resolves #437)

### DIFF
--- a/funnel/assets/cypress/fixtures/proposal.json
+++ b/funnel/assets/cypress/fixtures/proposal.json
@@ -1,12 +1,7 @@
 {
   "title": "End to end testing",
-  "abstract": "This talk is about e2e testing in frontend using Cypress.",
-  "outline": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. \nUt enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
-  "slides": "https://hasgeek.com/about",
+  "content": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. \nUt enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
   "preview_video": "https://www.youtube.com/watch?v=SLlSDI-N8iM",
-  "speaker_bio": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna ali",
-  "phone": "990001234",
-  "location": "Bangalore",
   "room": "Taj M G Road – Banquet hall",
   "venue_room": "Banquet hall, Taj M G Road",
   "time": "9:05",

--- a/funnel/assets/cypress/integration/10_addProposal.js
+++ b/funnel/assets/cypress/integration/10_addProposal.js
@@ -21,19 +21,10 @@ describe('Add a new proposal', function () {
     cy.location('pathname').should('contain', 'new');
     cy.get('#speaking label').eq(0).click();
     cy.get('#title').type(proposal.title);
-    cy.get('#field-abstract')
+    cy.get('#field-body')
       .find('.CodeMirror textarea')
-      .type(proposal.abstract, { force: true });
-    cy.get('#field-outline')
-      .find('.CodeMirror textarea')
-      .type(proposal.outline, { force: true });
-    cy.get('#slides').type(proposal.slides);
+      .type(proposal.content, { force: true });
     cy.get('#field-video_url').type(proposal.preview_video);
-    cy.get('#field-bio')
-      .find('.CodeMirror textarea')
-      .type(proposal.speaker_bio, { force: true });
-    cy.get('#phone').type(proposal.phone);
-    cy.get('#location').type(proposal.location);
     cy.get('fieldset').find('.listwidget').eq(0).find('input').eq(0).click();
     cy.get('fieldset').find('.listwidget').eq(1).find('input').eq(0).click();
     cy.get('button').contains('Submit proposal').click();

--- a/funnel/assets/cypress/integration/10_addProposal.js
+++ b/funnel/assets/cypress/integration/10_addProposal.js
@@ -19,7 +19,6 @@ describe('Add a new proposal', function () {
     cy.location('pathname').should('contain', 'proposals');
     cy.get('a[data-cy="propose-a-session"]').click();
     cy.location('pathname').should('contain', 'new');
-    cy.get('#speaking label').eq(0).click();
     cy.get('#title').type(proposal.title);
     cy.get('#field-body')
       .find('.CodeMirror textarea')
@@ -27,7 +26,7 @@ describe('Add a new proposal', function () {
     cy.get('#field-video_url').type(proposal.preview_video);
     cy.get('fieldset').find('.listwidget').eq(0).find('input').eq(0).click();
     cy.get('fieldset').find('.listwidget').eq(1).find('input').eq(0).click();
-    cy.get('button').contains('Submit proposal').click();
+    cy.get('button').contains('Submit').click();
     cy.location('pathname').should('contain', 'proposals');
 
     cy.get('.proposal__section__headline')

--- a/funnel/assets/js/comments.js
+++ b/funnel/assets/js/comments.js
@@ -5,6 +5,7 @@ import { userAvatarUI, faSvg, shareDropdown } from './vue_util';
 const Comments = {
   init({
     newCommentUrl,
+    commentsUrl,
     divElem,
     commentTemplate,
     isuserloggedin,
@@ -250,6 +251,7 @@ const Comments = {
         },
         fetchCommentsList() {
           $.ajax({
+            url: commentsUrl,
             type: 'GET',
             timeout: window.Hasgeek.config.ajaxTimeout,
             dataType: 'json',

--- a/funnel/forms/proposal.py
+++ b/funnel/forms/proposal.py
@@ -4,7 +4,6 @@ from coaster.auth import current_auth
 import baseframe.forms as forms
 
 from ..models import Proposal
-from .helpers import EmailAddressAvailable
 
 __all__ = [
     'ProposalForm',
@@ -131,49 +130,14 @@ class ProposalLabelsAdminForm(forms.Form):
 
 @Proposal.forms('main')
 class ProposalForm(forms.Form):
-    speaking = forms.RadioField(
-        __("Are you speaking?"),
-        coerce=int,
-        choices=[
-            (1, __("I will be speaking")),
-            (0, __("I’m proposing a topic for someone to speak on")),
-        ],
-    )
     title = forms.StringField(
         __("Title"),
         validators=[forms.validators.DataRequired()],
         filters=[forms.filters.strip()],
         description=__("The title of your session"),
     )
-    abstract = forms.MarkdownField(
-        __("Abstract"),
-        validators=[forms.validators.DataRequired()],
-        description=__(
-            "A brief description of your session with target audience and key takeaways"
-        ),
-    )
-    outline = forms.MarkdownField(
-        __("Outline"),
-        validators=[forms.validators.DataRequired()],
-        description=__(
-            "A detailed description of the session with the sequence of ideas to be presented"
-        ),
-    )
-    requirements = forms.MarkdownField(
-        __("Requirements"),
-        description=__("For workshops, what must participants bring to the session?"),
-    )
-    slides = forms.URLField(
-        __("Slides"),
-        validators=[
-            forms.validators.Optional(),
-            forms.validators.URL(),
-            forms.validators.ValidUrl(),
-        ],
-        description=__(
-            "Link to your slides. These can be just an outline initially. "
-            "If you provide a Slideshare/Speakerdeck link, we'll embed slides in the page"
-        ),
+    body = forms.MarkdownField(
+        __("Content"), validators=[forms.validators.DataRequired()]
     )
     video_url = forms.URLField(
         __("Preview Video"),
@@ -188,43 +152,6 @@ class ProposalForm(forms.Form):
             "If you provide a YouTube/Vimeo link, we'll embed it in the page"
         ),
     )
-    links = forms.TextAreaField(
-        __("Links"),
-        description=__(
-            "Other links, one per line. Provide links to your profile and "
-            "slides and videos from your previous sessions; anything that'll help "
-            "folks decide if they want to attend your session"
-        ),
-    )
-    bio = forms.MarkdownField(
-        __("Speaker bio"),
-        validators=[forms.validators.DataRequired()],
-        description=__("Tell us why you are the best person to be taking this session"),
-    )
-    email = forms.EmailField(
-        __("Your email address"),
-        validators=[
-            forms.validators.DataRequired(),
-            EmailAddressAvailable(purpose='use'),
-        ],
-        description=__(
-            "An email address we can contact you at. Not displayed anywhere"
-        ),
-    )
-    phone = forms.StringField(
-        __("Phone number"),
-        validators=[forms.validators.DataRequired(), forms.validators.Length(max=80)],
-        description=__(
-            "A phone number we can call you at to discuss your proposal, if required. "
-            "Will not be displayed"
-        ),
-    )
-    location = forms.StringField(
-        __("Your location"),
-        validators=[forms.validators.DataRequired(), forms.validators.Length(max=80)],
-        description=__("Your location, to help plan for your travel if required"),
-    )
-
     formlabels = forms.FormField(forms.Form, __("Labels"))
 
     def set_queries(self):

--- a/funnel/forms/proposal.py
+++ b/funnel/forms/proposal.py
@@ -134,23 +134,18 @@ class ProposalForm(forms.Form):
         __("Title"),
         validators=[forms.validators.DataRequired()],
         filters=[forms.filters.strip()],
-        description=__("The title of your session"),
     )
     body = forms.MarkdownField(
         __("Content"), validators=[forms.validators.DataRequired()]
     )
     video_url = forms.URLField(
-        __("Preview Video"),
+        __("Video"),
         validators=[
             forms.validators.Optional(),
             forms.validators.URL(),
             forms.validators.ValidUrl(),
         ],
-        description=__(
-            "Link to your preview video. Use a video to engage the community and give them a better "
-            "idea about what you are planning to cover in your session and why they should attend. "
-            "If you provide a YouTube/Vimeo link, we'll embed it in the page"
-        ),
+        description=__("YouTube or Vimeo URL (optional)"),
     )
     formlabels = forms.FormField(forms.Form, __("Labels"))
 

--- a/funnel/models/proposal.py
+++ b/funnel/models/proposal.py
@@ -14,7 +14,6 @@ from ..utils import geonameid_from_location
 from . import (
     BaseMixin,
     BaseScopedIdNameMixin,
-    CoordinatesMixin,
     MarkdownColumn,
     TimestampMixin,
     TSVectorType,
@@ -113,9 +112,8 @@ class PROPOSAL_STATE(LabeledEnum):  # NOQA: N801
 
 class Proposal(
     UuidMixin,
-    EmailAddressMixin,
+    EmailAddressMixin,  # TODO: Remove this, email is in user account anyway
     BaseScopedIdNameMixin,
-    CoordinatesMixin,
     VideoMixin,
     db.Model,
 ):
@@ -143,8 +141,9 @@ class Proposal(
         grants={'presenter'},
     )
 
+    # TODO: Remove this, phone is in user account anyway
     phone = db.Column(db.Unicode(80), nullable=True)
-    bio = MarkdownColumn('bio', nullable=True)
+
     project_id = db.Column(None, db.ForeignKey('project.id'), nullable=False)
     project = with_roles(
         db.relationship(
@@ -156,11 +155,18 @@ class Proposal(
     )
     parent = db.synonym('project')
 
+    # TODO: Deprecated
     abstract = MarkdownColumn('abstract', nullable=True)
+    # TODO: Deprecated
     outline = MarkdownColumn('outline', nullable=True)
+    # TODO: Deprecated
     requirements = MarkdownColumn('requirements', nullable=True)
+    # TODO: Deprecated
     slides = db.Column(UrlType, nullable=True)
+    # TODO: Deprecated
     links = db.Column(db.Text, default='', nullable=True)
+    # TODO: Deprecated
+    bio = MarkdownColumn('bio', nullable=True)
 
     _state = db.Column(
         'state',
@@ -186,38 +192,33 @@ class Proposal(
         back_populates='proposal',
     )
 
+    body = MarkdownColumn('body', nullable=False, default='')
+    description = db.Column(db.Unicode, nullable=False, default='')
+    custom_description = db.Column(db.Boolean, nullable=False, default=False)
+    template = db.Column(db.Boolean, nullable=False, default=False)
+    featured = db.Column(db.Boolean, nullable=False, default=False)
+
     edited_at = db.Column(db.TIMESTAMP(timezone=True), nullable=True)
-    location = db.Column(db.Unicode(80), nullable=False)
+    # TODO: Deprecated, take from proposer profile
+    location = db.Column(db.Unicode(80), nullable=False, default='')
 
     search_vector = db.deferred(
         db.Column(
             TSVectorType(
                 'title',
-                'abstract_text',
-                'outline_text',
-                'requirements_text',
-                'slides',
-                'links',
-                'bio_text',
+                'description',
+                'body_text',
                 weights={
                     'title': 'A',
-                    'abstract_text': 'B',
-                    'outline_text': 'B',
-                    'requirements_text': 'B',
-                    'slides': 'B',
-                    'links': 'B',
-                    'bio_text': 'B',
+                    'description': 'B',
+                    'body_text': 'B',
                 },
                 regconfig='english',
                 hltext=lambda: db.func.concat_ws(
                     visual_field_delimiter,
                     Proposal.title,
                     User.fullname,
-                    Proposal.abstract_html,
-                    Proposal.outline_html,
-                    Proposal.requirements_html,
-                    Proposal.links,
-                    Proposal.bio_html,
+                    Proposal.body_html,
                 ),
             ),
             nullable=False,
@@ -236,21 +237,19 @@ class Proposal(
                 'uuid_b58',
                 'url_name_uuid_b58',
                 'title',
+                'body',
                 'user',
                 'speaker',
                 'owner',
                 'speaking',
-                'bio',
-                'abstract',
-                'outline',
-                'requirements',
-                'slides',
+                'bio',  # TODO: Deprecated
+                'abstract',  # TODO: Deprecated
+                'outline',  # TODO: Deprecated
+                'requirements',  # TODO: Deprecated
+                'slides',  # TODO: Deprecated
                 'video',
-                'links',
-                'location',
-                'latitude',
-                'longitude',
-                'coordinates',
+                'links',  # TODO: Deprecated
+                'location',  # TODO: Deprecated
                 'session',
                 'project',
                 'datetime',
@@ -267,47 +266,43 @@ class Proposal(
             'uuid_b58',
             'url_name_uuid_b58',
             'title',
+            'body',
             'user',
             'speaker',
             'speaking',
-            'bio',
-            'abstract',
-            'outline',
-            'requirements',
-            'slides',
+            'bio',  # TODO: Deprecated
+            'abstract',  # TODO: Deprecated
+            'outline',  # TODO: Deprecated
+            'requirements',  # TODO: Deprecated
+            'slides',  # TODO: Deprecated
             'video',
-            'links',
-            'location',
-            'latitude',
-            'longitude',
-            'coordinates',
+            'links',  # TODO: Deprecated
+            'location',  # TODO: Deprecated
             'session',
             'project',
-            'email',
-            'phone',
+            'email',  # TODO: Deprecated
+            'phone',  # TODO: Deprecated
         },
         'without_parent': {
             'urls',
             'uuid_b58',
             'url_name_uuid_b58',
             'title',
+            'body',
             'user',
             'speaker',
             'speaking',
-            'bio',
-            'abstract',
-            'outline',
-            'requirements',
-            'slides',
+            'bio',  # TODO: Deprecated
+            'abstract',  # TODO: Deprecated
+            'outline',  # TODO: Deprecated
+            'requirements',  # TODO: Deprecated
+            'slides',  # TODO: Deprecated
             'video',
-            'links',
-            'location',
-            'latitude',
-            'longitude',
-            'coordinates',
+            'links',  # TODO: Deprecated
+            'location',  # TODO: Deprecated
             'session',
-            'email',
-            'phone',
+            'email',  # TODO: Deprecated
+            'phone',  # TODO: Deprecated
         },
         'related': {'urls', 'uuid_b58', 'url_name_uuid_b58', 'title'},
     }
@@ -531,10 +526,20 @@ class Proposal(
         return self.created_at  # Until proposals have a workflow-driven datetime
 
     @cached_property
-    def has_outstation_speaker(self):
+    def has_outstation_speaker(self) -> bool:
         """Verify if geocoded proposal location field differs from project location."""
+        if not self.location:
+            return False
         geonameid = geonameid_from_location(self.location)
         return bool(geonameid) and self.project.location_geonameid.isdisjoint(geonameid)
+
+    def update_description(self) -> None:
+        if not self.custom_description:
+            body = self.body_text.strip()
+            if body:
+                self.description = body.splitlines()[0]
+            else:
+                self.description = ''
 
     def getnext(self):
         return (

--- a/funnel/templates/project_comments.html.jinja2
+++ b/funnel/templates/project_comments.html.jinja2
@@ -63,6 +63,7 @@
 
       var commentsConfig = {
         newCommentUrl: "{{ project.commentset.url_for('new_comment') }}",
+        commentsUrl: "{{ project.url_for('comments') }}",
         comments: [],
         divElem: "#comments-wrapper",
         commentTemplate: '#comment-template',

--- a/funnel/templates/proposal.html.jinja2
+++ b/funnel/templates/proposal.html.jinja2
@@ -5,13 +5,7 @@
 {%- from "macros.html.jinja2" import embed_video_player, video_action_bar, comments_tree,  project_mini_header %}
 {%- from "js/comments.js.jinja2" import comments_tree, comment_template %}
 {% block title %}{{ proposal.title }}{% endblock %}
-{% block description %}
-  {%- if proposal.speaker -%}
-    {% trans title=proposal.title, speaker=proposal.speaker.pickername, project=project.title %}{{ title }} by {{ speaker }}, {{ project }}{% endtrans %}
-  {%- else -%}
-    {{ proposal.title }}, {{ project.title }}
-  {%- endif -%}
-{% endblock %}
+{% block description %}{{ proposal.description }}{% endblock %}
 
 {%- block pageheaders %}
   {% assets "css_codemirrormarkdown" -%}
@@ -232,49 +226,7 @@
 
       <div class="proposal__section proposal__section--left">
         <div class="proposal-content">
-          <h3 class="mui--text-headline mui--text-bold">{% trans %}Abstract{% endtrans %} {% if 'edit_proposal' in proposal.permissions(current_auth.user) %}<a href="{{ proposal.url_for('edit') }}#field-abstract" class="mui--text-subhead mui--align-middle"> {{ faicon(icon='edit', icon_size='subhead', baseline=false, css_class='fa5--link') }}</a>{% endif %}</h3>
-          <div class="mui--text-subhead">{{ proposal.abstract }}</div>
-
-          <h3 class="mui--text-headline mui--text-bold">{% trans %}Outline{% endtrans %} {% if 'edit_proposal' in proposal.permissions(current_auth.user) %}<a href="{{ proposal.url_for('edit') }}#field-outline" class="mui--text-subhead mui--align-middle"> {{ faicon(icon='edit', icon_size='subhead', baseline=false, css_class='fa5--link') }}</a>{% endif %}</h3>
-          <div class="mui--text-subhead">{{ proposal.outline }}</div>
-
-          {% if proposal.requirements.text -%}
-            <h3 class="mui--text-headline mui--text-bold">{% trans %}Requirements{% endtrans %} {% if 'edit_proposal' in proposal.permissions(current_auth.user) %}<a href="{{ proposal.url_for('edit') }}#field-requirements" class="mui--text-subhead mui--align-middle"> {{ faicon(icon='edit', icon_size='subhead', baseline=false, css_class='fa5--link') }}</a>{% endif %} </h3>
-            <div class="mui--text-subhead">{{ proposal.requirements }}</div>
-          {%- elif 'edit_proposal' in proposal.permissions(current_auth.user) %}
-            <h3 class="mui--text-headline mui--text-bold">{% trans %}Requirements{% endtrans %} <a href="{{ proposal.url_for('edit') }}#field-requirements" class="mui--text-subhead mui--align-middle"> {{ faicon(icon='edit', icon_size='subhead', baseline=false, css_class='fa5--link') }}</a></h3>
-            <p><i>{% trans %}This section is empty.{% endtrans %}</i></p>
-          {%- endif %}
-
-          {% if proposal.bio.text -%}
-            <h3 class="mui--text-headline mui--text-bold">{% trans %}Speaker bio{% endtrans %} {% if 'edit_proposal' in proposal.permissions(current_auth.user) %}<a href="{{ proposal.url_for('edit') }}#field-bio" class="mui--text-subhead mui--align-middle"> {{ faicon(icon='edit', icon_size='subhead', baseline=false, css_class='fa5--link') }}</a>{% endif %}</h3>
-            <div class="mui--text-subhead">{{ proposal.bio }}</div>
-          {%- endif %}
-
-          {% if proposal.links %}
-            <h3 class="mui--text-headline mui--text-bold">{% trans %}Links{% endtrans %} {% if 'edit_proposal' in proposal.permissions(current_auth.user) %}<a href="{{ proposal.url_for('edit') }}#field-links" class="mui--text-subhead mui--align-middle"> {{ faicon(icon='edit', icon_size='subhead', baseline=false, css_class='fa5--link') }}</a>{% endif %}</h3>
-            <ul class="links-list">
-              {% for link in links -%}
-                <li class="mui--text-subhead">{{ link }}</li>
-              {% endfor %}
-            </ul>
-          {%- elif 'edit_proposal' in proposal.permissions(current_auth.user) %}
-            <h3 class="mui--text-headline mui--text-bold">{% trans %}Links{% endtrans %} <a href="{{ proposal.url_for('edit') }}#field-links" class="mui--text-subhead mui--align-middle">{{ faicon(icon='edit', icon_size='subhead', baseline=false, css_class='fa5--link') }}</a></h3>
-            <p><i>{% trans %}This section is empty.{% endtrans %}</i></p>
-          {% endif %}
-
-          {% if proposal.slides.url %}
-            <h3 class="mui--text-headline mui--text-bold">{% trans %}Slides{% endtrans %} {% if 'edit_proposal' in proposal.permissions(current_auth.user) %}<a href="{{ proposal.url_for('edit') }}#field-slides" class="mui--text-subhead mui--align-middle"> {{ faicon(icon='edit', icon_size='subhead', baseline=false, css_class='fa5--link') }}</a>{% endif %}</h3>
-            <a href="{{ proposal.slides }}">{{ proposal.slides }}</a>
-          {%- elif 'edit_proposal' in proposal.permissions(current_auth.user) %}
-            <h3 class="mui--text-headline mui--text-bold">{% trans %}Slides{% endtrans %} <a href="{{ proposal.url_for('edit') }}#field-slides" class="mui--text-subhead mui--align-middle"> {{ faicon(icon='edit', icon_size='subhead', baseline=false, css_class='fa5--link') }}</a></h3>
-            <p><i>{% trans %}This section is empty.{% endtrans %}</i></p>
-          {% endif %}
-
-          {% if proposal.video %}
-            <h3 class="mui--text-headline mui--text-bold">{% trans %}Preview video{% endtrans %}</h3>
-            <a href="{{ proposal.video.url }}">{{ proposal.video.url }}</a>
-          {% endif %}
+          {{ proposal.body }}
         </div>
       </div>
 

--- a/funnel/templates/proposal.html.jinja2
+++ b/funnel/templates/proposal.html.jinja2
@@ -264,6 +264,7 @@
 
     var commentsConfig = {
       newCommentUrl: "{{ proposal.commentset.url_for('new_comment') }}",
+      commentsUrl: "{{ proposal.url_for('comments') }}",
       divElem: "#comments-wrapper",
       commentTemplate: '#comment-template',
       isuserloggedin: {% if current_auth.user -%}true{% else %}false{% endif %},

--- a/funnel/views/proposal.py
+++ b/funnel/views/proposal.py
@@ -1,4 +1,4 @@
-from flask import Markup, abort, escape, flash, jsonify, redirect, request
+from flask import Markup, abort, escape, flash, jsonify, redirect
 
 from bleach import linkify
 
@@ -77,28 +77,9 @@ def proposal_data(proposal):
             ('fullname', proposal.owner.fullname),
             ('proposer', proposal.user.pickername),
             ('speaker', proposal.speaker.pickername if proposal.speaker else None),
-            (
-                'objective',
-                proposal.abstract.html,
-            ),  # TODO: Remove this, name has changed
-            (
-                'description',
-                proposal.outline.html,
-            ),  # TODO: Remove this, name has changed
-            (
-                'requirements',
-                proposal.requirements.html,
-            ),  # TODO: Remove this, name has changed
-            ('abstract_text', proposal.abstract.text),
-            ('abstract_html', proposal.abstract.html),
-            ('outline_text', proposal.outline.text),
-            ('outline_html', proposal.outline.html),
-            ('requirements_text', proposal.requirements.text),
-            ('requirements_html', proposal.requirements.html),
-            ('slides', proposal.slides.url if proposal.slides else ''),
-            ('links', proposal.links),
+            ('description', proposal.description),
+            ('body', proposal.body.html),
             ('video', proposal.video),
-            ('bio', proposal.bio.html),
             ('votes', proposal.voteset.count),
             ('comments', proposal.commentset.count),
             ('submitted', proposal.created_at.isoformat()),
@@ -141,26 +122,25 @@ class BaseProjectProposalView(ProjectViewMixin, UrlChangeCheck, UrlForView, Mode
         # This along with the `reader` role makes it possible for
         # anyone to submit a proposal if the CFP is open.
         if not self.obj.cfp_state.OPEN:
-            flash(_("CFP for this project is not open"), 'error')
+            flash(_("This project is not accepting submissions"), 'error')
             return redirect(self.obj.url_for(), code=303)
 
         form = ProposalForm(model=Proposal, parent=self.obj)
 
-        if request.method == 'GET':
-            form.email.data = str(current_auth.user.email)
-            form.phone.data = str(current_auth.user.phone)
-
         if form.validate_on_submit():
-            proposal = Proposal(user=current_auth.user, project=self.obj)
+            proposal = Proposal(
+                user=current_auth.user, speaker=current_auth.user, project=self.obj
+            )
             db.session.add(proposal)
             with db.session.no_autoflush:
                 form.populate_obj(proposal)
             proposal.name = make_name(proposal.title)
+            proposal.update_description()
             proposal.voteset.vote(
                 current_auth.user
             )  # Vote up your own proposal by default
             db.session.commit()
-            flash(_("Your new session proposal has been submitted"), 'info')
+            flash(_("Your proposal has been submitted"), 'info')
             dispatch_notification(
                 ProposalSubmittedNotification(document=proposal),
                 ProposalReceivedNotification(
@@ -171,8 +151,8 @@ class BaseProjectProposalView(ProjectViewMixin, UrlChangeCheck, UrlForView, Mode
 
         return render_form(
             form=form,
-            title=_("Submit a session proposal"),
-            submit=_("Submit proposal"),
+            title=_("Submit a proposal"),
+            submit=_("Submit"),
             message=Markup(
                 _(
                     'This form uses <a target="_blank" rel="noopener noreferrer" href="https://www.markdownguide.org/basic-syntax/">Markdown</a> for formatting.'
@@ -211,6 +191,8 @@ class ProposalView(ProposalViewMixin, UrlChangeCheck, UrlForView, ModelView):
     @render_with('proposal.html.jinja2')
     @requires_permission('view')
     def view(self):
+        # FIXME: Use a separate endpoint for comments as this is messing with browser
+        # cache. View Source on proposal pages shows comments tree instead of source
         if request_is_xhr():
             return jsonify({'comments': self.obj.commentset.views.json_comments()})
 
@@ -265,12 +247,11 @@ class ProposalView(ProposalViewMixin, UrlChangeCheck, UrlForView, ModelView):
     @requires_permission('edit_proposal')
     def edit(self):
         form = ProposalForm(obj=self.obj, model=Proposal, parent=self.obj.project)
-        if self.obj.user != current_auth.user:
-            del form.speaking
         if form.validate_on_submit():
             with db.session.no_autoflush:
                 form.populate_obj(self.obj)
             self.obj.name = make_name(self.obj.title)
+            self.obj.update_description()
             self.obj.edited_at = db.func.utcnow()
             db.session.commit()
             flash(_("Your changes have been saved"), 'info')

--- a/funnel/views/proposal.py
+++ b/funnel/views/proposal.py
@@ -2,7 +2,7 @@ from flask import Markup, abort, escape, flash, jsonify, redirect
 
 from bleach import linkify
 
-from baseframe import _, request_is_xhr
+from baseframe import _, __, request_is_xhr
 from baseframe.forms import Form, render_delete_sqla, render_form
 from coaster.auth import current_auth
 from coaster.utils import make_name
@@ -57,6 +57,12 @@ proposal_headers = [
     'submitted',
     'confirmed',
 ]
+
+
+markdown_message = __(
+    'This form uses <a target="_blank" rel="noopener noreferrer"'
+    ' href="https://www.markdownguide.org/basic-syntax/">Markdown</a> for formatting.'
+)
 
 
 def proposal_data(proposal):
@@ -153,11 +159,7 @@ class BaseProjectProposalView(ProjectViewMixin, UrlChangeCheck, UrlForView, Mode
             form=form,
             title=_("Submit a proposal"),
             submit=_("Submit"),
-            message=Markup(
-                _(
-                    'This form uses <a target="_blank" rel="noopener noreferrer" href="https://www.markdownguide.org/basic-syntax/">Markdown</a> for formatting.'
-                )
-            ),
+            message=markdown_message,
         )
 
 
@@ -258,13 +260,9 @@ class ProposalView(ProposalViewMixin, UrlChangeCheck, UrlForView, ModelView):
             return redirect(self.obj.url_for(), code=303)
         return render_form(
             form=form,
-            title=_("Edit session proposal"),
-            submit=_("Update proposal"),
-            message=Markup(
-                _(
-                    'This form uses <a target="_blank" rel="noopener noreferrer" href="https://www.markdownguide.org/basic-syntax/">Markdown</a> for formatting.'
-                )
-            ),
+            title=_("Edit proposal"),
+            submit=_("Update"),
+            message=markdown_message,
         )
 
     @route('delete', methods=['GET', 'POST'])

--- a/migrations/versions/ad5013552ec6_simplify_proposal_fields.py
+++ b/migrations/versions/ad5013552ec6_simplify_proposal_fields.py
@@ -1,0 +1,215 @@
+"""Simplify Proposal fields.
+
+Revision ID: ad5013552ec6
+Revises: daeb6753652a
+Create Date: 2020-12-08 13:58:56.331436
+
+"""
+from textwrap import dedent
+
+from alembic import op
+from sqlalchemy.sql import column, table
+import sqlalchemy as sa
+
+from progressbar import ProgressBar
+import progressbar.widgets
+
+from coaster.utils import markdown
+
+# revision identifiers, used by Alembic.
+revision = 'ad5013552ec6'
+down_revision = 'daeb6753652a'
+branch_labels = None
+depends_on = None
+
+
+proposal = table(
+    'proposal',
+    column('id', sa.Integer()),
+    # New fields
+    column('body_text', sa.UnicodeText()),
+    column('body_html', sa.UnicodeText()),
+    column('description', sa.Unicode()),
+    # Old fields
+    column('abstract_text', sa.UnicodeText()),
+    column('outline_text', sa.UnicodeText()),
+    column('requirements_text', sa.UnicodeText()),
+    column('slides', sa.Unicode()),
+    column('links', sa.UnicodeText()),
+    column('bio_text', sa.UnicodeText()),
+    column('bio_html', sa.UnicodeText()),
+)
+
+
+def get_progressbar(label, maxval):
+    return ProgressBar(
+        maxval=maxval,
+        widgets=[
+            label,
+            ': ',
+            progressbar.widgets.Percentage(),
+            ' ',
+            progressbar.widgets.Bar(),
+            ' ',
+            progressbar.widgets.ETA(),
+            ' ',
+        ],
+    )
+
+
+def proposal_body(row):
+    """Return text for proposal body."""
+    # This template does not have localization because it adapts data from when the
+    # website was English-only. CRLF line endings are used as per the HTTP form spec
+    body = ''
+    if row.abstract_text:
+        body += f"{row.abstract_text.strip()}\r\n\r\n"
+    if row.outline_text:
+        body += f"### Outline\r\n\r\n{row.outline_text.strip()}\r\n\r\n"
+    if row.requirements_text:
+        body += f"### Requirements\r\n\r\n{row.requirements_text.strip()}\r\n\r\n"
+    if row.bio_text:
+        body += f"### Speaker bio\r\n\r\n{row.bio_text.strip()}\r\n\r\n"
+    if row.links:
+        links = '\r\n'.join(
+            f" * {link}" for link in row.links.strip().splitlines() if link
+        ).strip()
+        body += f"### Links\r\n\r\n{links}\r\n\r\n"
+    if row.slides:
+        body += f"### Slides\r\n\r\n{row.slides.strip()}\r\n\r\n"
+    return body
+
+
+def upgrade():
+    conn = op.get_bind()
+    # Add and populate body and description fields
+    op.add_column('proposal', sa.Column('body_text', sa.UnicodeText(), nullable=True))
+    op.add_column('proposal', sa.Column('body_html', sa.UnicodeText(), nullable=True))
+    op.add_column('proposal', sa.Column('description', sa.Unicode(), nullable=True))
+
+    count = conn.scalar(sa.select([sa.func.count('*')]).select_from(proposal))
+    progress = get_progressbar("Proposals", count)
+    progress.start()
+    items = conn.execute(proposal.select())
+    for counter, item in enumerate(items):
+        body_text = proposal_body(item)
+        body_html = markdown(body_text)
+        conn.execute(
+            sa.update(proposal)
+            .where(proposal.c.id == item.id)
+            .values(
+                description=(
+                    item.abstract_text.strip().splitlines()[0].strip()
+                    if item.abstract_text
+                    else ''
+                ),
+                body_text=body_text,
+                body_html=body_html,
+            )
+        )
+        progress.update(counter)
+    progress.finish()
+
+    op.alter_column('proposal', 'body_text', nullable=False)
+    op.alter_column('proposal', 'body_html', nullable=False)
+    op.alter_column('proposal', 'description', nullable=False)
+
+    # Add and populate flag fields
+    op.add_column(
+        'proposal',
+        sa.Column(
+            'custom_description',
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.sql.expression.true(),
+        ),
+    )
+    op.alter_column('proposal', 'custom_description', server_default=None)
+    op.add_column(
+        'proposal',
+        sa.Column(
+            'template',
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.sql.expression.false(),
+        ),
+    )
+    op.alter_column('proposal', 'template', server_default=None)
+    op.add_column(
+        'proposal',
+        sa.Column(
+            'featured',
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.sql.expression.false(),
+        ),
+    )
+    op.alter_column('proposal', 'featured', server_default=None)
+
+    # Drop never-used coordinates columns
+    op.drop_column('proposal', 'latitude')
+    op.drop_column('proposal', 'longitude')
+
+    # Update search vector
+    op.execute(
+        sa.DDL(
+            dedent(
+                '''
+        UPDATE proposal SET search_vector = setweight(to_tsvector('english', COALESCE(title, '')), 'A') || setweight(to_tsvector('english', COALESCE(description, '')), 'B') || setweight(to_tsvector('english', COALESCE(body_text, '')), 'B');
+
+        DROP TRIGGER proposal_search_vector_trigger ON proposal;
+        DROP FUNCTION proposal_search_vector_update();
+
+        CREATE FUNCTION proposal_search_vector_update() RETURNS trigger AS $$
+        BEGIN
+            NEW.search_vector := setweight(to_tsvector('english', COALESCE(NEW.title, '')), 'A') || setweight(to_tsvector('english', COALESCE(NEW.description, '')), 'B') || setweight(to_tsvector('english', COALESCE(NEW.body_text, '')), 'B');
+            RETURN NEW;
+        END
+        $$ LANGUAGE plpgsql;
+
+        CREATE TRIGGER proposal_search_vector_trigger BEFORE INSERT OR UPDATE ON proposal
+        FOR EACH ROW EXECUTE PROCEDURE proposal_search_vector_update();
+                '''
+            )
+        )
+    )
+
+
+def downgrade():
+    op.execute(
+        sa.DDL(
+            dedent(
+                '''
+        UPDATE proposal SET search_vector = setweight(to_tsvector('english', COALESCE(title, '')), 'A') || setweight(to_tsvector('english', COALESCE(abstract_text, '')), 'B') || setweight(to_tsvector('english', COALESCE(outline_text, '')), 'B') || setweight(to_tsvector('english', COALESCE(requirements_text, '')), 'B') || setweight(to_tsvector('english', COALESCE(slides, '')), 'B') || setweight(to_tsvector('english', COALESCE(links, '')), 'B') || setweight(to_tsvector('english', COALESCE(bio_text, '')), 'B');
+
+        DROP TRIGGER proposal_search_vector_trigger ON proposal;
+        DROP FUNCTION proposal_search_vector_update();
+
+        CREATE FUNCTION proposal_search_vector_update() RETURNS trigger AS $$
+        BEGIN
+            NEW.search_vector := setweight(to_tsvector('english', COALESCE(NEW.title, '')), 'A') || setweight(to_tsvector('english', COALESCE(NEW.abstract_text, '')), 'B') || setweight(to_tsvector('english', COALESCE(NEW.outline_text, '')), 'B') || setweight(to_tsvector('english', COALESCE(NEW.requirements_text, '')), 'B') || setweight(to_tsvector('english', COALESCE(NEW.slides, '')), 'B') || setweight(to_tsvector('english', COALESCE(NEW.links, '')), 'B') || setweight(to_tsvector('english', COALESCE(NEW.bio_text, '')), 'B');
+            RETURN NEW;
+        END
+        $$ LANGUAGE plpgsql;
+
+        CREATE TRIGGER proposal_search_vector_trigger BEFORE INSERT OR UPDATE ON proposal
+        FOR EACH ROW EXECUTE PROCEDURE proposal_search_vector_update();
+                '''
+            )
+        )
+    )
+
+    op.add_column(
+        'proposal',
+        sa.Column('longitude', sa.NUMERIC(), autoincrement=False, nullable=True),
+    )
+    op.add_column(
+        'proposal',
+        sa.Column('latitude', sa.NUMERIC(), autoincrement=False, nullable=True),
+    )
+    op.drop_column('proposal', 'featured')
+    op.drop_column('proposal', 'template')
+    op.drop_column('proposal', 'custom_description')
+    op.drop_column('proposal', 'description')
+    op.drop_column('proposal', 'body_html')
+    op.drop_column('proposal', 'body_text')


### PR DESCRIPTION
This PR replaces the multiple fields used in proposals so far (abstract, outline, etc) with a single "body" field. Existing proposals are migrated by converting the fields to Markdown headers.

This PR _does not_ delete legacy fields from the database as a transition period is prudent. A second PR following this must delete them. Additionally, a decision has to be made on handling existing data for three deprecated fields: email, phone and location.