### PR TITLE
Role check for reordering proposals

### DIFF
--- a/funnel/models/proposal.py
+++ b/funnel/models/proposal.py
@@ -246,7 +246,10 @@ class Proposal(UuidMixin, BaseScopedIdNameMixin, VideoMixin, ReorderMixin, db.Mo
             'call': {'url_for', 'state', 'commentset'},
         },
         'reviewer': {'read': {'email', 'phone'}},
-        'project_editor': {'read': {'email', 'phone'}},
+        'project_editor': {
+            'read': {'email', 'phone'},
+            'call': {'reorder_item', 'reorder_before', 'reorder_after'},
+        },
     }
 
     __datasets__ = {

--- a/funnel/templates/macros.html.jinja2
+++ b/funnel/templates/macros.html.jinja2
@@ -604,10 +604,11 @@
 {%- macro proposal_list(proposals, project='') %}
   <table id="submissions-table" class="proposal-list-table mui-table">
     <tbody>
+      {%- with reorderable=project and project.features.reorder_proposals() %}
       {% for proposal in proposals %}
-        <tr id="{{ proposal.uuid_b58 }}" {%- if project and project.current_roles.editor %}class="sortable" data-drag-placeholder="proposal-placeholder" draggable="true"{%- endif %}>
-          <td class="js-searchable {%- if project and project.current_roles.editor %} label-box label-box--no-border ui-draggable-box{%- endif %}">
-            {%- if project and project.current_roles.editor %}
+        <tr id="{{ proposal.uuid_b58 }}" {%- if reorderable %}class="sortable" data-drag-placeholder="proposal-placeholder" draggable="true"{%- endif %}>
+          <td class="js-searchable {%- if reorderable %} label-box label-box--no-border ui-draggable-box{%- endif %}">
+            {%- if project and reorderable %}
               {{ proposal_card(proposal, full_width=true, details=true, css_class='page-card__card', project=project, draggable=true) }}
             {%- else %}
               {{ proposal_card(proposal, full_width=true, details=true, css_class='page-card__card', project=project, draggable=false) }}
@@ -619,6 +620,7 @@
           <td><em>{% trans %}(No sessions have been submitted){% endtrans %}</em></td>
         </tr>
       {% endfor %}
+      {%- endwith %}
     </tbody>
   </table>
 {%- endmacro %}

--- a/funnel/views/proposal.py
+++ b/funnel/views/proposal.py
@@ -43,7 +43,12 @@ markdown_message = __(
 
 @Proposal.features('comment_new')
 def proposal_comment_new(obj):
-    return obj.current_roles.commenter is True
+    return obj.current_roles.commenter
+
+
+@Project.features('reorder_proposals')
+def proposals_can_be_reordered(obj):
+    return obj.current_roles.editor
 
 
 # --- Routes ------------------------------------------------------------------
@@ -105,7 +110,7 @@ class BaseProjectProposalView(ProjectViewMixin, UrlChangeCheck, UrlForView, Mode
                 .options(db.load_only(Proposal.id, Proposal.seq))
                 .one_or_404()
             )
-            proposal.reorder_item(other_proposal, before)
+            proposal.current_access().reorder_item(other_proposal, before)
             db.session.commit()
             return {'status': 'ok'}
         return {'status': 'error'}, 400


### PR DESCRIPTION
An draft of the reorder view in #1028 missed the role check, requiring only login. This PR dials up the checks, using a feature function and a role access proxy.