### PR TITLE
Add role access for Session.location

### DIFF
--- a/funnel/models/session.py
+++ b/funnel/models/session.py
@@ -218,6 +218,8 @@ class Session(UuidMixin, BaseScopedIdNameMixin, VideoMixin, db.Model):
             loc.append(self.project.location)
         return '\n'.join(loc)
 
+    with_roles(location, read={'all'})
+
     @classmethod
     def for_proposal(cls, proposal, create=False):
         session_obj = cls.query.filter_by(proposal=proposal).first()


### PR DESCRIPTION
Session.location was introduced in #1114, but without an accompanying role, thereby breaking all project registration notifications since then (27 days).