### PR TITLE
Remove strip filter for UrlType fields

### DIFF
--- a/funnel/forms/profile.py
+++ b/funnel/forms/profile.py
@@ -39,7 +39,6 @@ class ProfileForm(OrganizationForm):
             forms.validators.Length(max=2000),
             image_url_validator(),
         ],
-        filters=[forms.filters.strip()],
     )
     website = forms.URLField(
         __("Website URL"),
@@ -49,7 +48,7 @@ class ProfileForm(OrganizationForm):
             forms.validators.URL(),
             forms.validators.ValidUrl(),
         ],
-        filters=[forms.filters.strip(), forms.filters.none_if_empty()],
+        filters=[forms.filters.none_if_empty()],
     )
 
     def set_queries(self):
@@ -99,7 +98,6 @@ class ProfileLogoForm(forms.Form):
             forms.validators.Length(max=2000),
             image_url_validator(),
         ],
-        filters=[forms.filters.strip()],
     )
 
     def set_queries(self):
@@ -124,7 +122,6 @@ class ProfileBannerForm(forms.Form):
             forms.validators.Length(max=2000),
             image_url_validator(),
         ],
-        filters=[forms.filters.strip()],
     )
 
     def set_queries(self):

--- a/funnel/forms/project.py
+++ b/funnel/forms/project.py
@@ -95,7 +95,6 @@ class ProjectForm(forms.Form):
             forms.validators.Length(max=2000),
             image_url_validator(),
         ],
-        filters=[forms.filters.strip()],
     )
     description = forms.MarkdownField(
         __("Project description"),
@@ -192,7 +191,6 @@ class ProjectBannerForm(forms.Form):
             forms.validators.Length(max=2000),
             image_url_validator(),
         ],
-        filters=[forms.filters.strip()],
     )
 
     def set_queries(self):

--- a/funnel/forms/proposal.py
+++ b/funnel/forms/proposal.py
@@ -154,7 +154,6 @@ class ProposalForm(forms.Form):
             forms.validators.URL(),
             forms.validators.ValidUrl(),
         ],
-        filters=[forms.filters.strip()],
         description=__("YouTube or Vimeo URL (optional)"),
     )
     formlabels = forms.FormField(forms.Form, __("Labels"))

--- a/funnel/forms/session.py
+++ b/funnel/forms/session.py
@@ -37,7 +37,6 @@ class SessionForm(forms.Form):
             forms.validators.Length(max=2000),
             image_url_validator(),
         ],
-        filters=[forms.filters.strip()],
     )
     is_break = forms.BooleanField(__("This session is a break period"), default=False)
     featured = forms.BooleanField(__("This is a featured session"), default=False)
@@ -55,7 +54,6 @@ class SessionForm(forms.Form):
             forms.validators.ValidUrl(),
             forms.validators.Length(max=2000),
         ],
-        filters=[forms.filters.strip()],
     )
 
 


### PR DESCRIPTION
Strip filters were added for all text and URL fields in #1156. However, `UrlType` columns return a `Furl` type, which casts to a string but has no `strip` method, causing an internal server error when the form is processed.

Ideally the strip filter should accept a `coerce=str` parameter, so that it can be processed as a string before being converted back into a `Furl`.