### PR TITLE
Added github action for backend tests

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,11 +1,11 @@
-name: Coverage check
+name: Backend tests
 
 on:
   pull_request:
     branches: [master]
 
 jobs:
-  coverage-job:
+  backend-tests-job:
     runs-on: ubuntu-latest
 
     # Service containers to run with `container-job`

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,4 +45,4 @@ jobs:
       - name: Run tests
         run: ./runtests.sh
         env:
-          SQLALCHEMY_DATABASE_URI: postgresql://postgres:postgres@postgres/funnel_testing
+          SQLALCHEMY_DATABASE_URI: postgresql://postgres:postgres@localhost/funnel_testing

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -24,6 +24,9 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+        ports:
+          # Maps tcp port 5432 on service container to the host
+          - 5432:5432
 
     steps:
       - uses: actions/checkout@v2
@@ -45,4 +48,4 @@ jobs:
       - name: Run tests
         run: ./runtests.sh
         env:
-          SQLALCHEMY_DATABASE_URI: postgresql://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/funnel_testing
+          SQLALCHEMY_DATABASE_URI: postgresql://postgres:postgres@localhost/funnel_testing

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -45,4 +45,4 @@ jobs:
       - name: Run tests
         run: ./runtests.sh
         env:
-          SQLALCHEMY_DATABASE_URI: postgresql://postgres:postgres@localhost/funnel_testing
+          SQLALCHEMY_DATABASE_URI: postgresql://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/funnel_testing

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -27,6 +27,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
       - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
@@ -37,6 +40,8 @@ jobs:
           pip install git+https://github.com/hasgeek/flask-babelhg.git
           pip install -r test_requirements.txt
           pip install -r requirements.txt
+      - name: Make JS
+        run: make
       - name: Run tests
         run: ./runtests.sh
         env:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,42 @@
+name: Coverage check
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  coverage-job:
+    runs-on: ubuntu-latest
+
+    # Service containers to run with `container-job`
+    services:
+      # Label used to access the service container
+      postgres:
+        # Docker Hub image
+        image: postgres
+        # Provide the password for postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: funnel_testing
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r test_requirements.txt
+          pip install -r requirements.txt
+      - name: Run tests
+        run: ./runtests.sh
+        env:
+          SQLALCHEMY_DATABASE_URI: postgresql://postgres:postgres@postgres/funnel_testing

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install git+https://github.com/hasgeek/flask-babelhg.git
           pip install -r test_requirements.txt
           pip install -r requirements.txt
       - name: Run tests

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,7 +9,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build:
+  pre-commit-job:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/instance/testing.py
+++ b/instance/testing.py
@@ -5,7 +5,9 @@ CACHE_TYPE = 'null'
 SECRET_KEYS = ['testkey']  # nosec
 LASTUSER_SECRET_KEYS = ['testkey']  # nosec
 SITE_TITLE = 'Hasgeek'
-SQLALCHEMY_DATABASE_URI = 'postgresql:///funnel_testing'
+SQLALCHEMY_DATABASE_URI = environ.get(
+    'SQLALCHEMY_DATABASE_URI', 'postgresql:///funnel_testing'
+)
 SERVER_NAME = 'funnel.travis.local:3002'
 DEFAULT_DOMAIN = 'funnel.travis.local'
 STATIC_SUBDOMAIN = 'static'


### PR DESCRIPTION
Tried adding a github action for checking test coverage. But Github actions can only output pass/fail. So while it's possible to check whether the coverage is above or below a given number, it's not possible to check whether the coverage has gone up or down compared to what it was. It can't replace what coverall used to do. So renamed this one to backend test action. So we can technically drop travis from running backend tests now. We have to check coverage manually.