### PR TITLE
Change test hostname to funnel.test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - pip install idna --upgrade
   - make
 before_script:
-  - sudo -- sh -c "echo '127.0.0.1  funnel.travis.local' >> /etc/hosts"
+  - sudo -- sh -c "echo '127.0.0.1  funnel.test' >> /etc/hosts"
   - psql -c 'create database funnel_testing;' -U postgres
   - 'flask dbconfig | sudo -u postgres psql funnel_testing'
   - psql -c 'create database geoname_testing;' -U postgres

--- a/funnel/assets/cypress.json
+++ b/funnel/assets/cypress.json
@@ -1,7 +1,7 @@
 {
   "projectId": "1kvcow",
   "chromeWebSecurity": false,
-  "baseUrl": "http://funnel.travis.local:3002",
+  "baseUrl": "http://funnel.test:3002",
   "pageLoadTimeout": 150000,
   "video": false
 }

--- a/instance/testing.py
+++ b/instance/testing.py
@@ -9,11 +9,11 @@ SQLALCHEMY_DATABASE_URI = 'postgresql:///funnel_testing'
 SQLALCHEMY_BINDS = {
     'geoname': 'postgresql:///geoname_testing',
 }
-SERVER_NAME = 'funnel.travis.local:3002'
-SHORTLINK_DOMAIN = 'funnel.travis.local:3002'
-DEFAULT_DOMAIN = 'funnel.travis.local'
+SERVER_NAME = 'funnel.test:3002'
+SHORTLINK_DOMAIN = 'funnel.test:3002'
+DEFAULT_DOMAIN = 'funnel.test'
 STATIC_SUBDOMAIN = 'static'
-LASTUSER_COOKIE_DOMAIN = '.funnel.travis.local:3002'
+LASTUSER_COOKIE_DOMAIN = '.funnel.test:3002'
 UPLOAD_FOLDER = '/tmp'  # nosec  # noqa: S108
 TIMEZONE = 'Asia/Kolkata'
 GOOGLE_MAPS_API_KEY = environ.get('GOOGLE_MAPS_API_KEY')


### PR DESCRIPTION
The `.test` TLD is reserved for testing. This PR introduces `funnel.test` as a standard hostname, both for development and testing.