### PR TITLE
Add version numbers to vCal events

### DIFF
--- a/funnel/models/project.py
+++ b/funnel/models/project.py
@@ -681,8 +681,10 @@ class Project(UuidMixin, BaseScopedNameMixin, db.Model):
     def fetch_sorted(cls):
         return cls.query.filter(cls.state.PUBLISHED).order_by(cls.order_by_date())
 
+    # The base class offers `get(parent, name)`. We accept f'{parent}/{name}' here for
+    # convenience as this is only used in shell access.
     @classmethod
-    def get(cls, profile_project):
+    def get(cls, profile_project):  # skipcq: PYL-W0221
         """Get a project by its URL slug in the form ``<profile>/<project>``."""
         profile_name, project_name = profile_project.split('/')
         return (
@@ -871,5 +873,5 @@ class __Commentset:
 
 
 # Tail imports
-from .project_membership import ProjectCrewMembership  # isort:skip
-from .venue import Venue  # isort:skip
+from .project_membership import ProjectCrewMembership  # isort:skip  # skipcq: FLK-E402
+from .venue import Venue  # isort:skip  # skipcq: FLK-E402

--- a/funnel/models/project.py
+++ b/funnel/models/project.py
@@ -222,6 +222,9 @@ class Project(UuidMixin, BaseScopedNameMixin, db.Model):
         datasets={'primary', 'without_parent'},
     )
 
+    #: Version number maintained by SQLAlchemy, used for vCal files, starting at 1
+    versionid = db.Column(db.Integer, nullable=False)
+
     search_vector = db.deferred(
         db.Column(
             TSVectorType(
@@ -279,6 +282,8 @@ class Project(UuidMixin, BaseScopedNameMixin, db.Model):
             'project_cfp_start_at_cfp_end_at_check',
         ),
     )
+
+    __mapper_args__ = {'version_id_col': versionid}
 
     __roles__ = {
         'all': {

--- a/funnel/models/session.py
+++ b/funnel/models/session.py
@@ -273,8 +273,8 @@ TypeProject = Type[Project]
 
 @reopen(Project)
 class __Project:
-    # Project schedule column expressions
-    # Guide: https://docs.sqlalchemy.org/en/13/orm/mapped_sql_expr.html#using-column-property
+    # Project schedule column expressions. Guide:
+    # https://docs.sqlalchemy.org/en/13/orm/mapped_sql_expr.html#using-column-property
     schedule_start_at = with_roles(
         db.column_property(
             db.select([db.func.min(Session.start_at)])
@@ -566,15 +566,20 @@ class __Project:
         }
 
         # FIXME: This doesn't work. This code needs to be tested in isolation
-        # session_dates = db.session.query(
-        #     db.cast(
-        #         db.func.date_trunc('day', db.func.timezone(self.timezone.zone, Session.start_at)),
-        #         db.Date).label('date'),
-        #     db.func.count().label('count')
-        #     ).filter(
-        #         Session.project == self,
-        #         Session.scheduled
-        #         ).group_by(db.text('date')).order_by(db.text('date'))
+        # session_dates = (
+        #     db.session.query(
+        #         db.cast(
+        #             db.func.date_trunc(
+        #                 'day', db.func.timezone(self.timezone.zone, Session.start_at)
+        #             ),
+        #             db.Date,
+        #         ).label('date'),
+        #         db.func.count().label('count'),
+        #     )
+        #     .filter(Session.project == self, Session.scheduled)
+        #     .group_by(db.text('date'))
+        #     .order_by(db.text('date'))
+        # )
 
         # if the project's week is within next 2 weeks, send current week as well
         now = utcnow().astimezone(self.timezone)
@@ -621,8 +626,9 @@ class __Project:
         weeks_list = [v for k, v in sorted(weeks.items())]
 
         for week in weeks_list:
-            # Convering to JSON messes up dictionary key order even though we used OrderedDict.
-            # This turns the OrderedDict into a list of tuples and JSON preserves that order.
+            # Convering to JSON messes up dictionary key order even though we used
+            # OrderedDict. This turns the OrderedDict into a list of tuples and JSON
+            # preserves that order.
             week['dates'] = [
                 {
                     'isoformat': date.isoformat(),

--- a/funnel/models/session.py
+++ b/funnel/models/session.py
@@ -67,6 +67,9 @@ class Session(UuidMixin, BaseScopedIdNameMixin, VideoMixin, db.Model):
     featured = db.Column(db.Boolean, default=False, nullable=False)
     banner_image_url = db.Column(ImgeeType, nullable=True)
 
+    #: Version number maintained by SQLAlchemy, used for vCal files, starting at 1
+    versionid = db.Column(db.Integer, nullable=False)
+
     search_vector = db.deferred(
         db.Column(
             TSVectorType(
@@ -106,6 +109,8 @@ class Session(UuidMixin, BaseScopedIdNameMixin, VideoMixin, db.Model):
         ),
         db.Index('ix_session_search_vector', 'search_vector', postgresql_using='gin'),
     )
+
+    __mapper_args__ = {'version_id_col': versionid}
 
     __roles__ = {
         'all': {

--- a/funnel/views/schedule.py
+++ b/funnel/views/schedule.py
@@ -159,6 +159,7 @@ def project_as_session(project: Project) -> SimpleNamespace:
         end_at_localized=project.end_at_localized,
         location=f'{project.location} - {project.url_for(_external=True)}',
         venue_room=None,
+        versionid=project.versionid,
         proposal=SimpleNamespace(labels=()),  # Proposal is used to get a permalink
         url_for=project.url_for,
     )
@@ -216,6 +217,7 @@ def session_ical(session: Session, rsvp: Optional[Rsvp] = None) -> Event:
         desc = _("{session} in 5 minutes").format(session=session.title)
     alarm.add('description', desc)
     event.add_component(alarm)
+    event.add('sequence', session.versionid - 1)  # vCal starts at 0, SQLAlchemy at 1
     return event
 
 

--- a/migrations/versions/0fae06340346_add_version_numbers_for_timestamped_.py
+++ b/migrations/versions/0fae06340346_add_version_numbers_for_timestamped_.py
@@ -1,0 +1,56 @@
+"""Add version numbers for timestamped models.
+
+Revision ID: 0fae06340346
+Revises: 277ba2ca9e3e
+Create Date: 2022-01-06 16:11:26.035319
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '0fae06340346'
+down_revision = '277ba2ca9e3e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade(engine_name=''):
+    # Do not modify. Edit `upgrade_` instead
+    globals().get('upgrade_%s' % engine_name, lambda: None)()
+
+
+def downgrade(engine_name=''):
+    # Do not modify. Edit `downgrade_` instead
+    globals().get('downgrade_%s' % engine_name, lambda: None)()
+
+
+def upgrade_():
+    op.add_column(
+        'project',
+        sa.Column(
+            'versionid', sa.Integer(), nullable=False, server_default=sa.text('1')
+        ),
+    )
+    op.add_column(
+        'session',
+        sa.Column(
+            'versionid', sa.Integer(), nullable=False, server_default=sa.text('1')
+        ),
+    )
+    op.alter_column('project', 'versionid', server_default=None)
+    op.alter_column('session', 'versionid', server_default=None)
+
+
+def downgrade_():
+    op.drop_column('session', 'versionid')
+    op.drop_column('project', 'versionid')
+
+
+def upgrade_geoname():
+    pass
+
+
+def downgrade_geoname():
+    pass


### PR DESCRIPTION
vCal events have a `SEQUENCE` property that is supposed to be incremented when an event's data changes. This is required for calendar subscriptions to notice the change and sync it. This PR introduces a `versionid` column in `Project` and `Session`, managed by SQLAlchemy, and published to the vCal feed.

vCal starts numbering from 0 while SQLAlchemy starts from 1.

As a side effect, this will block parallel edits to Project and Session instances as SQLAlchemy checks for out-of-order versions when committing. This may have an impact on performance depending on how the check is performed, and will create a new source for unhandled errors. (The form nonce mechanism is meant to mitigate this before a database commit, but its effectiveness is unclear.)