### PR TITLE
Integrate geoname models from Hascore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@
 .webassets-cache
 __pycache__
 
-# MacOS File
+# MacOS file
 .DS_Store
 
 # Assets and static files
@@ -25,6 +25,9 @@ node_modules
 *.packed.js
 .webassets-cache
 baseframe-packed.*
+
+# Download files
+geoname_data
 
 # Log files
 error.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ before_script:
   - sudo -- sh -c "echo '127.0.0.1  funnel.travis.local' >> /etc/hosts"
   - psql -c 'create database funnel_testing;' -U postgres
   - 'flask dbconfig | sudo -u postgres psql funnel_testing'
+  - psql -c 'create database geoname_testing;' -U postgres
+  - 'flask dbconfig | sudo -u postgres psql geoname_testing'
 script:
   - './runtests.sh'
   - './runfrontendtests.sh'

--- a/funnel/__init__.py
+++ b/funnel/__init__.py
@@ -19,8 +19,9 @@ import coaster.app
 
 from ._version import __version__
 
-# App. Add additional apps here
+#: Main app for hasgeek.com
 app = Flask(__name__, instance_relative_config=True)
+#: Shortlink app at has.gy
 shortlinkapp = Flask(__name__, static_folder=None, instance_relative_config=True)
 
 mail = Mail()
@@ -44,21 +45,19 @@ assets['schedule-print.css'][version] = 'css/schedule-print.css'
 # --- Import rest of the app --------------------------------------------------
 
 from . import (  # NOQA  # isort:skip
-    cli,
     models,
     signals,
     forms,
     loginproviders,
     transports,
     views,
+    cli,
 )
 from .models import db  # isort:skip
 
 # --- Configuration------------------------------------------------------------
 coaster.app.init_app(app)
 coaster.app.init_app(shortlinkapp, init_logging=False)
-# For additional apps, do not install additional log handlers:
-# coaster.app.init_app(hasjobapp, init_logging=False)
 
 # These are app specific confguration files that must exist
 # inside the `instance/` directory. Sample config files are

--- a/funnel/cli/__init__.py
+++ b/funnel/cli/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa
+from . import geodata, misc, periodic

--- a/funnel/cli/geodata.py
+++ b/funnel/cli/geodata.py
@@ -1,0 +1,461 @@
+from collections import namedtuple
+from datetime import datetime
+from decimal import Decimal
+from typing import Optional
+from urllib.parse import urljoin
+import csv
+import os
+import sys
+import time
+import zipfile
+
+from flask.cli import AppGroup
+
+from progressbar import ProgressBar
+from unidecode import unidecode
+import progressbar.widgets
+import requests
+
+from coaster.utils import getbool
+
+from .. import app
+from ..models import (
+    GeoAdmin1Code,
+    GeoAdmin2Code,
+    GeoAltName,
+    GeoCountryInfo,
+    GeoName,
+    db,
+)
+
+csv.field_size_limit(sys.maxsize)
+
+geo = AppGroup('geoname', help="Process geoname data.")
+
+
+CountryInfoRecord = namedtuple(
+    'CountryInfoRecord',
+    [
+        'iso_alpha2',
+        'iso_alpha3',
+        'iso_numeric',
+        'fips_code',
+        'title',
+        'capital',
+        'area_in_sqkm',
+        'population',
+        'continent',
+        'tld',
+        'currency_code',
+        'currency_name',
+        'phone',
+        'postal_code_format',
+        'postal_code_regex',
+        'languages',
+        'geonameid',
+        'neighbours',
+        'equivalent_fips_code',
+    ],
+)
+
+
+GeoNameRecord = namedtuple(
+    'GeoNameRecord',
+    [
+        'geonameid',
+        'title',
+        'ascii_title',
+        'alternatenames',
+        'latitude',
+        'longitude',
+        'fclass',
+        'fcode',
+        'country_id',
+        'cc2',
+        'admin1',
+        'admin2',
+        'admin3',
+        'admin4',
+        'population',
+        'elevation',
+        'dem',
+        'timezone',
+        'moddate',
+    ],
+)
+
+
+GeoAdminRecord = namedtuple(
+    'GeoAdminRecord', ['code', 'title', 'ascii_title', 'geonameid']
+)
+
+GeoAltNameRecord = namedtuple(
+    'GeoAltNameRecord',
+    [
+        'id',
+        'geonameid',
+        'lang',
+        'title',
+        'is_preferred_name',
+        'is_short_name',
+        'is_colloquial',
+        'is_historic',
+    ],
+)
+
+
+def get_progressbar():
+    return ProgressBar(
+        widgets=[
+            progressbar.widgets.Percentage(),
+            ' ',
+            progressbar.widgets.Bar(),
+            ' ',
+            progressbar.widgets.ETA(),
+            ' ',
+        ]
+    )
+
+
+def downloadfile(basepath: str, filename: str, folder: Optional[str] = None):
+    if not folder:
+        folder_file = filename
+    else:
+        folder_file = os.path.join(folder, filename)
+    if (
+        os.path.exists(folder_file)
+        and (time.time() - os.path.getmtime(folder_file)) < 86400
+    ):
+        print(f"Skipping re-download of recent {filename}")  # NOQA: T001
+        return
+    print(f"Downloading {filename}...")  # NOQA: T001
+    url = urljoin(basepath, filename)
+    r = requests.get(url, stream=True)
+    if r.status_code == 200:
+        progress = ProgressBar(
+            maxval=int(r.headers.get('content-length', 0)),
+            widgets=[
+                progressbar.widgets.Percentage(),
+                ' ',
+                progressbar.widgets.Bar(),
+                ' ',
+                progressbar.widgets.ETA(),
+                ' ',
+            ],
+        ).start()
+        readbytes = 0
+        with open(folder_file, 'wb') as fd:
+            for chunk in r.iter_content(1024):
+                if not chunk:
+                    break  # Break when done. The connection remains open for Keep-Alive
+                readbytes += len(chunk)
+                fd.write(chunk)
+                progress.update(readbytes)
+        progress.finish()
+
+        if filename.lower().endswith('.zip'):
+            zipf = zipfile.ZipFile(folder_file, 'r')
+            zipf.extractall(folder)
+
+
+def load_country_info(fd):
+    print("Loading country info...")  # NOQA: T001
+    progress = get_progressbar()
+    countryinfo = [
+        CountryInfoRecord(*row)
+        for row in csv.reader(fd, delimiter='\t')
+        if not row[0].startswith('#')
+    ]
+
+    GeoCountryInfo.query.all()  # Load everything into session cache
+    for item in progress(countryinfo):
+        if item.geonameid:
+            ci = GeoCountryInfo.query.get(int(item.geonameid))
+            if ci is None:
+                ci = GeoCountryInfo(geonameid=int(item.geonameid))
+                db.session.add(ci)
+
+            ci.iso_alpha2 = item.iso_alpha2
+            ci.iso_alpha3 = item.iso_alpha3
+            ci.iso_numeric = int(item.iso_numeric)
+            ci.fips_code = item.fips_code
+            ci.title = item.title
+            ci.capital = item.capital
+            ci.area_in_sqkm = Decimal(item.area_in_sqkm) if item.area_in_sqkm else None
+            ci.population = int(item.population)
+            ci.continent = item.continent
+            ci.tld = item.tld
+            ci.currency_code = item.currency_code
+            ci.currency_name = item.currency_name
+            ci.phone = item.phone
+            ci.postal_code_format = item.postal_code_format
+            ci.postal_code_regex = item.postal_code_regex
+            ci.languages = item.languages.split(',')
+            ci.neighbours = item.neighbours.split(',')
+            ci.equivalent_fips_code = item.equivalent_fips_code
+
+            ci.make_name()
+
+    db.session.commit()
+
+
+def load_geonames(fd):
+    progress = get_progressbar()
+    print("Loading geonames...")  # NOQA: T001
+    size = sum(1 for line in fd)
+    fd.seek(0)  # Return to start
+    loadprogress = ProgressBar(
+        maxval=size,
+        widgets=[
+            progressbar.widgets.Percentage(),
+            ' ',
+            progressbar.widgets.Bar(),
+            ' ',
+            progressbar.widgets.ETA(),
+            ' ',
+        ],
+    ).start()
+
+    geonames = []
+
+    # Feature descriptions: http://download.geonames.org/export/dump/featureCodes_en.txt
+    # Sorting order, larger number has more weight
+    loadfeatures = {
+        ('L', 'CONT'): 22,  # Continent
+        ('A', 'PCL'): 21,  # Political entity (country)
+        ('A', 'PCLD'): 20,  # Dependent political entity
+        ('A', 'PCLF'): 19,  # Freely associated state
+        ('A', 'PCLI'): 18,  # Independent political entity
+        ('A', 'PCLS'): 17,  # Semi-independent political entity
+        ('A', 'ADM1'): 16,  # First-order administrative division (state, province)
+        ('P', 'PPLC'): 15,  # capital of a political entity
+        ('P', 'PPLA'): 14,  # Seat of a first-order admin. division (state capital)
+        ('P', 'PPLA2'): 13,  # Seat of a second-order administrative division
+        ('P', 'PPLA3'): 12,  # Seat of a third-order administrative division
+        ('P', 'PPLA4'): 11,  # Seat of a fourth-order administrative division
+        ('P', 'PPLG'): 10,  # Seat of government of a political entity
+        ('P', 'PPL'): 9,  # Populated place (city, could be a neighbourhood too)
+        ('P', 'PPLR'): 8,  # Religious populated place
+        ('P', 'PPLS'): 7,  # Populated places
+        ('P', 'PPLX'): 6,  # Section of populated place
+        ('S', 'TRIG'): 5,  # Triangulated location (shows up in data instead of P.PPL)
+        ('P', 'PPLL'): 4,  # Populated locality
+        ('P', 'PPLF'): 3,  # Farm village
+        ('A', 'ADM2'): 2,  # Second-order administrative division (district, county)
+        ('A', 'ADM3'): 1,  # Third-order administrative division
+    }
+
+    for counter, line in enumerate(fd):
+        loadprogress.update(counter)
+        if not line.startswith('#'):
+            rec = GeoNameRecord(*line.strip().split('\t'))
+            # Ignore places that have a population below 15,000, but keep places that
+            # have a population of 0, since that indicates data wasn't available
+            if rec.fclass == 'P' and (
+                (
+                    rec.population.isdigit()
+                    and int(rec.population != 0)
+                    and int(rec.population) < 15000
+                )
+                or not rec.population.isdigit()
+            ):
+                continue
+            if (rec.fclass, rec.fcode) not in loadfeatures:
+                continue
+            geonames.append(rec)
+
+    loadprogress.finish()
+
+    print(f"Sorting {len(geonames)} records...")  # NOQA: T001
+
+    geonames = [
+        row[2]
+        for row in sorted(
+            (
+                (
+                    loadfeatures[(item.fclass, item.fcode)],
+                    int(item.population) if item.population else 0,
+                    item,
+                )
+                for item in geonames
+            ),
+            reverse=True,
+        )
+    ]
+    GeoName.query.all()  # Load all data into session cache for faster lookup
+
+    print(f"Processing {len(geonames)} records...")  # NOQA: T001
+
+    for item in progress(geonames):
+        if item.geonameid:
+            gn = GeoName.query.get(int(item.geonameid))
+            if gn is None:
+                gn = GeoName(geonameid=int(item.geonameid))
+                db.session.add(gn)
+
+            gn.title = item.title or ''
+            gn.ascii_title = item.ascii_title or unidecode(item.title or '').replace(
+                '@', 'a'
+            )
+            gn.latitude = Decimal(item.latitude) or None
+            gn.longitude = Decimal(item.longitude) or None
+            gn.fclass = item.fclass or None
+            gn.fcode = item.fcode or None
+            gn.country_id = item.country_id or None
+            gn.cc2 = item.cc2 or None
+            gn.admin1 = item.admin1 or None
+            gn.admin2 = item.admin2 or None
+            gn.admin3 = item.admin3 or None
+            gn.admin4 = item.admin4 or None
+            gn.admin1code = gn.admin1_ref
+            gn.admin2code = gn.admin2_ref
+            gn.population = int(item.population) if item.population else None
+            gn.elevation = int(item.elevation) if item.elevation else None
+            gn.dem = int(item.dem) if item.dem else None
+            gn.timezone = item.timezone or None
+            gn.moddate = (
+                datetime.strptime(item.moddate, '%Y-%m-%d').date()
+                if item.moddate
+                else None
+            )
+
+            gn.make_name()
+            # Required for future make_name() calls to work correctly
+            db.session.flush()
+
+    db.session.commit()
+
+
+def load_alt_names(fd):
+    progress = get_progressbar()
+    print("Loading alternate names...")  # NOQA: T001
+    size = sum(1 for line in fd)
+    fd.seek(0)  # Return to start
+    loadprogress = ProgressBar(
+        maxval=size,
+        widgets=[
+            progressbar.widgets.Percentage(),
+            ' ',
+            progressbar.widgets.Bar(),
+            ' ',
+            progressbar.widgets.ETA(),
+            ' ',
+        ],
+    ).start()
+
+    def update_progress(counter):
+        loadprogress.update(counter + 1)
+        return True
+
+    geonameids = {r[0] for r in db.session.query(GeoName.id).all()}
+    altnames = [
+        GeoAltNameRecord(*row)
+        for counter, row in enumerate(csv.reader(fd, delimiter='\t'))
+        if update_progress(counter)
+        and not row[0].startswith('#')
+        and int(row[1]) in geonameids
+    ]
+
+    loadprogress.finish()
+
+    print(f"Processing {len(altnames)} records...")  # NOQA: T001
+    GeoAltName.query.all()  # Load all data into session cache for faster lookup
+
+    for item in progress(altnames):
+        if item.geonameid:
+            rec = GeoAltName.query.get(int(item.id))
+            if rec is None:
+                rec = GeoAltName(id=int(item.id))
+                db.session.add(rec)
+            rec.geonameid = int(item.geonameid)
+            rec.lang = item.lang or None
+            rec.title = item.title
+            rec.is_preferred_name = getbool(item.is_preferred_name) or False
+            rec.is_short_name = getbool(item.is_short_name) or False
+            rec.is_colloquial = getbool(item.is_colloquial) or False
+            rec.is_historic = getbool(item.is_historic) or False
+
+    db.session.commit()
+
+
+def load_admin1_codes(fd):
+    print("Loading admin1 codes...")  # NOQA: T001
+    progress = get_progressbar()
+    admincodes = [
+        GeoAdminRecord(*row)
+        for row in csv.reader(fd, delimiter='\t')
+        if not row[0].startswith('#')
+    ]
+
+    GeoAdmin1Code.query.all()  # Load all data into session cache for faster lookup
+    for item in progress(admincodes):
+        if item.geonameid:
+            rec = GeoAdmin1Code.query.get(item.geonameid)
+            if rec is None:
+                rec = GeoAdmin1Code(geonameid=item.geonameid)
+                db.session.add(rec)
+            rec.title = item.title
+            rec.ascii_title = item.ascii_title
+            rec.country_id, rec.admin1_code = item.code.split('.')
+
+    db.session.commit()
+
+
+def load_admin2_codes(fd):
+    print("Loading admin2 codes...")  # NOQA: T001
+    progress = get_progressbar()
+    admincodes = [
+        GeoAdminRecord(*row)
+        for row in csv.reader(fd, delimiter='\t')
+        if not row[0].startswith('#')
+    ]
+
+    GeoAdmin2Code.query.all()  # Load all data into session cache for faster lookup
+    for item in progress(admincodes):
+        if item.geonameid:
+            rec = GeoAdmin2Code.query.get(item.geonameid)
+            if rec is None:
+                rec = GeoAdmin2Code(geonameid=int(item.geonameid))
+                db.session.add(rec)
+            rec.title = item.title
+            rec.ascii_title = item.ascii_title
+            rec.country_id, rec.admin1_code, rec.admin2_code = item.code.split('.')
+
+    db.session.commit()
+
+
+@geo.command('download')
+def download():
+    """Download geoname data."""
+    os.makedirs('geoname_data', exist_ok=True)
+    for filename in (
+        'countryInfo.txt',
+        'admin1CodesASCII.txt',
+        'admin2Codes.txt',
+        'IN.zip',
+        'allCountries.zip',
+        'alternateNames.zip',
+    ):
+        downloadfile(
+            'http://download.geonames.org/export/dump/', filename, 'geoname_data'
+        )
+
+
+@geo.command('process')
+def process():
+    """Process downloaded geonames data."""
+    with open('geoname_data/countryInfo.txt', newline='') as fd:
+        load_country_info(fd)
+    with open('geoname_data/admin1CodesASCII.txt', newline='') as fd:
+        load_admin1_codes(fd)
+    with open('geoname_data/admin2Codes.txt', newline='') as fd:
+        load_admin2_codes(fd)
+    with open('geoname_data/IN.txt', newline='') as fd:
+        load_geonames(fd)
+    with open('geoname_data/allCountries.txt', newline='') as fd:
+        load_geonames(fd)
+    with open('geoname_data/alternateNames.txt', newline='') as fd:
+        load_alt_names(fd)
+
+
+app.cli.add_command(geo)

--- a/funnel/cli/geodata.py
+++ b/funnel/cli/geodata.py
@@ -105,6 +105,7 @@ GeoAltNameRecord = namedtuple(
 
 
 def get_progressbar():
+    """Create a progressbar."""
     return ProgressBar(
         widgets=[
             progressbar.widgets.Percentage(),
@@ -118,6 +119,7 @@ def get_progressbar():
 
 
 def downloadfile(basepath: str, filename: str, folder: Optional[str] = None):
+    """Download a geoname record file."""
     if not folder:
         folder_file = filename
     else:
@@ -159,6 +161,7 @@ def downloadfile(basepath: str, filename: str, folder: Optional[str] = None):
 
 
 def load_country_info(fd):
+    """Load country geonames from the given file descriptor."""
     print("Loading country info...")  # NOQA: T001
     progress = get_progressbar()
     countryinfo = [
@@ -200,6 +203,7 @@ def load_country_info(fd):
 
 
 def load_geonames(fd):
+    """Load geonames matching fixed criteria from the given file descriptor."""
     progress = get_progressbar()
     print("Loading geonames...")  # NOQA: T001
     size = sum(1 for line in fd)
@@ -327,6 +331,7 @@ def load_geonames(fd):
 
 
 def load_alt_names(fd):
+    """Load alternative names for geonames from the given file descriptor."""
     progress = get_progressbar()
     print("Loading alternate names...")  # NOQA: T001
     size = sum(1 for line in fd)
@@ -344,6 +349,7 @@ def load_alt_names(fd):
     ).start()
 
     def update_progress(counter):
+        """Update the progressbar, converting a statement into an expression."""
         loadprogress.update(counter + 1)
         return True
 
@@ -379,6 +385,7 @@ def load_alt_names(fd):
 
 
 def load_admin1_codes(fd):
+    """Load admin1 codes from the given file descriptor."""
     print("Loading admin1 codes...")  # NOQA: T001
     progress = get_progressbar()
     admincodes = [
@@ -402,6 +409,7 @@ def load_admin1_codes(fd):
 
 
 def load_admin2_codes(fd):
+    """Load admin2 codes from the given file descriptor."""
     print("Loading admin2 codes...")  # NOQA: T001
     progress = get_progressbar()
     admincodes = [

--- a/funnel/cli/misc.py
+++ b/funnel/cli/misc.py
@@ -6,6 +6,7 @@ from ..models import db
 
 @app.shell_context_processor
 def shell_context():
+    """Insert variables into flask shell locals."""
     return {'db': db, 'models': models}
 
 

--- a/funnel/cli/misc.py
+++ b/funnel/cli/misc.py
@@ -1,0 +1,31 @@
+from baseframe import baseframe_translations
+
+from .. import app, models
+from ..models import db
+
+
+@app.shell_context_processor
+def shell_context():
+    return {'db': db, 'models': models}
+
+
+@app.cli.command('dbconfig')
+def dbconfig():
+    """Show required database configuration."""
+    print(  # NOQA: T001
+        '''
+-- Pipe this into psql as a super user. Example:
+-- flask dbconfig | sudo -u postgres psql funnel
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+CREATE EXTENSION IF NOT EXISTS unaccent;
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE EXTENSION IF NOT EXISTS hll;
+'''
+    )
+
+
+@app.cli.command('baseframe_translations_path')
+def baseframe_translations_path():
+    """Show path to Baseframe translations."""
+    print(baseframe_translations.dirname)  # NOQA: T001

--- a/funnel/cli/periodic.py
+++ b/funnel/cli/periodic.py
@@ -20,6 +20,7 @@ DataSource = namedtuple('DataSource', ['basequery', 'datecolumn'])
 
 
 def data_sources():
+    """Return sources for daily growth report."""
     return {
         # `user_sessions`, `app_user_sessions` and `returning_users` (added below) are
         # lookup keys, while the others are titles
@@ -193,6 +194,7 @@ def growthstats():
     )
 
     def trend_symbol(current, previous):
+        """Return a trend symbol based on difference between current and previous."""
         if current > previous * 1.5:
             return '⏫'
         if current > previous:

--- a/funnel/cli/periodic.py
+++ b/funnel/cli/periodic.py
@@ -8,20 +8,11 @@ from dateutil.relativedelta import relativedelta
 import pytz
 import requests
 
-from baseframe import baseframe_translations
 from coaster.utils import midnight_to_utc, utcnow
 
-from . import app, models
-from .models import db
-from .views.notification import dispatch_notification
-
-# --- Shell context --------------------------------------------------------------------
-
-
-@app.shell_context_processor
-def shell_context():
-    return {'db': db, 'models': models}
-
+from .. import app, models
+from ..models import db
+from ..views.notification import dispatch_notification
 
 # --- Data sources ---------------------------------------------------------------------
 
@@ -62,28 +53,6 @@ def data_sources():
 
 
 # --- Commands -------------------------------------------------------------------------
-
-
-@app.cli.command('dbconfig')
-def dbconfig():
-    """Show required database configuration."""
-    print(  # NOQA: T001
-        '''
--- Pipe this into psql as a super user. Example:
--- flask dbconfig | sudo -u postgres psql funnel
-
-CREATE EXTENSION IF NOT EXISTS pg_trgm;
-CREATE EXTENSION IF NOT EXISTS unaccent;
-CREATE EXTENSION IF NOT EXISTS pgcrypto;
-CREATE EXTENSION IF NOT EXISTS hll;
-'''
-    )
-
-
-@app.cli.command('baseframe_translations_path')
-def baseframe_translations_path():
-    """Show path to Baseframe translations."""
-    print(baseframe_translations.dirname)  # NOQA: T001
 
 
 periodic = AppGroup(

--- a/funnel/models/__init__.py
+++ b/funnel/models/__init__.py
@@ -63,3 +63,4 @@ from .site_membership import *  # isort:skip
 from .moderation import *  # isort:skip
 from .notification_types import *  # isort:skip
 from .commentset_membership import *  # isort:skip
+from .geoname import *  # isort:skip

--- a/funnel/models/geoname.py
+++ b/funnel/models/geoname.py
@@ -1,0 +1,552 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Union, cast
+import re
+
+from sqlalchemy.dialects.postgresql import ARRAY
+from sqlalchemy.orm import joinedload
+
+from coaster.sqlalchemy import Query
+from coaster.utils import make_name
+
+from . import BaseMixin, BaseNameMixin, db
+from .helpers import quote_like
+
+__all__ = ['GeoName', 'GeoCountryInfo', 'GeoAdmin1Code', 'GeoAdmin2Code', 'GeoAltName']
+
+
+NOWORDS_RE = re.compile(r'(\W+)', re.UNICODE)
+WORDS_RE = re.compile(r'\w+', re.UNICODE)
+
+continent_codes = {
+    'AF': 6255146,  # Africa
+    'AS': 6255147,  # Asia
+    'EU': 6255148,  # Europe
+    'NA': 6255149,  # North America
+    'OC': 6255151,  # Ocenia
+    'SA': 6255150,  # South America
+    'AN': 6255152,  # Antarctica
+}
+
+
+class GeoCountryInfo(BaseNameMixin, db.Model):
+    __tablename__ = 'geo_country_info'
+    __bind_key__ = 'geoname'
+
+    geonameid = db.synonym('id')
+    geoname = db.relationship(
+        'GeoName',
+        uselist=False,
+        primaryjoin='GeoCountryInfo.id == foreign(GeoName.id)',
+        backref='has_country',
+    )
+    iso_alpha2 = db.Column(db.CHAR(2), unique=True)
+    iso_alpha3 = db.Column(db.CHAR(3), unique=True)
+    iso_numeric = db.Column(db.Integer)
+    fips_code = db.Column(db.Unicode(3))
+    capital = db.Column(db.Unicode)
+    area_in_sqkm = db.Column(db.Numeric)
+    population = db.Column(db.BigInteger)
+    continent = db.Column(db.CHAR(2))
+    tld = db.Column(db.Unicode(3))
+    currency_code = db.Column(db.CHAR(3))
+    currency_name = db.Column(db.Unicode)
+    phone = db.Column(db.Unicode(16))
+    postal_code_format = db.Column(db.Unicode)
+    postal_code_regex = db.Column(db.Unicode)
+    languages = db.Column(ARRAY(db.Unicode, dimensions=1))
+    neighbours = db.Column(ARRAY(db.CHAR(2), dimensions=1))
+    equivalent_fips_code = db.Column(db.Unicode(3))
+
+    __table_args__ = (
+        db.Index(
+            'ix_geo_country_info_title',
+            db.func.lower('title').label('title_lower'),
+            postgresql_ops={'title_lower': 'varchar_pattern_ops'},
+        ),
+    )
+
+    def __repr__(self):
+        """Return representation."""
+        return '<GeoCountryInfo %d "%s">' % (self.geonameid, self.title)
+
+
+class GeoAdmin1Code(BaseMixin, db.Model):
+    __tablename__ = 'geo_admin1_code'
+    __bind_key__ = 'geoname'
+
+    geonameid = db.synonym('id')
+    geoname = db.relationship(
+        'GeoName',
+        uselist=False,
+        primaryjoin='GeoAdmin1Code.id == foreign(GeoName.id)',
+        backref='has_admin1code',
+        viewonly=True,
+    )
+    title = db.Column(db.Unicode)
+    ascii_title = db.Column(db.Unicode)
+    country_id = db.Column(
+        'country', db.CHAR(2), db.ForeignKey('geo_country_info.iso_alpha2')
+    )
+    country = db.relationship('GeoCountryInfo')
+    admin1_code = db.Column(db.Unicode)
+
+    def __repr__(self):
+        """Return representation."""
+        return '<GeoAdmin1Code %d "%s">' % (self.geonameid, self.ascii_title)
+
+
+class GeoAdmin2Code(BaseMixin, db.Model):
+    __tablename__ = 'geo_admin2_code'
+    __bind_key__ = 'geoname'
+
+    geonameid = db.synonym('id')
+    geoname = db.relationship(
+        'GeoName',
+        uselist=False,
+        primaryjoin='GeoAdmin2Code.id == foreign(GeoName.id)',
+        backref='has_admin2code',
+        viewonly=True,
+    )
+    title = db.Column(db.Unicode)
+    ascii_title = db.Column(db.Unicode)
+    country_id = db.Column(
+        'country', db.CHAR(2), db.ForeignKey('geo_country_info.iso_alpha2')
+    )
+    country = db.relationship('GeoCountryInfo')
+    admin1_code = db.Column(db.Unicode)
+    admin2_code = db.Column(db.Unicode)
+
+    def __repr__(self):
+        """Return representation."""
+        return '<GeoAdmin2Code %d "%s">' % (self.geonameid, self.ascii_title)
+
+
+class GeoName(BaseNameMixin, db.Model):
+    __tablename__ = 'geo_name'
+    __bind_key__ = 'geoname'
+
+    geonameid = db.synonym('id')
+    ascii_title = db.Column(db.Unicode)
+    latitude = db.Column(db.Numeric)
+    longitude = db.Column(db.Numeric)
+    fclass = db.Column(db.CHAR(1))
+    fcode = db.Column(db.Unicode)
+    country_id = db.Column(
+        'country', db.CHAR(2), db.ForeignKey('geo_country_info.iso_alpha2')
+    )
+    country = db.relationship('GeoCountryInfo')
+    cc2 = db.Column(db.Unicode)
+    admin1 = db.Column(db.Unicode)
+    admin1_ref = db.relationship(
+        'GeoAdmin1Code',
+        uselist=False,
+        primaryjoin='and_(GeoName.country_id == foreign(GeoAdmin1Code.country_id), '
+        'GeoName.admin1 == foreign(GeoAdmin1Code.admin1_code))',
+        viewonly=True,
+    )
+    admin1_id = db.Column(None, db.ForeignKey('geo_admin1_code.id'), nullable=True)
+    admin1code = db.relationship(
+        'GeoAdmin1Code', uselist=False, foreign_keys=[admin1_id]
+    )
+
+    admin2 = db.Column(db.Unicode)
+    admin2_ref = db.relationship(
+        'GeoAdmin2Code',
+        uselist=False,
+        primaryjoin='and_(GeoName.country_id == foreign(GeoAdmin2Code.country_id), '
+        'GeoName.admin1 == foreign(GeoAdmin2Code.admin1_code), '
+        'GeoName.admin2 == foreign(GeoAdmin2Code.admin2_code))',
+        viewonly=True,
+    )
+    admin2_id = db.Column(None, db.ForeignKey('geo_admin2_code.id'), nullable=True)
+    admin2code = db.relationship(
+        'GeoAdmin2Code', uselist=False, foreign_keys=[admin2_id]
+    )
+
+    admin4 = db.Column(db.Unicode)
+    admin3 = db.Column(db.Unicode)
+    population = db.Column(db.BigInteger)
+    elevation = db.Column(db.Integer)
+    dem = db.Column(db.Integer)  # Digital Elevation Model
+    timezone = db.Column(db.Unicode)
+    moddate = db.Column(db.Date)
+
+    __table_args__ = (
+        db.Index(
+            'ix_geo_name_title',
+            db.func.lower('title').label('title_lower'),
+            postgresql_ops={'title_lower': 'varchar_pattern_ops'},
+        ),
+        db.Index(
+            'ix_geo_name_ascii_title',
+            db.func.lower(ascii_title).label('ascii_title_lower'),
+            postgresql_ops={'ascii_title_lower': 'varchar_pattern_ops'},
+        ),
+    )
+
+    @property
+    def short_title(self) -> str:
+        if self.has_country:
+            return self.has_country.title
+        elif self.has_admin1code:
+            return self.admin1code.title if self.admin1code else self.admin1_ref.title
+        elif self.has_admin2code:
+            return self.admin2code.title if self.admin2code else self.admin2_ref.title
+        else:
+            return self.ascii_title or self.title
+
+    @property
+    def picker_title(self) -> str:
+        title = self.use_title
+        country = self.country_id
+        if country == 'US':
+            state = self.admin1
+        else:
+            state = None
+        suffix = None
+
+        if (self.fclass, self.fcode) == ('L', 'CONT'):
+            suffix = 'continent'
+            country = None
+            state = None
+        elif self.has_country:
+            suffix = 'country'
+            country = None
+            state = None
+        elif self.has_admin1code:
+            if country in ('CA', 'CN', 'AF'):
+                suffix = 'province'
+            else:
+                suffix = 'state'
+            state = None
+        elif self.has_admin2code:
+            if country == 'US':
+                suffix = 'county'
+            elif country == 'CN':
+                suffix = 'prefecture'
+            else:
+                suffix = 'district'
+
+        if state:
+            title = '%s, %s' % (title, state)
+        if country:
+            title = '%s, %s' % (title, country)
+        if suffix:
+            return '%s (%s)' % (title, suffix)
+        else:
+            return title
+
+    @property
+    def geoname(self) -> GeoName:
+        return self
+
+    @property
+    def use_title(self) -> str:
+        usetitle = self.ascii_title
+        if self.fclass == 'A' and self.fcode.startswith('PCL'):
+            if 'of the' in usetitle:
+                usetitle = usetitle.split('of the')[-1].strip()
+            elif 'of The' in usetitle:
+                usetitle = usetitle.split('of The')[-1].strip()
+            elif 'of' in usetitle:
+                usetitle = usetitle.split('of')[-1].strip()
+        elif self.fclass == 'A' and self.fcode == 'ADM1':
+            usetitle = (
+                usetitle.replace('State of', '')
+                .replace('Union Territory of', '')
+                .strip()
+            )
+        return usetitle
+
+    def make_name(self, reserved: Optional[List[str]] = None) -> None:
+        if not reserved:
+            reserved = []
+        if self.ascii_title:
+            usetitle = self.use_title
+            if self.id:
+
+                def checkused(c):
+                    return bool(
+                        c in reserved
+                        or GeoName.query.filter(GeoName.id != self.id)
+                        .filter_by(name=c)
+                        .notempty()
+                    )
+
+            else:
+
+                def checkused(c):
+                    return bool(
+                        c in reserved or GeoName.query.filter_by(name=c).notempty()
+                    )
+
+            with db.session.no_autoflush:
+                self.name = str(make_name(usetitle, maxlength=250, checkused=checkused))
+
+    def __repr__(self) -> str:
+        """Return representation."""
+        return '<GeoName %d %s %s %s "%s">' % (
+            self.geonameid,
+            self.country_id,
+            self.fclass,
+            self.fcode,
+            self.ascii_title,
+        )
+
+    def related_geonames(self) -> Dict[str, GeoName]:
+        related = {}
+        if self.admin2code and self.admin2code.geonameid != self.geonameid:
+            related['admin2'] = self.admin2code.geoname
+        if self.admin1code and self.admin1code.geonameid != self.geonameid:
+            related['admin1'] = self.admin1code.geoname
+        if self.country and self.country.geonameid != self.geonameid:
+            related['country'] = self.country.geoname
+        if (self.fclass, self.fcode) != ('L', 'CONT') and self.country:
+            related['continent'] = GeoName.query.get(
+                continent_codes[self.country.continent]
+            )
+        return related
+
+    def as_dict(self, related=True, alternate_titles=True) -> dict:
+        return {
+            'geonameid': self.geonameid,
+            'name': self.name,
+            'title': self.title,
+            'ascii_title': self.ascii_title,
+            'short_title': self.short_title,
+            'use_title': self.use_title,
+            'picker_title': self.picker_title,
+            'latitude': str(self.latitude),
+            'longitude': str(self.longitude),
+            'fclass': self.fclass,
+            'fcode': self.fcode,
+            'country': self.country_id,
+            'cc2': self.cc2,
+            'admin1': self.admin1,
+            'admin2': self.admin2,
+            'admin3': self.admin3,
+            'admin4': self.admin4,
+            'is_country': bool(self.has_country),
+            'is_admin1': bool(self.has_admin1code),
+            'is_admin2': bool(self.has_admin2code),
+            'is_continent': (self.fclass, self.fcode) == ('L', 'CONT'),
+            'population': self.population,
+            'elevation': self.elevation,
+            'dem': self.dem,
+            'timezone': self.timezone,
+            'moddate': self.moddate.strftime('%Y-%m-%d') if self.moddate else None,
+            'related': {
+                k: v.as_dict(related=False, alternate_titles=False)
+                for (k, v) in self.related_geonames().items()
+            }
+            if related
+            else {},
+            'alternate_titles': [a.as_dict() for a in self.alternate_titles]
+            if alternate_titles
+            else [],
+        }
+
+    @classmethod
+    def get(cls, name) -> Optional[GeoName]:
+        return cls.query.filter_by(name=name).one_or_none()
+
+    @classmethod
+    def get_by_title(
+        cls, titles: Union[str, List[str]], lang: Optional[str] = None
+    ) -> List[GeoName]:
+        results = set()
+        if isinstance(titles, str):
+            titles = [titles]
+        for title in titles:
+            if lang:
+                results.update(
+                    [
+                        r.geoname
+                        for r in GeoAltName.query.filter(
+                            db.func.lower(GeoAltName.title) == title.lower(),
+                            GeoAltName.lang == lang,
+                        ).all()
+                        if r.geoname
+                    ]
+                )
+            else:
+                results.update(
+                    [
+                        r.geoname
+                        for r in GeoAltName.query.filter(
+                            db.func.lower(GeoAltName.title) == title.lower()
+                        ).all()
+                        if r.geoname
+                    ]
+                )
+        return sorted(
+            results,
+            key=lambda g: ({'A': 1, 'P': 2}.get(g.fclass, 0), g.population),
+            reverse=True,
+        )
+
+    @classmethod
+    def parse_locations(
+        cls,
+        q: str,
+        special: Optional[List[str]] = None,
+        lang: Optional[str] = None,
+        bias: Optional[List[str]] = None,
+    ):
+        """
+        Parse a string and return annotations marking all identified locations.
+
+        :param q: String to parse
+        :param special: Special tokens to be marked in the annotations
+        :param lang: Limit locations to names in this language
+        :param bias: Country codes (ISO two letter) to prioritize locations from
+        """
+        special = [s.lower() for s in special] if special else []
+        if bias is None:
+            bias = []
+        tokens = NOWORDS_RE.split(q)
+        while '' in tokens:
+            tokens.remove('')  # Remove blank tokens from beginning and end
+        ltokens = [t.lower() for t in tokens]
+        results: List[Dict[str, Any]] = []
+        counter = 0
+        limit = len(tokens)
+        while counter < limit:
+            token = tokens[counter]
+            # Do a case-insensitive match
+            ltoken = token.lower()
+            # Ignore punctuation, only query for tokens containing text
+            # Special-case 'or' and 'in' to prevent matching against Oregon and Indiana, USA.
+            if ltoken not in ('or', 'in', 'to', 'the') and WORDS_RE.match(token):
+                # Find a GeoAltName matching token, add GeoAltName.geoname to results
+                if lang:
+                    matches = (
+                        GeoAltName.query.filter(
+                            db.func.lower(GeoAltName.title).like(ltoken)
+                        )
+                        .filter(
+                            db.or_(GeoAltName.lang == lang, GeoAltName.lang.is_(None))
+                        )
+                        .options(
+                            joinedload('geoname').joinedload('country'),
+                            joinedload('geoname').joinedload('admin1code'),
+                            joinedload('geoname').joinedload('admin2code'),
+                        )
+                        .all()
+                    )
+                else:
+                    matches = (
+                        GeoAltName.query.filter(
+                            db.func.lower(GeoAltName.title).like(quote_like(ltoken))
+                        )
+                        .options(
+                            joinedload('geoname').joinedload('country'),
+                            joinedload('geoname').joinedload('admin1code'),
+                            joinedload('geoname').joinedload('admin2code'),
+                        )
+                        .all()
+                    )
+                if not matches:
+                    # This token didn't match anything, move on
+                    results.append({'token': token})
+                else:
+                    # Now filter through the matches to see if there are exact matches
+                    candidates = [
+                        (NOWORDS_RE.split(m.title.lower()), m) for m in matches
+                    ]
+                    fullmatch = []
+                    for mtokens, match in candidates:
+                        if mtokens == ltokens[counter : counter + len(mtokens)]:
+                            fullmatch.append((len(mtokens), match))
+                    if fullmatch:
+                        maxmatch = max(f[0] for f in fullmatch)
+                        accepted = list({f[1] for f in fullmatch if f[0] == maxmatch})
+                        # Filter accepted down to one match.
+                        # Sort by (a) bias, (b) language match, (c) city over state and (d) population
+                        accepted.sort(
+                            key=lambda a: (
+                                {
+                                    v: k
+                                    for k, v in enumerate(
+                                        reversed(cast(List[str], bias))
+                                    )
+                                }.get(a.geoname.country_id, -1),
+                                {lang: 0}.get(a.lang, 1),
+                                {'A': 1, 'P': 2}.get(a.geoname.fclass, 0),
+                                a.geoname.population,
+                            ),
+                            reverse=True,
+                        )
+                        results.append(
+                            {
+                                'token': ''.join(tokens[counter : counter + maxmatch]),
+                                'geoname': accepted[0].geoname,
+                            }
+                        )
+                        counter += maxmatch - 1
+                    else:
+                        results.append({'token': token})
+            else:
+                results.append({'token': token})
+
+            if ltoken in special:
+                results[-1]['special'] = True
+            counter += 1
+        return results
+
+    @classmethod
+    def autocomplete(cls, q: str, lang: Optional[str] = None) -> Query:
+        query = (
+            cls.query.join(cls.alternate_titles)
+            .filter(db.func.lower(GeoAltName.title).like(quote_like(q.lower())))
+            .order_by(db.desc(cls.population))
+        )
+        if lang:
+            query = query.filter(
+                db.or_(GeoAltName.lang.is_(None), GeoAltName.lang == lang)
+            )
+        return query
+
+
+class GeoAltName(BaseMixin, db.Model):
+    __tablename__ = 'geo_alt_name'
+    __bind_key__ = 'geoname'
+
+    geonameid = db.Column(None, db.ForeignKey('geo_name.id'), nullable=False)
+    geoname = db.relationship(
+        GeoName, backref=db.backref('alternate_titles', cascade='all, delete-orphan')
+    )
+    lang = db.Column(db.Unicode, nullable=True, index=True)
+    title = db.Column(db.Unicode, nullable=False)
+    is_preferred_name = db.Column(db.Boolean, nullable=False)
+    is_short_name = db.Column(db.Boolean, nullable=False)
+    is_colloquial = db.Column(db.Boolean, nullable=False)
+    is_historic = db.Column(db.Boolean, nullable=False)
+
+    __table_args__ = (
+        db.Index(
+            'ix_geo_alt_name_title',
+            db.func.lower('title').label('title_lower'),
+            postgresql_ops={'title_lower': 'varchar_pattern_ops'},
+        ),
+    )
+
+    def __repr__(self) -> str:
+        """Return representation."""
+        return '<GeoAltName %s "%s" of %s>' % (
+            self.lang,
+            self.title,
+            repr(self.geoname)[1:-1] if self.geoname else None,
+        )
+
+    def as_dict(self) -> dict:
+        return {
+            'geonameid': self.geonameid,
+            'lang': self.lang,
+            'title': self.title,
+            'is_preferred_name': self.is_preferred_name,
+            'is_short_name': self.is_short_name,
+            'is_colloquial': self.is_colloquial,
+            'is_historic': self.is_historic,
+        }

--- a/funnel/models/helpers.py
+++ b/funnel/models/helpers.py
@@ -34,6 +34,7 @@ __all__ = [
     'password_policy',
     'valid_name',
     'valid_username',
+    'quote_like',
     'ImgeeFurl',
     'ImgeeType',
 ]
@@ -299,6 +300,22 @@ def pgquote(identifier: str) -> str:
     """Add double quotes to the given identifier if required (PostgreSQL only)."""
     return (
         ('"%s"' % identifier) if identifier in POSTGRESQL_RESERVED_WORDS else identifier
+    )
+
+
+def quote_like(query):
+    """
+    Construct a LIKE query.
+
+    Usage::
+
+        column.like(quote_like(q))
+    """
+    # Escape the '%' and '_' wildcards in SQL LIKE clauses.
+    # Some SQL dialects respond to '[' and ']', so remove them.
+    return (
+        query.replace('%', r'\%').replace('_', r'\_').replace('[', '').replace(']', '')
+        + '%'
     )
 
 

--- a/funnel/models/user.py
+++ b/funnel/models/user.py
@@ -38,7 +38,7 @@ from . import (
     hybrid_property,
 )
 from .email_address import EmailAddress, EmailAddressMixin
-from .helpers import ImgeeFurl, add_search_trigger
+from .helpers import ImgeeFurl, add_search_trigger, quote_like
 
 __all__ = [
     'USER_STATE',
@@ -670,13 +670,7 @@ class User(SharedProfileMixin, UuidMixin, BaseMixin, db.Model):
         """
         # Escape the '%' and '_' wildcards in SQL LIKE clauses.
         # Some SQL dialects respond to '[' and ']', so remove them.
-        like_query = (
-            query.replace('%', r'\%')
-            .replace('_', r'\_')
-            .replace('[', '')
-            .replace(']', '')
-            + '%'
-        )
+        like_query = quote_like(query)
 
         # We convert to lowercase and use the LIKE operator since ILIKE isn't standard
         # and doesn't use an index in PostgreSQL. There's a functional index for lower()

--- a/funnel/views/__init__.py
+++ b/funnel/views/__init__.py
@@ -13,6 +13,7 @@ from . import (
     email,
     email_events,
     errors,
+    geoname,
     helpers,
     index,
     label,

--- a/funnel/views/geoname.py
+++ b/funnel/views/geoname.py
@@ -14,6 +14,7 @@ from ..typing import ReturnRenderWith
 def geo_get_by_name(
     name: str, related: bool = False, alternate_titles: bool = False
 ) -> ReturnRenderWith:
+    """Get a geoname record given a single URL stub name or geoname id."""
     if name.isdigit():
         geoname = GeoName.query.get(int(name))
     else:
@@ -36,6 +37,7 @@ def geo_get_by_name(
 def geo_get_by_names(
     name: List[str], related: bool = False, alternate_titles: bool = False
 ) -> ReturnRenderWith:
+    """Get geoname records matching given URL stub names or geonameids."""
     geonames = []
     for n in name:
         if n.isdigit():
@@ -57,6 +59,7 @@ def geo_get_by_names(
 @render_with(json=True)
 @requestargs('title[]', 'lang')
 def geo_get_by_title(title: List[str], lang: Optional[str] = None) -> ReturnRenderWith:
+    """Get locations matching given titles."""
     return {
         'status': 'ok',
         'result': [g.as_dict() for g in GeoName.get_by_title(title, lang)],
@@ -73,6 +76,7 @@ def geo_parse_location(
     bias: List[str] = None,
     alternate_titles: bool = False,
 ) -> ReturnRenderWith:
+    """Parse locations from a string of locations."""
     result = GeoName.parse_locations(q, special, lang, bias)
     for item in result:
         if 'geoname' in item:
@@ -86,6 +90,7 @@ def geo_parse_location(
 def geo_autocomplete(
     q: str, lang: Optional[str] = None, limit: int = 100
 ) -> ReturnRenderWith:
+    """Autocomplete a geoname record."""
     return {
         'status': 'ok',
         'result': [

--- a/funnel/views/geoname.py
+++ b/funnel/views/geoname.py
@@ -1,0 +1,95 @@
+from typing import List, Optional
+
+from coaster.utils import getbool
+from coaster.views import render_with, requestargs
+
+from .. import app
+from ..models import GeoName
+from ..typing import ReturnRenderWith
+
+
+@app.route('/api/1/geo/get_by_name')
+@render_with(json=True)
+@requestargs('name', ('related', getbool), ('alternate_titles', getbool))
+def geo_get_by_name(
+    name: str, related: bool = False, alternate_titles: bool = False
+) -> ReturnRenderWith:
+    if name.isdigit():
+        geoname = GeoName.query.get(int(name))
+    else:
+        geoname = GeoName.get(name)
+    return (
+        {
+            'status': 'ok',
+            'result': geoname.as_dict(
+                related=related, alternate_titles=alternate_titles
+            ),
+        }
+        if geoname
+        else {'status': 'error', 'error': 'not_found'}
+    )
+
+
+@app.route('/api/1/geo/get_by_names')
+@render_with(json=True)
+@requestargs('name[]', ('related', getbool), ('alternate_titles', getbool))
+def geo_get_by_names(
+    name: List[str], related: bool = False, alternate_titles: bool = False
+) -> ReturnRenderWith:
+    geonames = []
+    for n in name:
+        if n.isdigit():
+            geoname = GeoName.query.get(int(n))
+        else:
+            geoname = GeoName.get(n)
+        if geoname:
+            geonames.append(geoname)
+    return {
+        'status': 'ok',
+        'result': [
+            gn.as_dict(related=related, alternate_titles=alternate_titles)
+            for gn in geonames
+        ],
+    }
+
+
+@app.route('/api/1/geo/get_by_title')
+@render_with(json=True)
+@requestargs('title[]', 'lang')
+def geo_get_by_title(title: List[str], lang: Optional[str] = None) -> ReturnRenderWith:
+    return {
+        'status': 'ok',
+        'result': [g.as_dict() for g in GeoName.get_by_title(title, lang)],
+    }
+
+
+@app.route('/api/1/geo/parse_locations')
+@render_with(json=True)
+@requestargs('q', 'special[]', 'lang', 'bias[]', ('alternate_titles', getbool))
+def geo_parse_location(
+    q: str,
+    special: List[str] = None,
+    lang: str = None,
+    bias: List[str] = None,
+    alternate_titles: bool = False,
+) -> ReturnRenderWith:
+    result = GeoName.parse_locations(q, special, lang, bias)
+    for item in result:
+        if 'geoname' in item:
+            item['geoname'] = item['geoname'].as_dict(alternate_titles=alternate_titles)
+    return {'status': 'ok', 'result': result}
+
+
+@app.route('/api/1/geo/autocomplete')
+@render_with(json=True)
+@requestargs('q', 'lang', ('limit', int))
+def geo_autocomplete(
+    q: str, lang: Optional[str] = None, limit: int = 100
+) -> ReturnRenderWith:
+    return {
+        'status': 'ok',
+        'result': [
+            g.as_dict(related=False, alternate_titles=False)
+            for g in GeoName.autocomplete(q, lang).limit(limit)
+        ],
+    }

--- a/funnel/views/jobs.py
+++ b/funnel/views/jobs.py
@@ -1,14 +1,13 @@
 from collections import defaultdict
-from urllib.parse import urljoin
 
 import requests
 
-from baseframe import __, statsd
+from baseframe import statsd
 
 from .. import app, rq
 from ..extapi.boxoffice import Boxoffice
 from ..extapi.explara import ExplaraAPI
-from ..models import EmailAddress, Project, ProjectLocation, TicketClient, db
+from ..models import EmailAddress, GeoName, Project, ProjectLocation, TicketClient, db
 
 
 @rq.job('funnel')
@@ -32,69 +31,61 @@ def import_tickets(ticket_client_id):
 
 @rq.job('funnel')
 def tag_locations(project_id):
-    """Retrieve geonameids from Hascore against plaintext location string in project."""
-    if app.config.get('HASCORE_SERVER'):
-        with app.test_request_context():
-            project = Project.query.get(project_id)
-            if not project.location:
-                return
-            url = urljoin(app.config['HASCORE_SERVER'], '/1/geo/parse_locations')
-            response = requests.get(
-                url,
-                params={
-                    'q': project.location,
-                    'bias': ['IN', 'US'],
-                    'special': ['Internet', 'Online', __('Internet'), __('Online')],
-                },
-            ).json()
+    """
+    Tag a project with geoname locations.
 
-            if response.get('status') == 'ok':
-                results = response.get('result', [])
-                geonames = defaultdict(dict)
-                tokens = []
-                for item in results:
-                    geoname = item.get('geoname', {})
-                    if geoname:
-                        geonames[geoname['geonameid']]['geonameid'] = geoname[
+    This function used to retrieve data from Hascore, which has been merged into Funnel
+    and is available directly as the GeoName model. This code continues to operate with
+    the legacy Hascore data structure, and is pending rewrite.
+    """
+    with app.test_request_context():
+        project = Project.query.get(project_id)
+        if not project.location:
+            return
+        results = GeoName.parse_locations(
+            project.location, special=["Internet", "Online"], bias=['IN', 'US']
+        )
+        geonames = defaultdict(dict)
+        tokens = []
+        for item in results:
+            if 'geoname' in item:
+                geoname = item['geoname'].as_dict(alternate_titles=False)
+                geonames[geoname['geonameid']]['geonameid'] = geoname['geonameid']
+                geonames[geoname['geonameid']]['primary'] = geonames[
+                    geoname['geonameid']
+                ].get('primary', True)
+                for gtype, related in geoname.get('related', {}).items():
+                    if gtype in ['admin2', 'admin1', 'country', 'continent']:
+                        geonames[related['geonameid']]['geonameid'] = related[
                             'geonameid'
                         ]
-                        geonames[geoname['geonameid']]['primary'] = geonames[
-                            geoname['geonameid']
-                        ].get('primary', True)
-                        for gtype, related in geoname.get('related', {}).items():
-                            if gtype in ['admin2', 'admin1', 'country', 'continent']:
-                                geonames[related['geonameid']]['geonameid'] = related[
-                                    'geonameid'
-                                ]
-                                geonames[related['geonameid']]['primary'] = False
+                        geonames[related['geonameid']]['primary'] = False
 
-                        tokens.append(
-                            {
-                                'token': item.get('token', ''),
-                                'geoname': {
-                                    'name': geoname['name'],
-                                    'geonameid': geoname['geonameid'],
-                                },
-                            }
-                        )
-                    else:
-                        tokens.append({'token': item.get('token', '')})
+                tokens.append(
+                    {
+                        'token': item.get('token', ''),
+                        'geoname': {
+                            'name': geoname['name'],
+                            'geonameid': geoname['geonameid'],
+                        },
+                    }
+                )
+            else:
+                tokens.append({'token': item.get('token', '')})
 
-                project.parsed_location = {'tokens': tokens}
+        project.parsed_location = {'tokens': tokens}
 
-                for locdata in geonames.values():
-                    loc = ProjectLocation.query.get((project_id, locdata['geonameid']))
-                    if loc is None:
-                        loc = ProjectLocation(
-                            project=project, geonameid=locdata['geonameid']
-                        )
-                        db.session.add(loc)
-                        db.session.flush()
-                    loc.primary = locdata['primary']
-                for location in project.locations:
-                    if location.geonameid not in geonames:
-                        db.session.delete(location)
-                db.session.commit()
+        for locdata in geonames.values():
+            loc = ProjectLocation.query.get((project_id, locdata['geonameid']))
+            if loc is None:
+                loc = ProjectLocation(project=project, geonameid=locdata['geonameid'])
+                db.session.add(loc)
+                db.session.flush()
+            loc.primary = locdata['primary']
+        for location in project.locations:
+            if location.geonameid not in geonames:
+                db.session.delete(location)
+        db.session.commit()
 
 
 # TODO: Deprecate this method and the AuthClient notification system

--- a/instance/settings-sample.py
+++ b/instance/settings-sample.py
@@ -6,6 +6,9 @@ SITE_SUPPORT_EMAIL = 'test@example.com'
 GA_CODE = ''
 #: Database backend
 SQLALCHEMY_DATABASE_URI = 'postgresql://host/database'
+SQLALCHEMY_BINDS = {
+    'geoname': 'postgresql://host/geoname',
+}
 #: Shortlink domain for SMS links (must be served via wsgi:shortlinkapp)
 SHORTLINK_DOMAIN = 'domain.tld'
 #: Secret keys

--- a/instance/testing.py
+++ b/instance/testing.py
@@ -6,6 +6,9 @@ SECRET_KEYS = ['testkey']  # nosec
 LASTUSER_SECRET_KEYS = ['testkey']  # nosec
 SITE_TITLE = 'Hasgeek'
 SQLALCHEMY_DATABASE_URI = 'postgresql:///funnel_testing'
+SQLALCHEMY_BINDS = {
+    'geoname': 'postgresql:///geoname_testing',
+}
 SERVER_NAME = 'funnel.travis.local:3002'
 SHORTLINK_DOMAIN = 'funnel.travis.local:3002'
 DEFAULT_DOMAIN = 'funnel.travis.local'

--- a/migrations/versions/7d5b77aada1e_add_geoname_models.py
+++ b/migrations/versions/7d5b77aada1e_add_geoname_models.py
@@ -1,0 +1,204 @@
+"""Add geoname models.
+
+Revision ID: 7d5b77aada1e
+Revises: 896137ace892
+Create Date: 2021-06-19 17:05:32.356693
+
+"""
+
+from alembic import op
+from sqlalchemy.dialects import postgresql
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '7d5b77aada1e'
+down_revision = '896137ace892'
+branch_labels = None
+depends_on = None
+
+
+def upgrade(engine_name=''):
+    # Do not modify. Edit `upgrade_` instead
+    globals().get('upgrade_%s' % engine_name, lambda: None)()
+
+
+def downgrade(engine_name=''):
+    # Do not modify. Edit `downgrade_` instead
+    globals().get('downgrade_%s' % engine_name, lambda: None)()
+
+
+def upgrade_():
+    pass
+
+
+def downgrade_():
+    pass
+
+
+def upgrade_geoname():
+    op.create_table(
+        'geo_country_info',
+        sa.Column('iso_alpha2', sa.CHAR(length=2), nullable=True),
+        sa.Column('iso_alpha3', sa.CHAR(length=3), nullable=True),
+        sa.Column('iso_numeric', sa.Integer(), nullable=True),
+        sa.Column('fips_code', sa.Unicode(length=3), nullable=True),
+        sa.Column('capital', sa.Unicode(), nullable=True),
+        sa.Column('area_in_sqkm', sa.Numeric(), nullable=True),
+        sa.Column('population', sa.BigInteger(), nullable=True),
+        sa.Column('continent', sa.CHAR(length=2), nullable=True),
+        sa.Column('tld', sa.Unicode(length=3), nullable=True),
+        sa.Column('currency_code', sa.CHAR(length=3), nullable=True),
+        sa.Column('currency_name', sa.Unicode(), nullable=True),
+        sa.Column('phone', sa.Unicode(length=16), nullable=True),
+        sa.Column('postal_code_format', sa.Unicode(), nullable=True),
+        sa.Column('postal_code_regex', sa.Unicode(), nullable=True),
+        sa.Column(
+            'languages', postgresql.ARRAY(sa.Unicode(), dimensions=1), nullable=True
+        ),
+        sa.Column(
+            'neighbours',
+            postgresql.ARRAY(sa.CHAR(length=2), dimensions=1),
+            nullable=True,
+        ),
+        sa.Column('equivalent_fips_code', sa.Unicode(length=3), nullable=True),
+        sa.Column('name', sa.Unicode(length=250), nullable=False),
+        sa.Column('title', sa.Unicode(length=250), nullable=False),
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column('updated_at', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('iso_alpha2'),
+        sa.UniqueConstraint('iso_alpha3'),
+        sa.UniqueConstraint('name'),
+    )
+    op.create_table(
+        'geo_admin1_code',
+        sa.Column('title', sa.Unicode(), nullable=True),
+        sa.Column('ascii_title', sa.Unicode(), nullable=True),
+        sa.Column('country', sa.CHAR(length=2), nullable=True),
+        sa.Column('admin1_code', sa.Unicode(), nullable=True),
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column('updated_at', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ['country'],
+            ['geo_country_info.iso_alpha2'],
+        ),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_table(
+        'geo_admin2_code',
+        sa.Column('title', sa.Unicode(), nullable=True),
+        sa.Column('ascii_title', sa.Unicode(), nullable=True),
+        sa.Column('country', sa.CHAR(length=2), nullable=True),
+        sa.Column('admin1_code', sa.Unicode(), nullable=True),
+        sa.Column('admin2_code', sa.Unicode(), nullable=True),
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column('updated_at', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ['country'],
+            ['geo_country_info.iso_alpha2'],
+        ),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_table(
+        'geo_name',
+        sa.Column('ascii_title', sa.Unicode(), nullable=True),
+        sa.Column('latitude', sa.Numeric(), nullable=True),
+        sa.Column('longitude', sa.Numeric(), nullable=True),
+        sa.Column('fclass', sa.CHAR(length=1), nullable=True),
+        sa.Column('fcode', sa.Unicode(), nullable=True),
+        sa.Column('country', sa.CHAR(length=2), nullable=True),
+        sa.Column('cc2', sa.Unicode(), nullable=True),
+        sa.Column('admin1', sa.Unicode(), nullable=True),
+        sa.Column('admin1_id', sa.Integer(), nullable=True),
+        sa.Column('admin2', sa.Unicode(), nullable=True),
+        sa.Column('admin2_id', sa.Integer(), nullable=True),
+        sa.Column('admin4', sa.Unicode(), nullable=True),
+        sa.Column('admin3', sa.Unicode(), nullable=True),
+        sa.Column('population', sa.BigInteger(), nullable=True),
+        sa.Column('elevation', sa.Integer(), nullable=True),
+        sa.Column('dem', sa.Integer(), nullable=True),
+        sa.Column('timezone', sa.Unicode(), nullable=True),
+        sa.Column('moddate', sa.Date(), nullable=True),
+        sa.Column('name', sa.Unicode(length=250), nullable=False),
+        sa.Column('title', sa.Unicode(length=250), nullable=False),
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column('updated_at', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ['admin1_id'],
+            ['geo_admin1_code.id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['admin2_id'],
+            ['geo_admin2_code.id'],
+        ),
+        sa.ForeignKeyConstraint(
+            ['country'],
+            ['geo_country_info.iso_alpha2'],
+        ),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('name'),
+    )
+    op.create_table(
+        'geo_alt_name',
+        sa.Column('geonameid', sa.Integer(), nullable=False),
+        sa.Column('lang', sa.Unicode(), nullable=True),
+        sa.Column('title', sa.Unicode(), nullable=False),
+        sa.Column('is_preferred_name', sa.Boolean(), nullable=False),
+        sa.Column('is_short_name', sa.Boolean(), nullable=False),
+        sa.Column('is_colloquial', sa.Boolean(), nullable=False),
+        sa.Column('is_historic', sa.Boolean(), nullable=False),
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column('updated_at', sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ['geonameid'],
+            ['geo_name.id'],
+        ),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index(
+        op.f('ix_geo_alt_name_lang'), 'geo_alt_name', ['lang'], unique=False
+    )
+
+    op.execute(
+        sa.DDL(
+            'CREATE INDEX ix_geo_country_info_title ON geo_country_info'
+            ' (lower(title) varchar_pattern_ops);'
+        )
+    )
+    op.execute(
+        sa.DDL(
+            'CREATE INDEX ix_geo_name_title ON geo_name'
+            ' (lower(title) varchar_pattern_ops);'
+        )
+    )
+    op.execute(
+        sa.DDL(
+            'CREATE INDEX ix_geo_name_ascii_title ON geo_name'
+            ' (lower(ascii_title) varchar_pattern_ops);'
+        )
+    )
+
+    op.execute(
+        sa.DDL(
+            'CREATE INDEX ix_geo_alt_name_title ON geo_alt_name'
+            ' (lower(title) varchar_pattern_ops);'
+        )
+    )
+
+
+def downgrade_geoname():
+    op.drop_index(op.f('ix_geo_alt_name_title'), table_name='geo_alt_name')
+    op.drop_index(op.f('ix_geo_name_ascii_title'), table_name='geo_name')
+    op.drop_index(op.f('ix_geo_name_title'), table_name='geo_name')
+    op.drop_index(op.f('ix_geo_country_info_title'), table_name='geo_country_info')
+    op.drop_index(op.f('ix_geo_alt_name_lang'), table_name='geo_alt_name')
+    op.drop_table('geo_alt_name')
+    op.drop_table('geo_name')
+    op.drop_table('geo_admin2_code')
+    op.drop_table('geo_admin1_code')
+    op.drop_table('geo_country_info')


### PR DESCRIPTION
This PR deprecates [Hascore](https://github.com/hasgeek/hascore) by moving the geoname models and views here. The `tag_locations` job now reads from the model instead of calling Hascore.

The geoname models are linked to a separate database using SQLAlchemy binds. This requires some changes to an existing dev setup:

1. Add a second database to settings. It should not look like this:

```python
SQLALCHEMY_DATABASE_URI = 'postgresql:///funnel'
SQLALCHEMY_BINDS = {
    'geoname': 'postgresql:///geoname',
}
```

2. Create the database and grant access rights as needed. Assuming the main database is on the latest revision, stamp the new database with the same revision number, then upgrade to the latest revision:

```bash
$ createdb geoname
$ flask db stamp 896137ace892
$ flask db upgrade
```

This should upgrade to database revision `7d5b77aada1e`.

3. The geoname models store data from geonames.org. Download and import these:

```bash
$ flask geoname download
$ flask geoname process
```

The processing step will take about 2 hours to import everything. This can be left running in a background tab. The rest of the app is ready to use with `runserver.sh`