### PR TITLE
Prep for SQLAlchemy 1.4

### DIFF
--- a/funnel/models/auth_client.py
+++ b/funnel/models/auth_client.py
@@ -464,7 +464,12 @@ class AuthToken(ScopeMixin, BaseMixin, db.Model):
         db.UniqueConstraint('user_session_id', 'auth_client_id'),
     )
 
-    __roles__ = {'owner': {'read': {'created_at'}}}
+    __roles__ = {
+        'owner': {
+            'read': {'created_at', 'user'},
+            'granted_by': {'user'},
+        }
+    }
 
     @property
     def user(self) -> User:
@@ -477,9 +482,7 @@ class AuthToken(ScopeMixin, BaseMixin, db.Model):
     def user(self, value: User):
         self._user = value
 
-    user = with_roles(
-        db.synonym('_user', descriptor=user), read={'owner'}, grants={'owner'}
-    )
+    user = db.synonym('_user', descriptor=user)
 
     def __init__(self, **kwargs) -> None:
         super().__init__(**kwargs)

--- a/funnel/models/commentset_membership.py
+++ b/funnel/models/commentset_membership.py
@@ -46,8 +46,8 @@ class CommentsetMembership(ImmutableMembershipMixin, db.Model):
         )
     )
 
-    parent = immutable(db.synonym('commentset'))
-    parent_id = immutable(db.synonym('commentset_id'))
+    parent = db.synonym('commentset')
+    parent_id = db.synonym('commentset_id')
 
     #: Flag to indicate notifications are muted
     is_muted = db.Column(db.Boolean, nullable=False, default=False)

--- a/funnel/models/label.py
+++ b/funnel/models/label.py
@@ -365,6 +365,26 @@ class ProposalLabelProxy(object):
             return self
 
 
+@reopen(Project)
+class __Project:
+    labels = db.relationship(
+        Label,
+        cascade='all',
+        primaryjoin=db.and_(
+            Label.project_id == Project.id,
+            Label.main_label_id.is_(None),
+            Label._archived.is_(False),
+        ),
+        order_by=Label.seq,
+        viewonly=True,
+    )
+    all_labels = db.relationship(
+        Label,
+        collection_class=ordering_list('seq', count_from=1),
+        back_populates='project',
+    )
+
+
 @reopen(Proposal)
 class __Proposal:
     #: For reading and setting labels from the edit form

--- a/funnel/models/organization_membership.py
+++ b/funnel/models/organization_membership.py
@@ -71,8 +71,8 @@ class OrganizationMembership(ImmutableMembershipMixin, db.Model):
             grants_via={None: {'admin': 'profile_admin', 'owner': 'profile_owner'}},
         )
     )
-    parent = immutable(db.synonym('organization'))
-    parent_id = immutable(db.synonym('organization_id'))
+    parent = db.synonym('organization')
+    parent_id = db.synonym('organization_id')
 
     # Organization roles:
     is_owner = immutable(db.Column(db.Boolean, nullable=False, default=False))

--- a/funnel/models/project.py
+++ b/funnel/models/project.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 from typing import Iterable, Optional, Set
 
-from sqlalchemy.ext.orderinglist import ordering_list
-
 from flask import current_app
 from werkzeug.utils import cached_property
 
@@ -250,24 +248,6 @@ class Project(UuidMixin, BaseScopedNameMixin, db.Model):
         read={'all'},
         datasets={'primary', 'without_parent'},
     )
-
-    venues = with_roles(
-        db.relationship(
-            'Venue',
-            cascade='all',
-            order_by='Venue.seq',
-            collection_class=ordering_list('seq', count_from=1),
-        ),
-        read={'all'},
-    )
-    labels = db.relationship(
-        'Label',
-        cascade='all',
-        primaryjoin='and_(Label.project_id == Project.id, Label.main_label_id == None, Label._archived == False)',
-        order_by='Label.seq',
-        collection_class=ordering_list('seq', count_from=1),
-    )
-    all_labels = db.relationship('Label', lazy='dynamic')
 
     __table_args__ = (
         db.UniqueConstraint('profile_id', 'name'),
@@ -756,6 +736,7 @@ class __Profile:
             Project.parent_id.is_(None),
             Project.state.PUBLISHED,
         ),
+        viewonly=True,
     )
     draft_projects = db.relationship(
         Project,
@@ -766,6 +747,7 @@ class __Profile:
             Project.parent_id.is_(None),
             db.or_(Project.state.DRAFT, Project.cfp_state.DRAFT),
         ),
+        viewonly=True,
     )
 
     def draft_projects_for(self, user):

--- a/funnel/models/project_membership.py
+++ b/funnel/models/project_membership.py
@@ -78,8 +78,8 @@ class ProjectCrewMembership(ImmutableMembershipMixin, db.Model):
             ),
         )
     )
-    parent = immutable(db.synonym('project'))
-    parent_id = immutable(db.synonym('project_id'))
+    parent = db.synonym('project')
+    parent_id = db.synonym('project_id')
 
     # Project crew roles (at least one must be True):
 

--- a/funnel/models/proposal_membership.py
+++ b/funnel/models/proposal_membership.py
@@ -58,8 +58,8 @@ class ProposalMembership(ImmutableMembershipMixin, db.Model):
             ),
         )
     )
-    parent = immutable(db.synonym('proposal'))
-    parent_id = immutable(db.synonym('proposal_id'))
+    parent = db.synonym('proposal')
+    parent_id = db.synonym('proposal_id')
 
     # Proposal roles (at least one must be True):
 

--- a/funnel/models/session.py
+++ b/funnel/models/session.py
@@ -224,6 +224,15 @@ class Session(UuidMixin, BaseScopedIdNameMixin, VideoMixin, db.Model):
 add_search_trigger(Session, 'search_vector')
 
 
+@reopen(VenueRoom)
+class __VenueRoom:
+    scheduled_sessions = db.relationship(
+        Session,
+        primaryjoin=db.and_(Session.venue_room_id == VenueRoom.id, Session.scheduled),
+        viewonly=True,
+    )
+
+
 @reopen(Project)
 class __Project:
     # Project schedule column expressions
@@ -234,6 +243,7 @@ class __Project:
             .where(Session.start_at.isnot(None))
             .where(Session.project_id == Project.id)
             .correlate_except(Session)
+            # .scalar_subquery()
         ),
         read={'all'},
         datasets={'primary', 'without_parent'},
@@ -246,6 +256,7 @@ class __Project:
             .where(Session.start_at > db.func.utcnow())
             .where(Session.project_id == Project.id)
             .correlate_except(Session)
+            # .scalar_subquery()
         ),
         read={'all'},
     )
@@ -256,6 +267,7 @@ class __Project:
             .where(Session.end_at.isnot(None))
             .where(Session.project_id == Project.id)
             .correlate_except(Session)
+            # .scalar_subquery()
         ),
         read={'all'},
         datasets={'primary', 'without_parent'},
@@ -291,6 +303,7 @@ class __Project:
             primaryjoin=db.and_(
                 Session.project_id == Project.id, Session.featured.is_(True)
             ),
+            viewonly=True,
         ),
         read={'all'},
     )
@@ -299,6 +312,7 @@ class __Project:
             Session,
             order_by=Session.start_at.asc(),
             primaryjoin=db.and_(Session.project_id == Project.id, Session.scheduled),
+            viewonly=True,
         ),
         read={'all'},
     )
@@ -310,6 +324,7 @@ class __Project:
                 Session.project_id == Project.id,
                 Session.scheduled.isnot(True),  # type: ignore[attr-defined]
             ),
+            viewonly=True,
         ),
         read={'all'},
     )
@@ -323,6 +338,7 @@ class __Project:
                 Session.video_id.isnot(None),
                 Session.video_source.isnot(None),
             ),
+            viewonly=True,
         ),
         read={'all'},
     )
@@ -418,21 +434,22 @@ class __Project:
         # session_dates is a list of tuples in this format -
         # (date, day_start_at, day_end_at, event_count)
         session_dates = list(
-            db.session.query('date', 'day_start_at', 'day_end_at', 'count')
-            .from_statement(
-                db.text(
-                    '''
-                    SELECT
-                        DATE_TRUNC('day', "start_at" AT TIME ZONE :timezone) AS date,
-                        MIN(start_at) as day_start_at,
-                        MAX(end_at) as day_end_at,
-                        COUNT(*) AS count
-                    FROM "session" WHERE "project_id" = :project_id AND "start_at" IS NOT NULL AND "end_at" IS NOT NULL
-                    GROUP BY date ORDER BY date;
-                    '''
-                )
+            db.session.query(
+                db.func.date_trunc(
+                    'day', db.func.timezone(self.timezone.zone, Session.start_at)
+                ).label('date'),
+                db.func.min(Session.start_at).label('day_start_at'),
+                db.func.max(Session.end_at).label('day_end_at'),
+                db.func.count().label('count'),
             )
-            .params(timezone=self.timezone.zone, project_id=self.id)
+            .select_from(Session)
+            .filter(
+                Session.project == self,
+                Session.start_at.isnot(None),
+                Session.end_at.isnot(None),
+            )
+            .group_by('date')
+            .order_by('date')
         )
 
         session_dates_dict = {

--- a/funnel/models/sync_ticket.py
+++ b/funnel/models/sync_ticket.py
@@ -100,6 +100,7 @@ class TicketEvent(GetTitleMixin, db.Model):
         secondary='ticket_event_participant',
         backref='ticket_events',
         lazy='dynamic',
+        viewonly=True,
     )
     badge_template = db.Column(db.Unicode(250), nullable=True)
 
@@ -184,7 +185,7 @@ class TicketParticipant(EmailAddressMixin, UuidMixin, BaseMixin, db.Model):
     )
     project_id = db.Column(None, db.ForeignKey('project.id'), nullable=False)
     project = with_roles(
-        db.relationship(Project),
+        db.relationship(Project, back_populates='ticket_participants'),
         read={'promoter', 'subject', 'scanner'},
         grants_via={None: project_child_role_map},
     )
@@ -481,7 +482,9 @@ class __Project:
     # expose a new edge case in future in case the TicketParticipant model adds an
     # `offered_roles` method, as only the first matching record's method will be called
     ticket_participants = with_roles(
-        db.relationship(TicketParticipant, lazy='dynamic', cascade='all'),
+        db.relationship(
+            TicketParticipant, lazy='dynamic', cascade='all', back_populates='project'
+        ),
         grants_via={'user': {'participant'}},
     )
 

--- a/funnel/models/sync_ticket.py
+++ b/funnel/models/sync_ticket.py
@@ -100,7 +100,6 @@ class TicketEvent(GetTitleMixin, db.Model):
         secondary='ticket_event_participant',
         backref='ticket_events',
         lazy='dynamic',
-        viewonly=True,
     )
     badge_template = db.Column(db.Unicode(250), nullable=True)
 

--- a/funnel/models/user.py
+++ b/funnel/models/user.py
@@ -112,8 +112,6 @@ class User(SharedProfileMixin, UuidMixin, BaseMixin, db.Model):
     __tablename__ = 'user'
     __title_length__ = 80
 
-    # XXX: Deprecated, still here for Baseframe compatibility
-    userid = db.synonym('buid')
     #: The user's fullname
     fullname: db.Column = with_roles(
         db.Column(db.Unicode(__title_length__), default='', nullable=False),
@@ -763,6 +761,9 @@ class User(SharedProfileMixin, UuidMixin, BaseMixin, db.Model):
     def organization_links(self) -> List:
         return []
 
+
+# XXX: Deprecated, still here for Baseframe compatibility
+User.userid = User.uuid_b64
 
 auto_init_default(User._state)  # skipcq: PYL-W0212
 add_search_trigger(User, 'search_vector')

--- a/funnel/models/user_session.py
+++ b/funnel/models/user_session.py
@@ -140,4 +140,5 @@ class __User:
             UserSession.revoked_at.is_(None),
         ),
         order_by=UserSession.accessed_at.desc(),
+        viewonly=True,
     )

--- a/funnel/views/label.py
+++ b/funnel/views/label.py
@@ -60,9 +60,8 @@ class ProjectLabelView(ProjectViewMixin, UrlForView, ModelView):
             )
             label.restricted = form.data.get('restricted')
             label.make_name()
-            self.obj.labels.append(label)
-            self.obj.labels.reorder()
-            db.session.add(label)
+            self.obj.all_labels.append(label)
+            self.obj.all_labels.reorder()
 
             for idx in range(len(titlelist)):
                 subform = LabelOptionForm(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -565,14 +565,9 @@ def new_main_label(db_session, new_project):
     main_label_a = Label(
         title="Parent Label A", project=new_project, description="A test parent label"
     )
-    new_project.labels.append(main_label_a)
-    db_session.add(main_label_a)
-
+    new_project.all_labels.append(main_label_a)
     label_a1 = Label(title="Label A1", icon_emoji="👍", project=new_project)
-    db_session.add(label_a1)
-
     label_a2 = Label(title="Label A2", project=new_project)
-    db_session.add(label_a2)
 
     main_label_a.options.append(label_a1)
     main_label_a.options.append(label_a2)
@@ -588,14 +583,9 @@ def new_main_label_unrestricted(db_session, new_project):
     main_label_b = Label(
         title="Parent Label B", project=new_project, description="A test parent label"
     )
-    new_project.labels.append(main_label_b)
-    db_session.add(main_label_b)
-
+    new_project.all_labels.append(main_label_b)
     label_b1 = Label(title="Label B1", icon_emoji="👍", project=new_project)
-    db_session.add(label_b1)
-
     label_b2 = Label(title="Label B2", project=new_project)
-    db_session.add(label_b2)
 
     main_label_b.options.append(label_b1)
     main_label_b.options.append(label_b2)
@@ -609,7 +599,7 @@ def new_main_label_unrestricted(db_session, new_project):
 @pytest.fixture
 def new_label(db_session, new_project):
     label_b = Label(title="Label B", icon_emoji="🔟", project=new_project)
-    new_project.labels.append(label_b)
+    new_project.all_labels.append(label_b)
     db_session.add(label_b)
     db_session.commit()
     return label_b

--- a/tests/unit/models/test_notification.py
+++ b/tests/unit/models/test_notification.py
@@ -292,6 +292,7 @@ def test_user_notification_preferences(notification_types, db_session):
     # Preferences cannot be set for invalid types
     with pytest.raises(ValueError):
         NotificationPreferences(user=user, notification_type='invalid')
+    db_session.rollback()
 
     # Preferences can be set for other notification types though
     np2 = NotificationPreferences(


### PR DESCRIPTION
* Remove annotations from synonyms as coaster is dropping support
* Fix SQLAlchemy relationship warnings with `back_populates` and `viewonly`
* Add but comment-out `scalar_subquery` as that doesn't work in 1.3. Will need to be uncommented when upgrade happens
* Replace raw SQL with SQLAlchemy construct to remove warnings

The test dependency `pytest-flask-sqlalchemy` has issues with SQLAlchemy 1.4, so it's a roadblock to the upgrade.