### PR TITLE
Hide the project menu on comments pages in mobile

### DIFF
--- a/funnel/assets/js/comments.js
+++ b/funnel/assets/js/comments.js
@@ -64,7 +64,6 @@ const Comments = {
             this.formAction.forEach((commentForm) => {
               this[commentForm.form] = false;
             });
-            $('#js-header').removeClass('header--lowzindex');
             this.$parent.refreshCommentsTimer();
           }
         },
@@ -175,7 +174,6 @@ const Comments = {
           this.activateForm(this.COMMENTACTIONS.NEW, textareaId);
         },
         activateForm(action, textareaId, parentApp = app) {
-          $('#js-header').addClass('header--lowzindex');
           if (textareaId) {
             this.$nextTick(() => {
               let editor = window.CodeMirror.fromTextArea(
@@ -205,7 +203,6 @@ const Comments = {
             this.commentForm = false;
             this.formTitle = '';
             this.showmodal = false;
-            $('#js-header').removeClass('header--lowzindex');
             this.refreshCommentsTimer();
           }
         },

--- a/funnel/static/css/app.css
+++ b/funnel/static/css/app.css
@@ -2545,8 +2545,9 @@ a.loginbutton.hidden,
 .ajax-form .mui-form .mui-form__fields .CodeMirror {
   border: 1px solid #0f73ed;
   border-radius: 16px 16px 0 16px;
-  min-height: 16px;
+  min-height: 56px;
   padding: 16px;
+  height: auto;
 }
 .ajax-form .mui-form .mui-form__fields .CodeMirror ~ .CodeMirror {
   display: none;
@@ -4126,7 +4127,7 @@ a.loginbutton.hidden,
     justify-content: space-between;
   }
   .proposal-card--fullwidth .proposal-card__video {
-    min-width: 200px;
+    width: 200px;
     margin-top: 14px;
     margin: 14px 0 0 16px;
   }
@@ -4381,6 +4382,10 @@ a.loginbutton.hidden,
 }
 
 @media (max-width: 767px) {
+  .comments-page .project-header {
+    display: none;
+  }
+
   .post-form-block {
     position: fixed;
     top: 16px;
@@ -4453,6 +4458,9 @@ a.loginbutton.hidden,
 .comment .comment__body .comment--children {
   padding-left: 8px;
   word-break: break-word;
+}
+.comment .comment__body .js-comment-form .ajax-form {
+  margin-top: 8px;
 }
 .comment
   .comment__body

--- a/funnel/static/sass/_comments.scss
+++ b/funnel/static/sass/_comments.scss
@@ -1,4 +1,9 @@
 @media (max-width: 767px) {
+  .comments-page {
+    .project-header {
+      display: none;
+    }
+  }
   .post-form-block {
     position: fixed;
     top: 16px;
@@ -69,6 +74,9 @@
       word-break: break-word;
     }
     .js-comment-form {
+      .ajax-form {
+        margin-top: $mui-grid-padding/2;
+      }
       > .comment__body__links.link-icon:first-child {
         padding-left: 0;
       }

--- a/funnel/static/sass/_form.scss
+++ b/funnel/static/sass/_form.scss
@@ -370,8 +370,9 @@
       .CodeMirror {
         border: 1px solid $mui-primary-color;
         border-radius: 16px 16px 0 16px;
-        min-height: 16px;
-        padding: 16px;
+        min-height: 56px;
+        padding: $mui-grid-padding;
+        height: auto;
       }
       .CodeMirror ~ .CodeMirror {
         display: none;

--- a/funnel/static/sass/_proposal.scss
+++ b/funnel/static/sass/_proposal.scss
@@ -170,7 +170,7 @@
     align-items: start;
     justify-content: space-between;
     .proposal-card__video {
-      min-width: 200px;
+      width: 200px;
       margin-top: 14px;
       margin: 14px 0 0 $mui-grid-padding;
     }

--- a/funnel/templates/js/comments.js.jinja2
+++ b/funnel/templates/js/comments.js.jinja2
@@ -13,7 +13,7 @@
       </a>
       <div class="mui--hidden-md mui--hidden-lg mui--hidden-xl" v-if="showmodal">
         <div class="mobile-nav mui--z1">
-          <span :aria-label="gettext('Close')" class="mui--text-dark mobile-nav__icon" data-ga="Close new comment form" @click="closeNewCommentForm($event)"><faicon :icon="'times'" :icon_size="'subhead'"></faicon></span><span class="mui--text-dark mobile-nav__headline">{{ formTitle }}</span>
+          <span :aria-label="gettext('Close')" class="mui--text-dark mobile-nav__icon" data-ga="Close new comment form" @click="closeNewCommentForm($event)"><faicon :icon="'times'" :icon_size="'title'"></faicon></span><span class="mui--text-dark mobile-nav__headline">{{ formTitle }}</span>
         </div>
       </div>
       <div class="ajax-form" :class="[showmodal ? 'ajax-form--mob' : '']" v-if="commentForm">
@@ -43,7 +43,7 @@
       <li class="comment" :class="[formOpened ? 'comment--modal' : '']"  :id="'c-' + comment.uuid_b58">
         <div class="mui--hidden-md mui--hidden-lg mui--hidden-xl" v-if="formOpened">
           <div class="mobile-nav mui--z1">
-            <span :aria-label="gettext('Close')" class="mui--text-dark mobile-nav__icon" data-ga="Close comment form" @click="closeAllForms($event)"><faicon :icon="'times'" :icon_size="'subhead'"></faicon></span><span class="mui--text-dark mobile-nav__headline">{{ commentFormTitle }}</span>
+            <span :aria-label="gettext('Close')" class="mui--text-dark mobile-nav__icon" data-ga="Close comment form" @click="closeAllForms($event)"><faicon :icon="'times'" :icon_size="'title'"></faicon></span><span class="mui--text-dark mobile-nav__headline">{{ commentFormTitle }}</span>
           </div>
         </div>
         <div class="comment__header">

--- a/funnel/templates/macros.html.jinja2
+++ b/funnel/templates/macros.html.jinja2
@@ -330,7 +330,7 @@
         </h1>
         <p class="mui--text-subhead mui--text-light zero-bottom-margin">{{ project.tagline }}</p>
       </div>
-      <div class="mui--pull-right">
+      <div class="mui--pull-right {% if current_page == 'comments' %}comments-page{%- endif %}">
         {{ project_share(project) }}
       </div>
     </div>

--- a/funnel/templates/project_settings.html.jinja2
+++ b/funnel/templates/project_settings.html.jinja2
@@ -74,7 +74,7 @@
           <li>
             <a href="{{ project.url_for('cfp') }}" data-cy="add-cfp">{% trans %}Add submission guidelines and timing{% endtrans %}</a>
           </li>
-        {% else -%}
+        {% elif project.view_for('cfp').is_available() -%}
           <li>
             <a href="{{ project.url_for('cfp') }}" data-cy="modify-cfp">{% trans %}Modify submission guidelines and timing{% endtrans %}</a>
           </li>


### PR DESCRIPTION
1. Hide project menu on header (bookmark, share, add to calendar) in comments page in mobile to show `New comments`.
   Since project header on inner project pages in mobile is not show, no need to reduce it's z-index.
2. Limit the image width in featured submission card
3. Show `Modify submission guidelines and timing` for editors
4. Limit the height of codemirror in comments form