### PR TITLE
Use tz.localize with pytz timezones (as per #950)

### DIFF
--- a/funnel/models/video.py
+++ b/funnel/models/video.py
@@ -211,9 +211,9 @@ class VideoMixin:
 
                         data['duration'] = vimeo_video['duration']
                         # Vimeo returns naive datetime, we will add utc timezone to it
-                        data['uploaded_at'] = parse_isoformat(
-                            vimeo_video['upload_date'], delimiter=' '
-                        ).replace(tzinfo=utc)
+                        data['uploaded_at'] = utc.localize(
+                            parse_isoformat(vimeo_video['upload_date'], delimiter=' ')
+                        )
                         data['thumbnail'] = vimeo_video['thumbnail_medium']
                     elif vimeo_resp.status_code == 404:
                         # Video doesn't exist on Vimeo anymore

--- a/funnel/views/sitemap.py
+++ b/funnel/views/sitemap.py
@@ -52,7 +52,7 @@ class SitemapPage(NamedTuple):
 # The earliest date in Hasgeek's production database is 26 May 2011 (from Lastuser).
 # We use 1 May here as we're only interested in the month. Hasjob's dataset starts
 # earlier, from 14 Mar 2011, but this sitemap does not apply to Hasjob
-earliest_date = datetime(2011, 5, 1, tzinfo=utc)
+earliest_date = utc.localize(datetime(2011, 5, 1))
 
 
 def all_sitemap_days(until: datetime) -> list:
@@ -118,11 +118,11 @@ def validate_daterange(
 
     # Now make a date range
     if not day:
-        dtstart = datetime(year, month, 1, tzinfo=utc)
+        dtstart = utc.localize(datetime(year, month, 1))
         dtend = dtstart + relativedelta(months=1)
     else:
         try:
-            dtstart = datetime(year, month, day, tzinfo=utc)
+            dtstart = utc.localize(datetime(year, month, day))
         except ValueError:
             # Invalid day
             abort(404)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,7 +98,7 @@ def user_death(db_session):
     user = User(
         username='death',
         fullname="Death",
-        created_at=datetime(1970, 1, 1, tzinfo=utc),
+        created_at=utc.localize(datetime(1970, 1, 1)),
     )
     db_session.add(user)
     return user
@@ -113,7 +113,7 @@ def user_mort(db_session):
     priority when merging user accounts. Unlike Death, Mort does not have a username or
     profile, so Mort will acquire it from a merged user.
     """
-    user = User(fullname="Mort", created_at=datetime(1987, 11, 12, tzinfo=utc))
+    user = User(fullname="Mort", created_at=utc.localize(datetime(1987, 11, 12)))
     db_session.add(user)
     return user
 

--- a/tests/unit/models/test_session.py
+++ b/tests/unit/models/test_session.py
@@ -17,72 +17,72 @@ def block_of_sessions(db_session, new_project):
     # https://hasgeek.com/doctypehtml5/bangalore/schedule
     session1 = Session(
         project=new_project,
-        start_at=datetime(2010, 10, 9, 9, 0, tzinfo=utc),
-        end_at=datetime(2010, 10, 9, 10, 0, tzinfo=utc),
+        start_at=utc.localize(datetime(2010, 10, 9, 9, 0)),
+        end_at=utc.localize(datetime(2010, 10, 9, 10, 0)),
         title="Registration",
         is_break=True,
     )
     session2 = Session(
         project=new_project,
-        start_at=datetime(2010, 10, 9, 10, 0, tzinfo=utc),
-        end_at=datetime(2010, 10, 9, 10, 15, tzinfo=utc),
+        start_at=utc.localize(datetime(2010, 10, 9, 10, 0)),
+        end_at=utc.localize(datetime(2010, 10, 9, 10, 15)),
         title="Introduction",
     )
     session3 = Session(
         project=new_project,
-        start_at=datetime(2010, 10, 9, 10, 15, tzinfo=utc),
-        end_at=datetime(2010, 10, 9, 11, 15, tzinfo=utc),
+        start_at=utc.localize(datetime(2010, 10, 9, 10, 15)),
+        end_at=utc.localize(datetime(2010, 10, 9, 11, 15)),
         title="Business Case for HTML5",
     )
     session4 = Session(
         project=new_project,
-        start_at=datetime(2010, 10, 9, 11, 15, tzinfo=utc),
-        end_at=datetime(2010, 10, 9, 12, 15, tzinfo=utc),
+        start_at=utc.localize(datetime(2010, 10, 9, 11, 15)),
+        end_at=utc.localize(datetime(2010, 10, 9, 12, 15)),
         title="New Ideas in HTML5",
     )
     session5 = Session(
         project=new_project,
-        start_at=datetime(2010, 10, 9, 12, 15, tzinfo=utc),
-        end_at=datetime(2010, 10, 9, 12, 30, tzinfo=utc),
+        start_at=utc.localize(datetime(2010, 10, 9, 12, 15)),
+        end_at=utc.localize(datetime(2010, 10, 9, 12, 30)),
         title="Tea & Coffee Break",
         is_break=True,
     )
     session6 = Session(
         project=new_project,
-        start_at=datetime(2010, 10, 9, 12, 30, tzinfo=utc),
-        end_at=datetime(2010, 10, 9, 13, 30, tzinfo=utc),
+        start_at=utc.localize(datetime(2010, 10, 9, 12, 30)),
+        end_at=utc.localize(datetime(2010, 10, 9, 13, 30)),
         title="CSS3 and Presentation",
     )
     # Deliberately leave out lunch break at session 7 to break the block
     session8 = Session(
         project=new_project,
-        start_at=datetime(2010, 10, 9, 14, 30, tzinfo=utc),
-        end_at=datetime(2010, 10, 9, 14, 45, tzinfo=utc),
+        start_at=utc.localize(datetime(2010, 10, 9, 14, 30)),
+        end_at=utc.localize(datetime(2010, 10, 9, 14, 45)),
         title="Quiz",
     )
     session9 = Session(
         project=new_project,
-        start_at=datetime(2010, 10, 9, 14, 45, tzinfo=utc),
-        end_at=datetime(2010, 10, 9, 15, 45, tzinfo=utc),
+        start_at=utc.localize(datetime(2010, 10, 9, 14, 45)),
+        end_at=utc.localize(datetime(2010, 10, 9, 15, 45)),
         title="Multimedia Kit",
     )
     session10 = Session(
         project=new_project,
-        start_at=datetime(2010, 10, 9, 15, 45, tzinfo=utc),
-        end_at=datetime(2010, 10, 9, 16, 0, tzinfo=utc),
+        start_at=utc.localize(datetime(2010, 10, 9, 15, 45)),
+        end_at=utc.localize(datetime(2010, 10, 9, 16, 0)),
         title="Tea & Coffee Break",
         is_break=True,
     )
     session11 = Session(
         project=new_project,
-        start_at=datetime(2010, 10, 9, 16, 0, tzinfo=utc),
-        end_at=datetime(2010, 10, 9, 17, 0, tzinfo=utc),
+        start_at=utc.localize(datetime(2010, 10, 9, 16, 0)),
+        end_at=utc.localize(datetime(2010, 10, 9, 17, 0)),
         title="Location, Offline and Mobile",
     )
     session12 = Session(
         project=new_project,
-        start_at=datetime(2010, 10, 9, 17, 0, tzinfo=utc),
-        end_at=datetime(2010, 10, 9, 17, 15, tzinfo=utc),
+        start_at=utc.localize(datetime(2010, 10, 9, 17, 0)),
+        end_at=utc.localize(datetime(2010, 10, 9, 17, 15)),
         title="Closing Remarks",
     )
 
@@ -115,7 +115,7 @@ def test_project_starting_at(db_session, block_of_sessions):
 
     # Loop through the day at 5 min intervals from 8 AM, looking for start time
     starting_times = [
-        datetime(2010, 10, 9, 8, 0, tzinfo=utc) + timedelta(minutes=5) * multipler
+        utc.localize(datetime(2010, 10, 9, 8, 0)) + timedelta(minutes=5) * multipler
         for multipler in range(100)
     ]
 
@@ -141,8 +141,8 @@ def test_project_starting_at(db_session, block_of_sessions):
 
     # Confirm we found two starting times at 9 AM and 2:30 PM
     assert found_projects == {
-        datetime(2010, 10, 9, 9, 0, tzinfo=utc): [block_of_sessions.new_project],
-        datetime(2010, 10, 9, 14, 30, tzinfo=utc): [block_of_sessions.new_project],
+        utc.localize(datetime(2010, 10, 9, 9, 0)): [block_of_sessions.new_project],
+        utc.localize(datetime(2010, 10, 9, 14, 30)): [block_of_sessions.new_project],
     }
 
     # Confirm we can retrieve the session as well
@@ -151,8 +151,8 @@ def test_project_starting_at(db_session, block_of_sessions):
         for timestamp, project_list in found_projects.items()
     }
     assert found_sessions == {
-        datetime(2010, 10, 9, 9, 0, tzinfo=utc): [block_of_sessions.session1],
-        datetime(2010, 10, 9, 14, 30, tzinfo=utc): [block_of_sessions.session8],
+        utc.localize(datetime(2010, 10, 9, 9, 0)): [block_of_sessions.session1],
+        utc.localize(datetime(2010, 10, 9, 14, 30)): [block_of_sessions.session8],
     }
 
     # Repeat search with 120 minute gap requirement instead of 60. Now we find a single
@@ -163,13 +163,13 @@ def test_project_starting_at(db_session, block_of_sessions):
 
     # Confirm we found a single starting time at 9 AM
     assert found_projects == {
-        datetime(2010, 10, 9, 9, 0, tzinfo=utc): [block_of_sessions.new_project],
+        utc.localize(datetime(2010, 10, 9, 9, 0)): [block_of_sessions.new_project],
     }
 
     # Use an an odd offset on the starting time. We're looking for 1 hour gap before the
     # query time and not session starting time, so this will miss the second block
     starting_times = [
-        datetime(2010, 10, 9, 7, 59, tzinfo=utc) + timedelta(minutes=5) * multipler
+        utc.localize(datetime(2010, 10, 9, 7, 59)) + timedelta(minutes=5) * multipler
         for multipler in range(100)
     ]
 
@@ -181,5 +181,5 @@ def test_project_starting_at(db_session, block_of_sessions):
     # 1. The first block is found (test uses query timestamp, not session timestamp)
     # 2. The second block was missed because 13:29 to 14:29 has a match at 13:30 end_at.
     assert found_projects == {
-        datetime(2010, 10, 9, 8, 59, tzinfo=utc): [block_of_sessions.new_project],
+        utc.localize(datetime(2010, 10, 9, 8, 59)): [block_of_sessions.new_project],
     }

--- a/tests/unit/models/test_video.py
+++ b/tests/unit/models/test_video.py
@@ -55,7 +55,7 @@ def test_youtube(db_session, new_proposal):
     assert check_video['id'] == check_proposal.video_id
     assert check_video['url'] == check_proposal.video_url
     assert check_video['duration'] == 213
-    assert check_video['uploaded_at'] == datetime(2009, 10, 25, 6, 57, 33, tzinfo=utc)
+    assert check_video['uploaded_at'] == utc.localize(datetime(2009, 10, 25, 6, 57, 33))
     assert (
         check_video['thumbnail']
         == f'https://i.ytimg.com/vi/{check_proposal.video_id}/mqdefault.jpg'
@@ -68,7 +68,9 @@ def test_youtube(db_session, new_proposal):
     assert check_cached['id'] == check_proposal.video_id
     assert check_cached['url'] == check_proposal.video_url
     assert check_cached['duration'] == 213
-    assert check_cached['uploaded_at'] == datetime(2009, 10, 25, 6, 57, 33, tzinfo=utc)
+    assert check_cached['uploaded_at'] == utc.localize(
+        datetime(2009, 10, 25, 6, 57, 33)
+    )
     assert (
         check_cached['thumbnail']
         == f'https://i.ytimg.com/vi/{check_proposal.video_id}/mqdefault.jpg'
@@ -110,7 +112,7 @@ def test_vimeo(db_session, new_proposal):
     assert check_video['id'] == check_proposal.video_id
     assert check_video['url'] == check_proposal.video_url
     assert check_video['duration'] == 212
-    assert check_video['uploaded_at'] == datetime(2019, 5, 17, 15, 48, 2, tzinfo=utc)
+    assert check_video['uploaded_at'] == utc.localize(datetime(2019, 5, 17, 15, 48, 2))
     assert (
         check_video['thumbnail'] == 'https://i.vimeocdn.com/video/783856813_200x150.jpg'
     )
@@ -122,7 +124,7 @@ def test_vimeo(db_session, new_proposal):
     assert check_cached['id'] == check_proposal.video_id
     assert check_cached['url'] == check_proposal.video_url
     assert check_cached['duration'] == 212
-    assert check_cached['uploaded_at'] == datetime(2019, 5, 17, 15, 48, 2, tzinfo=utc)
+    assert check_cached['uploaded_at'] == utc.localize(datetime(2019, 5, 17, 15, 48, 2))
     assert (
         check_cached['thumbnail']
         == 'https://i.vimeocdn.com/video/783856813_200x150.jpg'

--- a/tests/unit/views/test_sitemap.py
+++ b/tests/unit/views/test_sitemap.py
@@ -48,68 +48,68 @@ def test_all_sitemap_months_days():
     """The sitemap months and days ranges are contiguous."""
     # Test dates 14, 15, 16 & 17, at midnight and noon, to see month/day rollover
 
-    until = datetime(2020, 10, 14, tzinfo=utc)
+    until = utc.localize(datetime(2020, 10, 14))
     days = all_sitemap_days(until)
     months = all_sitemap_months(until)
-    assert days[0] == datetime(2020, 10, 14, tzinfo=utc)
-    assert days[-1] == datetime(2020, 9, 1, tzinfo=utc)
-    assert months[0] == datetime(2020, 8, 1, tzinfo=utc)
+    assert days[0] == utc.localize(datetime(2020, 10, 14))
+    assert days[-1] == utc.localize(datetime(2020, 9, 1))
+    assert months[0] == utc.localize(datetime(2020, 8, 1))
     assert months[-1] == earliest_date
 
-    until = datetime(2020, 10, 14, 12, 0, tzinfo=utc)
+    until = utc.localize(datetime(2020, 10, 14, 12, 0))
     days = all_sitemap_days(until)
     months = all_sitemap_months(until)
-    assert days[0] == datetime(2020, 10, 14, tzinfo=utc)
-    assert days[-1] == datetime(2020, 9, 1, tzinfo=utc)
-    assert months[0] == datetime(2020, 8, 1, tzinfo=utc)
+    assert days[0] == utc.localize(datetime(2020, 10, 14))
+    assert days[-1] == utc.localize(datetime(2020, 9, 1))
+    assert months[0] == utc.localize(datetime(2020, 8, 1))
     assert months[-1] == earliest_date
 
-    until = datetime(2020, 10, 15, tzinfo=utc)
+    until = utc.localize(datetime(2020, 10, 15))
     days = all_sitemap_days(until)
     months = all_sitemap_months(until)
-    assert days[0] == datetime(2020, 10, 15, tzinfo=utc)
-    assert days[-1] == datetime(2020, 9, 1, tzinfo=utc)
-    assert months[0] == datetime(2020, 8, 1, tzinfo=utc)
+    assert days[0] == utc.localize(datetime(2020, 10, 15))
+    assert days[-1] == utc.localize(datetime(2020, 9, 1))
+    assert months[0] == utc.localize(datetime(2020, 8, 1))
     assert months[-1] == earliest_date
 
-    until = datetime(2020, 10, 15, 12, 0, tzinfo=utc)
+    until = utc.localize(datetime(2020, 10, 15, 12, 0))
     days = all_sitemap_days(until)
     months = all_sitemap_months(until)
-    assert days[0] == datetime(2020, 10, 15, tzinfo=utc)
-    assert days[-1] == datetime(2020, 9, 1, tzinfo=utc)
-    assert months[0] == datetime(2020, 8, 1, tzinfo=utc)
+    assert days[0] == utc.localize(datetime(2020, 10, 15))
+    assert days[-1] == utc.localize(datetime(2020, 9, 1))
+    assert months[0] == utc.localize(datetime(2020, 8, 1))
     assert months[-1] == earliest_date
 
-    until = datetime(2020, 10, 16, tzinfo=utc)
+    until = utc.localize(datetime(2020, 10, 16))
     days = all_sitemap_days(until)
     months = all_sitemap_months(until)
-    assert days[0] == datetime(2020, 10, 16, tzinfo=utc)
-    assert days[-1] == datetime(2020, 10, 1, tzinfo=utc)
-    assert months[0] == datetime(2020, 9, 1, tzinfo=utc)
+    assert days[0] == utc.localize(datetime(2020, 10, 16))
+    assert days[-1] == utc.localize(datetime(2020, 10, 1))
+    assert months[0] == utc.localize(datetime(2020, 9, 1))
     assert months[-1] == earliest_date
 
-    until = datetime(2020, 10, 16, 12, 0, tzinfo=utc)
+    until = utc.localize(datetime(2020, 10, 16, 12, 0))
     days = all_sitemap_days(until)
     months = all_sitemap_months(until)
-    assert days[0] == datetime(2020, 10, 16, tzinfo=utc)
-    assert days[-1] == datetime(2020, 10, 1, tzinfo=utc)
-    assert months[0] == datetime(2020, 9, 1, tzinfo=utc)
+    assert days[0] == utc.localize(datetime(2020, 10, 16))
+    assert days[-1] == utc.localize(datetime(2020, 10, 1))
+    assert months[0] == utc.localize(datetime(2020, 9, 1))
     assert months[-1] == earliest_date
 
-    until = datetime(2020, 10, 17, tzinfo=utc)
+    until = utc.localize(datetime(2020, 10, 17))
     days = all_sitemap_days(until)
     months = all_sitemap_months(until)
-    assert days[0] == datetime(2020, 10, 17, tzinfo=utc)
-    assert days[-1] == datetime(2020, 10, 1, tzinfo=utc)
-    assert months[0] == datetime(2020, 9, 1, tzinfo=utc)
+    assert days[0] == utc.localize(datetime(2020, 10, 17))
+    assert days[-1] == utc.localize(datetime(2020, 10, 1))
+    assert months[0] == utc.localize(datetime(2020, 9, 1))
     assert months[-1] == earliest_date
 
-    until = datetime(2020, 10, 17, 12, 0, tzinfo=utc)
+    until = utc.localize(datetime(2020, 10, 17, 12, 0))
     days = all_sitemap_days(until)
     months = all_sitemap_months(until)
-    assert days[0] == datetime(2020, 10, 17, tzinfo=utc)
-    assert days[-1] == datetime(2020, 10, 1, tzinfo=utc)
-    assert months[0] == datetime(2020, 9, 1, tzinfo=utc)
+    assert days[0] == utc.localize(datetime(2020, 10, 17))
+    assert days[-1] == utc.localize(datetime(2020, 10, 1))
+    assert months[0] == utc.localize(datetime(2020, 9, 1))
     assert months[-1] == earliest_date
 
 
@@ -117,32 +117,32 @@ def test_validate_daterange():
     """Test the values that validate_dayrange accepts."""
     # String dates are accepted
     assert validate_daterange('2015', '11', '05') == (
-        datetime(2015, 11, 5, tzinfo=utc),
-        datetime(2015, 11, 6, tzinfo=utc),
+        utc.localize(datetime(2015, 11, 5)),
+        utc.localize(datetime(2015, 11, 6)),
     )
 
     # Integer dates are fine too
     assert validate_daterange(2015, 11, 5) == (
-        datetime(2015, 11, 5, tzinfo=utc),
-        datetime(2015, 11, 6, tzinfo=utc),
+        utc.localize(datetime(2015, 11, 5)),
+        utc.localize(datetime(2015, 11, 6)),
     )
 
     # Zero padding is fine, as long as int(x) will accept it
     assert validate_daterange('2015', '11', '00005') == (
-        datetime(2015, 11, 5, tzinfo=utc),
-        datetime(2015, 11, 6, tzinfo=utc),
+        utc.localize(datetime(2015, 11, 5)),
+        utc.localize(datetime(2015, 11, 6)),
     )
 
     # Day is optional, and date range is then for the full month
     assert validate_daterange('2015', '11', None) == (
-        datetime(2015, 11, 1, tzinfo=utc),
-        datetime(2015, 12, 1, tzinfo=utc),
+        utc.localize(datetime(2015, 11, 1)),
+        utc.localize(datetime(2015, 12, 1)),
     )
 
     # Same with int year/month
     assert validate_daterange(2015, 11, None) == (
-        datetime(2015, 11, 1, tzinfo=utc),
-        datetime(2015, 12, 1, tzinfo=utc),
+        utc.localize(datetime(2015, 11, 1)),
+        utc.localize(datetime(2015, 12, 1)),
     )
 
     # However, invalid dates and dates prior to earliest date or later than present day


### PR DESCRIPTION
The correct way to use pytz timezones is `tz.localize(datetime)` (as discussed in the article linked from #950). While the `utc` timezone isn't affected, this PR updates all references to use the canonical invocation.