### PR TITLE
Add active/suspended states to Organization

### DIFF
--- a/funnel/models/profile.py
+++ b/funnel/models/profile.py
@@ -147,14 +147,21 @@ class Profile(UuidMixin, BaseMixin, db.Model):
             db.case(
                 [
                     (
-                        user_id.isnot(None),
+                        user_id.isnot(None),  # ← when, ↙ then
                         db.select(User.state.ACTIVE)  # type: ignore[has-type]
                         .where(User.id == user_id)
                         .correlate_except(User)
                         .scalar_subquery(),
-                    )
+                    ),
+                    (
+                        organization_id.isnot(None),  # ← when, ↙ then
+                        db.select(Organization.state.ACTIVE)  # type: ignore[has-type]
+                        .where(Organization.id == organization_id)
+                        .correlate_except(Organization)
+                        .scalar_subquery(),
+                    ),
                 ],
-                else_=expression.true(),  # TODO: Add suspended state to orgs
+                else_=expression.false(),
             )
         ),
         read={'all'},

--- a/funnel/models/utils.py
+++ b/funnel/models/utils.py
@@ -9,10 +9,10 @@ from flask import current_app
 from ..typing import OptionalMigratedTables
 from .user import User, UserEmail, UserEmailClaim, UserExternalId, db
 
-__all__ = ['getuser', 'getextid', 'merge_users', 'IncompleteUserMigration']
+__all__ = ['getuser', 'getextid', 'merge_users', 'IncompleteUserMigrationError']
 
 
-class IncompleteUserMigration(Exception):
+class IncompleteUserMigrationError(Exception):
     """Could not migrate users because of data conflicts."""
 
 
@@ -177,11 +177,11 @@ def do_migrate_instances(
                     if isinstance(result, (list, tuple, set)):
                         migrated_tables.update(result)
                     migrated_tables.add(model.__table__.name)
-                except IncompleteUserMigration:
+                except IncompleteUserMigrationError:
                     safe_to_remove_instance = False
                     current_app.logger.error(
-                        "_do_merge_into interrupted because IncompleteUserMigration"
-                        " raised by %s",
+                        "_do_merge_into interrupted because"
+                        "  IncompleteUserMigrationError raised by %s",
                         model,
                     )
             else:

--- a/funnel/views/mixins.py
+++ b/funnel/views/mixins.py
@@ -37,7 +37,7 @@ class ProfileCheckMixin:
         if profile is None:
             raise ValueError("Subclass must set self.profile")
         g.profile = profile
-        if profile.user is not None and not profile.user.state.ACTIVE:
+        if not profile.is_active:
             abort(410)
 
         return super().after_loader()

--- a/funnel/views/organization.py
+++ b/funnel/views/organization.py
@@ -66,6 +66,8 @@ class OrgView(UrlChangeCheck, UrlForView, ModelView):
             obj = Organization.get(name=organization)
             if obj is None:
                 abort(404)
+            if not obj.state.ACTIVE:
+                abort(410)
             return obj
         return None
 
@@ -88,6 +90,7 @@ class OrgView(UrlChangeCheck, UrlForView, ModelView):
             org = Organization(owner=current_auth.user)
             form.populate_obj(org)
             db.session.add(org)
+            db.session.flush()  # Required to auto-create profile
             org.profile.make_public()
             db.session.commit()
             org_data_changed.send(org, changes=['new'], user=current_auth.user)

--- a/migrations/versions/294362dc7e49_add_organization_state.py
+++ b/migrations/versions/294362dc7e49_add_organization_state.py
@@ -1,0 +1,64 @@
+"""Add organization state.
+
+Revision ID: 294362dc7e49
+Revises: 1c9cbf3a1e5e
+Create Date: 2021-08-10 18:04:27.259907
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '294362dc7e49'
+down_revision = '1c9cbf3a1e5e'
+branch_labels = None
+depends_on = None
+
+
+class ORGANIZATION_STATE:  # noqa: N801
+    """State codes for organizations."""
+
+    #: Regular, active organization
+    ACTIVE = 1
+    #: Suspended organization (cause and explanation not included here)
+    SUSPENDED = 2
+
+
+def upgrade(engine_name=''):
+    # Do not modify. Edit `upgrade_` instead
+    globals().get('upgrade_%s' % engine_name, lambda: None)()
+
+
+def downgrade(engine_name=''):
+    # Do not modify. Edit `downgrade_` instead
+    globals().get('downgrade_%s' % engine_name, lambda: None)()
+
+
+def upgrade_():
+    op.add_column(
+        'organization',
+        sa.Column(
+            'state',
+            sa.SmallInteger(),
+            nullable=False,
+            server_default=sa.text(str(ORGANIZATION_STATE.ACTIVE)),
+        ),
+    )
+    op.alter_column('organization', 'state', server_default=None)
+    op.create_check_constraint(
+        'organization_state_check', 'organization', 'state IN (1, 2)'
+    )
+
+
+def downgrade_():
+    op.drop_constraint('organization_state_check', 'organization', type_='check')
+    op.drop_column('organization', 'state')
+
+
+def upgrade_geoname():
+    pass
+
+
+def downgrade_geoname():
+    pass

--- a/tests/unit/models/test_user_Organization.py
+++ b/tests/unit/models/test_user_Organization.py
@@ -1,100 +1,105 @@
 import pytest
 
+from coaster.sqlalchemy.statemanager import StateTransitionError
 import funnel.models as models
 
-from .test_db import TestDatabaseFixture
+
+def test_organization_init(db_session, user_twoflower):
+    """Test for initializing a Organization instance."""
+    name = 'inn-sewer-ants'
+    title = 'Inn-sewer-ants-polly-sea'
+    org = models.Organization(name=name, title=title, owner=user_twoflower)
+    assert isinstance(org, models.Organization)
+    assert org.title == title
+    assert org.name == name
 
 
-class TestOrganization(TestDatabaseFixture):
-    def test_organization_init(self):
-        """Test for initializing a Organization instance."""
-        name = 'dachshunited'
-        title = 'Dachshunds United'
-        dachsunited = models.Organization(
-            name=name, title=title, owner=self.fixtures.crusoe
-        )
-        assert isinstance(dachsunited, models.Organization)
-        assert dachsunited.title == title
-        assert dachsunited.name == name
+def test_organization_get(db_session, user_twoflower):
+    """Test for retrieving an organization."""
+    name = 'inn-sewer-ants'
+    title = 'Inn-sewer-ants-polly-sea'
+    org = models.Organization(name=name, title=title, owner=user_twoflower)
+    db_session.add(org)
+    db_session.commit()
+    # scenario 1: when neither name or buid are passed
+    with pytest.raises(TypeError):
+        models.Organization.get()
+    # scenario 2: when buid is passed
+    buid = org.buid
+    get_by_buid = models.Organization.get(buid=buid)
+    assert get_by_buid == org
+    # scenario 3: when username is passed
+    get_by_name = models.Organization.get(name=name)
+    assert get_by_name == org
+    # scenario 4: when defercols is set to True
+    get_by_name_with_defercols = models.Organization.get(name=name, defercols=True)
+    get_by_name_with_defercols == org
 
-    def test_organization_get(self):
-        """Test for retrieving an organization."""
-        name = 'spew'
-        title = 'S.P.E.W'
-        spew = models.Organization(name=name, title=title, owner=self.fixtures.crusoe)
-        self.db_session.add(spew)
-        self.db_session.commit()
-        # scenario 1: when neither name or buid are passed
-        with pytest.raises(TypeError):
-            models.Organization.get()
-        # scenario 2: when buid is passed
-        buid = spew.buid
-        get_by_buid = models.Organization.get(buid=buid)
-        assert isinstance(get_by_buid, models.Organization)
-        assert title == get_by_buid.title
-        # scenario 3: when username is passed
-        get_by_name = models.Organization.get(name=name)
-        assert isinstance(get_by_name, models.Organization)
-        assert title == get_by_name.title
-        # scenario 4: when defercols is set to True
-        get_by_name_with_defercols = models.Organization.get(name=name, defercols=True)
-        assert isinstance(get_by_name_with_defercols, models.Organization)
-        assert title == get_by_name_with_defercols.title
 
-    def test_organization_all(self):
-        """Test for getting all organizations (takes buid or name optionally)."""
-        gryffindor = models.Organization(name='gryffindor', owner=self.fixtures.crusoe)
-        ravenclaw = models.Organization(name='ravenclaw', owner=self.fixtures.crusoe)
-        self.db_session.add(gryffindor)
-        self.db_session.add(ravenclaw)
-        self.db_session.commit()
-        # scenario 1: when neither buids nor names are given
-        assert models.Organization.all() == []
-        # scenario 2: when buids are passed
-        orglist = {gryffindor, ravenclaw}
-        all_by_buids = models.Organization.all(buids=[_org.buid for _org in orglist])
-        assert set(all_by_buids) == orglist
-        # scenario 3: when org names are passed
-        all_by_names = models.Organization.all(names=[_org.name for _org in orglist])
-        assert set(all_by_names) == orglist
-        # scenario 4: when defercols is set to True for names
-        all_by_names_with_defercols = models.Organization.all(
-            names=[_org.name for _org in orglist]
-        )
-        assert set(all_by_names_with_defercols) == orglist
-        # scenario 5: when defercols is set to True for buids
-        all_by_buids_with_defercols = models.Organization.all(
-            buids=[_org.buid for _org in orglist]
-        )
-        assert set(all_by_buids_with_defercols) == orglist
+def test_organization_all(db_session, org_ankhmorpork, org_citywatch, org_uu):
+    """Test for getting all organizations (takes buid or name optionally)."""
+    db_session.commit()
+    # scenario 1: when neither buids nor names are given
+    assert models.Organization.all() == []
+    # scenario 2: when buids are passed
+    orglist = {org_ankhmorpork, org_citywatch}
+    all_by_buids = models.Organization.all(buids=[_org.buid for _org in orglist])
+    assert set(all_by_buids) == orglist
+    # scenario 3: when org names are passed
+    all_by_names = models.Organization.all(names=[_org.name for _org in orglist])
+    assert set(all_by_names) == orglist
+    # scenario 4: when defercols is set to True for names
+    all_by_names_with_defercols = models.Organization.all(
+        names=[_org.name for _org in orglist]
+    )
+    assert set(all_by_names_with_defercols) == orglist
+    # scenario 5: when defercols is set to True for buids
+    all_by_buids_with_defercols = models.Organization.all(
+        buids=[_org.buid for _org in orglist]
+    )
+    assert set(all_by_buids_with_defercols) == orglist
 
-    def test_organization_pickername(self):
-        """Test for checking Organization's pickername."""
-        # scenario 1: when only title is given
-        abnegation = models.Organization(
-            title="Abnegation", name='abnegation', owner=self.fixtures.crusoe
-        )
-        assert isinstance(abnegation.pickername, str)
-        assert abnegation.pickername == f'{abnegation.title} (@{abnegation.name})'
 
-        # scenario 2: when both name and title are given
-        name = 'cullens'
-        title = 'The Cullens'
-        olympic_coven = models.Organization(title=title, owner=self.fixtures.crusoe)
-        olympic_coven.name = name
-        self.db_session.add(olympic_coven)
-        self.db_session.commit()
-        assert isinstance(olympic_coven.pickername, str)
-        assert f'{title} (@{name})' in olympic_coven.pickername
+def test_organization_pickername(db_session, org_uu):
+    """Test for checking Organization's pickername."""
+    assert isinstance(org_uu.pickername, str)
+    assert org_uu.pickername == f'{org_uu.title} (@{org_uu.name})'
 
-    def test_organization_name(self):
-        """Test for retrieving and setting an Organization's name."""
-        insurgent = models.Organization(title="Insurgent", owner=self.fixtures.crusoe)
-        with pytest.raises(ValueError):
-            insurgent.name = '35453496*%&^$%^'
-        with pytest.raises(ValueError):
-            insurgent.name = '-Insurgent'
-        insurgent.name = 'insurgent'
-        assert insurgent.name == 'insurgent'
-        insurgent.name = 'Insurgent'
-        assert insurgent.name == 'Insurgent'
+
+def test_organization_name(db_session, org_ankhmorpork):
+    """Test for retrieving and setting an Organization's name."""
+    with pytest.raises(ValueError):
+        org_ankhmorpork.name = '35453496*%&^$%^'
+    with pytest.raises(ValueError):
+        org_ankhmorpork.name = '-Insurgent'
+    org_ankhmorpork.name = 'anky'
+    assert org_ankhmorpork.name == 'anky'
+    org_ankhmorpork.name = 'AnkhMorpork'
+    assert org_ankhmorpork.name == 'AnkhMorpork'
+
+
+def test_organization_suspend_restore(db_session, org_citywatch):
+    """Test for an organization being suspended and restored."""
+    db_session.commit()
+    assert org_citywatch.state.ACTIVE
+    assert not org_citywatch.state.SUSPENDED
+    assert org_citywatch.profile.is_active
+
+    org_citywatch.mark_suspended()
+    db_session.commit()
+    assert not org_citywatch.state.ACTIVE
+    assert org_citywatch.state.SUSPENDED
+    assert not org_citywatch.profile.is_active
+
+    org_citywatch.mark_active()
+    db_session.commit()
+    assert org_citywatch.state.ACTIVE
+    assert not org_citywatch.state.SUSPENDED
+    assert org_citywatch.profile.is_active
+
+    with pytest.raises(StateTransitionError):
+        org_citywatch.mark_active()
+
+    org_citywatch.mark_suspended()
+    with pytest.raises(StateTransitionError):
+        org_citywatch.mark_suspended()


### PR DESCRIPTION
This is required for spam control, to take down spam organizations without permanently deleting data, allowing for an appeal process.