### PR TITLE
Fix and test SMS unsubscribe view with new form submit wrapper

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,21 +51,22 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
-          - sqlalchemy-stubs
-          - types-certifi
-          - types-cryptography
-          - types-Flask
-          - types-geoip2
-          - types-itsdangerous
-          - types-maxminddb
-          - types-python-dateutil
-          - types-pytz
-          - types-requests
-          - types-setuptools
-          - types-simplejson
-          - types-six
-          - types-toml
-          - types-Werkzeug
+          - lxml-stubs==0.2.0
+          - sqlalchemy-stubs==0.4
+          - types-certifi==0.1.4
+          - types-cryptography==3.3.3
+          - types-Flask==1.1.1
+          - types-geoip2==0.1.2
+          - types-itsdangerous==1.1.2
+          - types-maxminddb==0.1.2
+          - types-python-dateutil==0.1.4
+          - types-pytz==2021.1.0
+          - types-requests==2.25.0
+          - types-setuptools==57.0.0
+          - types-simplejson==0.1.4
+          - types-six==0.1.7
+          - types-toml==0.1.3
+          - types-Werkzeug==1.0.2
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -10,6 +10,7 @@ flake8-logging-format==0.6.0
 flake8-mutable==1.2.0
 flake8-print==4.0.0
 isort==5.8.0
+lxml-stubs==0.2.0
 mypy==0.910
 pep8-naming==0.11.1
 pre-commit==2.13.0
@@ -17,12 +18,17 @@ pyupgrade==2.19.4
 sqlalchemy-stubs==0.4
 toml==0.10.2
 types-certifi==0.1.4
+types-cryptography==3.3.3
+types-Flask==1.1.1
 types-geoip2==0.1.2
 types-itsdangerous==1.1.2
 types-maxminddb==0.1.2
 types-python-dateutil==0.1.4
 types-pytz==2021.1.0
 types-requests==2.25.0
+types-setuptools==57.0.0
 types-simplejson==0.1.4
+types-six==0.1.7
 types-toml==0.1.3
+types-Werkzeug==1.0.2
 watchdog==2.1.2

--- a/funnel/views/notification.py
+++ b/funnel/views/notification.py
@@ -178,7 +178,7 @@ class RenderNotification:
         if unsubscribe_domain:
             # For this to work, a web server must listen on the unsubscribe domain and
             # redirect all paths to url_for('notification_unsubscribe_short') + path
-            return 'https://' + unsubscribe_domain + '/' + token
+            return f'https://{unsubscribe_domain}/{token}'
         return url_for('notification_unsubscribe_short', token=token, _external=True)
 
     @cached_property

--- a/instance/testing.py
+++ b/instance/testing.py
@@ -1,7 +1,7 @@
 from os import environ
 
 TESTING = True
-CACHE_TYPE = 'null'
+CACHE_TYPE = 'SimpleCache'
 SECRET_KEYS = ['testkey']  # nosec
 LASTUSER_SECRET_KEYS = ['testkey']  # nosec
 SITE_TITLE = 'Hasgeek'
@@ -16,12 +16,12 @@ STATIC_SUBDOMAIN = 'static'
 LASTUSER_COOKIE_DOMAIN = '.funnel.travis.local:3002'
 UPLOAD_FOLDER = '/tmp'  # nosec  # noqa: S108
 TIMEZONE = 'Asia/Kolkata'
-ASSET_BASE_PATH = "build"
 GOOGLE_MAPS_API_KEY = environ.get('GOOGLE_MAPS_API_KEY')
 BOXOFFICE_SERVER = 'https://boxoffice.hasgeek.com/api/1/'
 
-ASSET_MANIFEST_PATH = "static/build/manifest.json"
-ASSET_BASE_PATH = "build"
+ASSET_MANIFEST_PATH = 'static/build/manifest.json'
+ASSET_BASE_PATH = 'build'
+UNSUBSCRIBE_DOMAIN = 'bye.test'
 #: Recaptcha for the registration form
 RECAPTCHA_USE_SSL = True
 RECAPTCHA_PUBLIC_KEY = environ.get('RECAPTCHA_PUBLIC_KEY')

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,6 +1,7 @@
 coverage==5.5
 coveralls==3.1.0
 fakeredis==1.5.1
+lxml==4.6.3
 pytest==6.2.4
 pytest-bdd==4.0.2
 pytest-cov==2.12.0

--- a/tests/unit/views/test_notification.py
+++ b/tests/unit/views/test_notification.py
@@ -1,0 +1,134 @@
+from urllib.parse import urlsplit
+
+from flask import url_for
+
+import pytest
+
+from funnel.models import (
+    NewUpdateNotification,
+    Notification,
+    NotificationPreferences,
+    Update,
+)
+
+
+@pytest.fixture
+def phone_vetinari(db_session, user_vetinari):
+    """Add a phone number to user_vetinari."""
+    userphone = user_vetinari.add_phone('+12345678900')
+    db_session.add(userphone)
+    db_session.commit()
+    return userphone
+
+
+@pytest.fixture
+def notification_prefs_vetinari(db_session, user_vetinari):
+    prefs = NotificationPreferences(
+        user=user_vetinari,
+        notification_type='',
+        by_email=True,
+        by_sms=True,
+        by_webpush=True,
+        by_telegram=True,
+        by_whatsapp=True,
+    )
+    db_session.add(prefs)
+    db_session.commit()
+    return prefs
+
+
+@pytest.fixture
+def project_update(db_session, user_vetinari, project_expo2010):
+    """Create an update to add a notification for."""
+    db_session.commit()
+    update = Update(
+        project=project_expo2010,
+        user=user_vetinari,
+        title="New update",
+        body="New update body",
+    )
+    db_session.add(update)
+    db_session.commit()
+    update.publish(user_vetinari)
+    db_session.commit()
+    return update
+
+
+@pytest.fixture
+def update_user_notification(db_session, user_vetinari, project_update):
+    """Get a user notification for the update fixture."""
+    notification = NewUpdateNotification(project_update)
+    db_session.add(notification)
+    db_session.commit()
+
+    # Extract all the user notifications
+    all_user_notifications = list(notification.dispatch())
+    db_session.commit()
+    # There should be only one, assigned to Vetinari, but we'll let the test confirm
+    return all_user_notifications[0]
+
+
+def test_user_notification_is_for_user_vetinari(
+    update_user_notification, user_vetinari
+):
+    """Confirm the test notification is for the test user fixture."""
+    assert update_user_notification.user == user_vetinari
+
+
+@pytest.fixture
+def notification_view(update_user_notification):
+    """Get the notification view renderer."""
+    return Notification.renderers[update_user_notification.notification.type](
+        update_user_notification
+    )
+
+
+@pytest.fixture
+def unsubscribe_sms_short_url(
+    notification_view, phone_vetinari, notification_prefs_vetinari
+):
+    """Get an unsubscribe URL for the SMS notification."""
+    return notification_view.unsubscribe_short_url('sms')
+
+
+def test_unsubscribe_view_is_well_formatted(unsubscribe_sms_short_url, user_vetinari):
+    """Confirm the SMS unsubscribe URL is well formatted."""
+    prefix = 'https://bye.test/'
+    assert unsubscribe_sms_short_url.startswith(prefix)
+    assert len(unsubscribe_sms_short_url) == len(prefix) + 4  # 4 char random value
+
+
+def test_unsubscribe_sms_view(client, unsubscribe_sms_short_url, user_vetinari):
+    """Confirm the unsubscribe URL renders a form."""
+    unsub_url = url_for(
+        'notification_unsubscribe_short',
+        token=urlsplit(unsubscribe_sms_short_url).path[1:],
+        _external=True,
+    )
+
+    # Get the unsubscribe URL. This should cause a cookie to be set, with a
+    # redirect to the same URL and `?cookietest=1` appended
+    rv = client.get(unsub_url)
+    assert rv.status_code == 302
+    assert rv.location.startswith(unsub_url)
+    assert rv.location.endswith('cookietest=1')
+
+    # Follow the redirect. This will cause yet another redirect
+    rv = client.get(rv.location)
+    assert rv.status_code == 302
+    assert rv.location == url_for('notification_unsubscribe_do', _external=True)
+
+    # This time we'll get the unsubscribe form.
+    rv = client.get(rv.location)
+    assert rv.status_code == 200
+
+    # Assert the user has SMS notifications enabled, and the form agrees
+    assert user_vetinari.main_notification_preferences.by_sms is True
+    form = rv.form('form-unsubscribe-preferences')
+    assert form.fields['main'] == 'y'
+    form.fields['main'] = False
+    rv = form.submit(client)
+    # We'll now get an acknowledgement
+    assert rv.status_code == 200
+    # And the user's preferences will be turned off
+    assert user_vetinari.main_notification_preferences.by_sms is False

--- a/tests/unit/views/test_notification.py
+++ b/tests/unit/views/test_notification.py
@@ -23,6 +23,7 @@ def phone_vetinari(db_session, user_vetinari):
 
 @pytest.fixture
 def notification_prefs_vetinari(db_session, user_vetinari):
+    """Add main notification preferences for user_vetinari."""
     prefs = NotificationPreferences(
         user=user_vetinari,
         notification_type='',


### PR DESCRIPTION
The SMS unsubscribe view was broken by #1207 due to a mistaken assumption about datetimes. While the Flask 2.0 `session` object now stores tz-aware datetimes, Flask-Caching does not do this. Datetimes stored in Redis continue to be naive.

This PR fixes the bug and also introduces tests for the view, to confirm the SMS unsubscribe form is accessible and can be submitted successfully.

A new `ResponseWithForms` test helper class is introduced for the test client fixture, making it possible to test forms using the actually rendered HTML.