### PR TITLE
Hiding comment content if user is suspended or deleted

### DIFF
--- a/funnel/models/commentvote.py
+++ b/funnel/models/commentvote.py
@@ -260,9 +260,9 @@ class Comment(UuidMixin, BaseMixin, db.Model):
     def user(self) -> Union[User, DuckTypeUser]:
         return (
             deleted_user
-            if self.state.DELETED
+            if self.state.DELETED or self._user.state.DELETED
             else removed_user
-            if self.state.SPAM
+            if self.state.SPAM or self._user.state.SUSPENDED
             else self._user
         )
 
@@ -282,9 +282,9 @@ class Comment(UuidMixin, BaseMixin, db.Model):
     def message(self) -> Union[str, Markup]:
         return (
             _('[deleted]')
-            if self.state.DELETED
+            if self.user == deleted_user
             else _('[removed]')
-            if self.state.SPAM
+            if self.user == removed_user
             else self._message
         )
 

--- a/funnel/models/user.py
+++ b/funnel/models/user.py
@@ -809,8 +809,12 @@ class DuckTypeUser(RoleMixin):
         self.fullname = self.title = self.pickername = representation
 
     def __str__(self) -> str:
-        """Represent user account as a string."""
-        return self.pickername
+        """
+        Represent user account as a string.
+
+        `str()` because `__str__()` needs to return a string object.
+        """
+        return str(self.pickername)
 
 
 deleted_user = DuckTypeUser(__("[deleted]"))

--- a/tests/unit/models/test_comment.py
+++ b/tests/unit/models/test_comment.py
@@ -1,0 +1,47 @@
+from funnel.models import Comment
+
+
+def test_spam_comment(db_session, user_twoflower, project_expo2010):
+    not_spam = Comment(
+        user=user_twoflower,
+        commentset=project_expo2010.commentset,
+        message="Test comment",
+    )
+    db_session.add(not_spam)
+    db_session.commit()
+
+    assert bool(not_spam.state.SPAM) is False
+    assert str(not_spam.message) == "Test comment"
+
+    not_spam.mark_spam()
+    db_session.commit()
+    spam = not_spam
+
+    assert bool(spam.state.SPAM) is True
+    assert str(spam.user) == "[removed]"
+    assert str(spam.message) == "[removed]"
+
+
+def test_suspended_user_comment(db_session, user_twoflower, project_expo2010):
+    not_spam = Comment(
+        user=user_twoflower,
+        commentset=project_expo2010.commentset,
+        message="Test comment 2",
+    )
+    db_session.add(not_spam)
+    db_session.commit()
+
+    assert bool(not_spam.state.SPAM) is False
+    assert str(not_spam.message) == "Test comment 2"
+
+    user_twoflower.mark_suspended()  # user gets suspended
+    db_session.commit()
+    comment_by_suspended_user = not_spam
+
+    assert bool(comment_by_suspended_user.state.SPAM) is False  # Comment is not spam
+    assert (
+        str(comment_by_suspended_user.user) == "[removed]"
+    )  # but the content is hidden
+    assert (
+        str(comment_by_suspended_user.message) == "[removed]"
+    )  # but the content is hidden


### PR DESCRIPTION
> Kiran Jonnalagadda, [17.03.21 11:34]
> @m0ntypy comments view does not exclude comments where the user is suspended. It should mark the user as such.
> 
> Kiran Jonnalagadda, [17.03.21 11:35]
> I've suspended a persistent spammer's account. Comments are still showing. https://hasgeek.com/thegoaproject/design/sub/project-defy-design-education-for-yourself-TUeVDbExzF9DQ3PcfE3jEE#c-PUU72uf7C4Ko8e2nTQHcB6