### PR TITLE
Membership helper properties for grant/revoke

### DIFF
--- a/funnel/models/membership.py
+++ b/funnel/models/membership.py
@@ -135,7 +135,7 @@ class ImmutableMembershipMixin(UuidMixin, BaseMixin):
         return db.relationship(User, foreign_keys=[cls.granted_by_id])
 
     @hybrid_property
-    def is_active(self):
+    def is_active(self) -> bool:
         return (
             self.revoked_at is None
             and self.record_type != MEMBERSHIP_RECORD_TYPE.INVITE
@@ -151,8 +151,20 @@ class ImmutableMembershipMixin(UuidMixin, BaseMixin):
 
     @with_roles(read={'subject', 'editor'})
     @hybrid_property
-    def is_invite(self):
+    def is_invite(self) -> bool:
         return self.record_type == MEMBERSHIP_RECORD_TYPE.INVITE
+
+    @with_roles(read={'subject', 'editor'})
+    @hybrid_property
+    def is_self_granted(self) -> bool:
+        """Return True if the subject of this record is also the granting actor."""
+        return self.user_id == self.granted_by_id
+
+    @with_roles(read={'subject', 'editor'})
+    @hybrid_property
+    def is_self_revoked(self) -> bool:
+        """Return True if the subject of this record is also the revoking actor."""
+        return self.user_id == self.revoked_by_id
 
     @declared_attr
     def __table_args__(cls):

--- a/funnel/models/organization_membership.py
+++ b/funnel/models/organization_membership.py
@@ -36,6 +36,8 @@ class OrganizationMembership(ImmutableMembershipMixin, db.Model):
                 'user',
                 'is_active',
                 'is_invite',
+                'is_self_granted',
+                'is_self_revoked',
             }
         },
     }

--- a/funnel/views/notifications/organization_membership_notification.py
+++ b/funnel/views/notifications/organization_membership_notification.py
@@ -31,10 +31,7 @@ class DecisionFactor(NamedTuple):
             (self.is_subject is is_subject)
             and (not self.rtypes or record_type in self.rtypes)
             and (self.is_owner is None or self.is_owner is membership.is_owner)
-            and (
-                self.is_actor is None
-                or (self.is_actor is bool(membership.user == membership.granted_by))
-            )
+            and (self.is_actor is None or (self.is_actor is membership.is_self_granted))
         )
 
 


### PR DESCRIPTION
The expression `bool(membership.user == membership.granted_by)` when used on a RoleProxy was comparing data structures instead of ids.