### PR TITLE
Remove obsolete proposal fields

### DIFF
--- a/funnel/models/proposal.py
+++ b/funnel/models/proposal.py
@@ -17,12 +17,10 @@ from . import (
     MarkdownColumn,
     TimestampMixin,
     TSVectorType,
-    UrlType,
     UuidMixin,
     db,
 )
 from .commentvote import SET_TYPE, Commentset, Voteset
-from .email_address import EmailAddressMixin
 from .helpers import (
     add_search_trigger,
     markdown_content_options,
@@ -117,7 +115,6 @@ class PROPOSAL_STATE(LabeledEnum):  # NOQA: N801
 
 class Proposal(
     UuidMixin,
-    EmailAddressMixin,  # TODO: Remove this, email is in user account anyway
     BaseScopedIdNameMixin,
     VideoMixin,
     db.Model,
@@ -146,9 +143,6 @@ class Proposal(
         grants={'presenter'},
     )
 
-    # TODO: Remove this, phone is in user account anyway
-    phone = db.Column(db.Unicode(80), nullable=True)
-
     project_id = db.Column(None, db.ForeignKey('project.id'), nullable=False)
     project = with_roles(
         db.relationship(
@@ -159,19 +153,6 @@ class Proposal(
         grants_via={None: project_child_role_map},
     )
     parent = db.synonym('project')
-
-    # TODO: Deprecated
-    abstract = MarkdownColumn('abstract', nullable=True)
-    # TODO: Deprecated
-    outline = MarkdownColumn('outline', nullable=True)
-    # TODO: Deprecated
-    requirements = MarkdownColumn('requirements', nullable=True)
-    # TODO: Deprecated
-    slides = db.Column(UrlType, nullable=True)
-    # TODO: Deprecated
-    links = db.Column(db.Text, default='', nullable=True)
-    # TODO: Deprecated
-    bio = MarkdownColumn('bio', nullable=True)
 
     _state = db.Column(
         'state',
@@ -206,8 +187,6 @@ class Proposal(
     featured = db.Column(db.Boolean, nullable=False, default=False)
 
     edited_at = db.Column(db.TIMESTAMP(timezone=True), nullable=True)
-    # TODO: Deprecated, take from proposer profile
-    location = db.Column(db.Unicode(80), nullable=False, default='')
 
     search_vector = db.deferred(
         db.Column(
@@ -249,14 +228,7 @@ class Proposal(
                 'speaker',
                 'owner',
                 'speaking',
-                'bio',  # TODO: Deprecated
-                'abstract',  # TODO: Deprecated
-                'outline',  # TODO: Deprecated
-                'requirements',  # TODO: Deprecated
-                'slides',  # TODO: Deprecated
                 'video',
-                'links',  # TODO: Deprecated
-                'location',  # TODO: Deprecated
                 'session',
                 'project',
                 'datetime',
@@ -277,18 +249,9 @@ class Proposal(
             'user',
             'speaker',
             'speaking',
-            'bio',  # TODO: Deprecated
-            'abstract',  # TODO: Deprecated
-            'outline',  # TODO: Deprecated
-            'requirements',  # TODO: Deprecated
-            'slides',  # TODO: Deprecated
             'video',
-            'links',  # TODO: Deprecated
-            'location',  # TODO: Deprecated
             'session',
             'project',
-            'email',  # TODO: Deprecated
-            'phone',  # TODO: Deprecated
         },
         'without_parent': {
             'urls',
@@ -299,17 +262,8 @@ class Proposal(
             'user',
             'speaker',
             'speaking',
-            'bio',  # TODO: Deprecated
-            'abstract',  # TODO: Deprecated
-            'outline',  # TODO: Deprecated
-            'requirements',  # TODO: Deprecated
-            'slides',  # TODO: Deprecated
             'video',
-            'links',  # TODO: Deprecated
-            'location',  # TODO: Deprecated
             'session',
-            'email',  # TODO: Deprecated
-            'phone',  # TODO: Deprecated
         },
         'related': {'urls', 'uuid_b58', 'url_name_uuid_b58', 'title'},
     }

--- a/funnel/models/session.py
+++ b/funnel/models/session.py
@@ -201,7 +201,7 @@ class Session(UuidMixin, BaseScopedIdNameMixin, VideoMixin, db.Model):
         if session_obj is None and create:
             session_obj = cls(
                 title=proposal.title,
-                description=proposal.outline,
+                description=proposal.body,
                 project=proposal.project,
                 proposal=proposal,
             )

--- a/funnel/templates/macros.html.jinja2
+++ b/funnel/templates/macros.html.jinja2
@@ -763,11 +763,6 @@
                       {{ faicon(icon='video', icon_size='subhead', baseline=true, css_class='proposal-card__body__inner__headline__info__icon') }}
                     </li>
                   {% endif %}
-                  {% if proposal.slides.url %}
-                    <li class="no-border" data-toggle="tooltip" data-placement="top" title="{% trans %}This proposal has slides{% endtrans %}" aria-label="{% trans %}This proposal has slides{% endtrans %}">
-                      {{ faicon(icon='presentation', icon_size='subhead', baseline=true, css_class='proposal-card__body__inner__headline__info__icon') }}
-                    </li>
-                  {% endif %}
                   {%- if project and project.current_roles.editor %}
                     {%- if proposal.has_outstation_speaker %}
                       <li class="no-border" data-toggle="tooltip" data-placement="top" title="{% trans %}Outstation speaker{% endtrans %}" aria-label="{% trans %}Outstation speaker{% endtrans %}">{{ faicon(icon='plane', icon_size='subhead', baseline=true, css_class='proposal-card__body__inner__headline__info__icon') }}</li>

--- a/funnel/views/proposal.py
+++ b/funnel/views/proposal.py
@@ -1,6 +1,4 @@
-from flask import Markup, abort, escape, flash, jsonify, redirect
-
-from bleach import linkify
+from flask import abort, flash, jsonify, redirect
 
 from baseframe import _, __, request_is_xhr
 from baseframe.forms import render_delete_sqla, render_form
@@ -198,16 +196,9 @@ class ProposalView(ProposalViewMixin, UrlChangeCheck, UrlForView, ModelView):
         if request_is_xhr():
             return jsonify({'comments': self.obj.commentset.views.json_comments()})
 
-        links = [
-            Markup(linkify(str(escape(link))))
-            for link in self.obj.links.replace('\r\n', '\n').split('\n')
-            if link
-        ]
-
         return {
             'project': self.obj.project,
             'proposal': self.obj,
-            'links': links,
         }
 
     @route('admin')

--- a/migrations/versions/c3483d25178c_remove_obsolete_proposal_fields.py
+++ b/migrations/versions/c3483d25178c_remove_obsolete_proposal_fields.py
@@ -1,0 +1,106 @@
+"""Remove obsolete Proposal fields.
+
+Revision ID: c3483d25178c
+Revises: a23e88f06478
+Create Date: 2021-04-05 20:36:55.734125
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = 'c3483d25178c'
+down_revision = 'a23e88f06478'
+branch_labels = None
+depends_on = None
+
+# This migration removes the obsolete proposal fields that were deprecated four months
+# ago (Dec 2020) in migration ad5013552ec6. The deletion in this migration is permanent.
+# The email, phone and location fields are not redundant and will be lost.
+
+
+def upgrade():
+    op.drop_index('ix_proposal_email_address_id', table_name='proposal')
+    op.drop_constraint('proposal_email_address_id_fkey', 'proposal', type_='foreignkey')
+    op.drop_column('proposal', 'outline_html')
+    op.drop_column('proposal', 'slides')
+    op.drop_column('proposal', 'abstract_html')
+    op.drop_column('proposal', 'email_address_id')
+    op.drop_column('proposal', 'location')
+    op.drop_column('proposal', 'abstract_text')
+    op.drop_column('proposal', 'phone')
+    op.drop_column('proposal', 'bio_html')
+    op.drop_column('proposal', 'bio_text')
+    op.drop_column('proposal', 'links')
+    op.drop_column('proposal', 'outline_text')
+    op.drop_column('proposal', 'requirements_html')
+    op.drop_column('proposal', 'requirements_text')
+
+
+def downgrade():
+    op.add_column(
+        'proposal',
+        sa.Column('requirements_text', sa.TEXT(), autoincrement=False, nullable=True),
+    )
+    op.add_column(
+        'proposal',
+        sa.Column('requirements_html', sa.TEXT(), autoincrement=False, nullable=True),
+    )
+    op.add_column(
+        'proposal',
+        sa.Column('outline_text', sa.TEXT(), autoincrement=False, nullable=True),
+    )
+    op.add_column(
+        'proposal', sa.Column('links', sa.TEXT(), autoincrement=False, nullable=True)
+    )
+    op.add_column(
+        'proposal', sa.Column('bio_text', sa.TEXT(), autoincrement=False, nullable=True)
+    )
+    op.add_column(
+        'proposal', sa.Column('bio_html', sa.TEXT(), autoincrement=False, nullable=True)
+    )
+    op.add_column(
+        'proposal',
+        sa.Column('phone', sa.VARCHAR(length=80), autoincrement=False, nullable=True),
+    )
+    op.add_column(
+        'proposal',
+        sa.Column('abstract_text', sa.TEXT(), autoincrement=False, nullable=True),
+    )
+    op.add_column(
+        'proposal',
+        sa.Column(
+            'location',
+            sa.VARCHAR(length=80),
+            autoincrement=False,
+            nullable=False,
+            server_default='',
+        ),
+    )
+    op.alter_column('proposal', 'location', server_default=None)
+    op.add_column(
+        'proposal',
+        sa.Column('email_address_id', sa.INTEGER(), autoincrement=False, nullable=True),
+    )
+    op.add_column(
+        'proposal',
+        sa.Column('abstract_html', sa.TEXT(), autoincrement=False, nullable=True),
+    )
+    op.add_column(
+        'proposal', sa.Column('slides', sa.TEXT(), autoincrement=False, nullable=True)
+    )
+    op.add_column(
+        'proposal',
+        sa.Column('outline_html', sa.TEXT(), autoincrement=False, nullable=True),
+    )
+    op.create_foreign_key(
+        'proposal_email_address_id_fkey',
+        'proposal',
+        'email_address',
+        ['email_address_id'],
+        ['id'],
+        ondelete='SET NULL',
+    )
+    op.create_index(
+        'ix_proposal_email_address_id', 'proposal', ['email_address_id'], unique=False
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -614,8 +614,7 @@ def new_proposal(db_session, new_user, new_project):
         speaker=new_user,
         project=new_project,
         title="Test Proposal",
-        outline="Test proposal description",
-        location="Bangalore",
+        body="Test proposal description",
     )
     db_session.add(proposal)
     db_session.commit()


### PR DESCRIPTION
This migration removes the obsolete proposal fields that were deprecated about four months ago (Dec 2020) in #979. The deletion in this migration is permanent. The email, phone and location fields are not redundant and will be lost.