### PR TITLE
Use dataclass instead of namedtuple

### DIFF
--- a/funnel/cli/geodata.py
+++ b/funnel/cli/geodata.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections import namedtuple
+from dataclasses import dataclass
 from datetime import datetime
 from decimal import Decimal
 from typing import Optional
@@ -35,75 +35,70 @@ csv.field_size_limit(sys.maxsize)
 geo = AppGroup('geoname', help="Process geoname data.")
 
 
-CountryInfoRecord = namedtuple(
-    'CountryInfoRecord',
-    [
-        'iso_alpha2',
-        'iso_alpha3',
-        'iso_numeric',
-        'fips_code',
-        'title',
-        'capital',
-        'area_in_sqkm',
-        'population',
-        'continent',
-        'tld',
-        'currency_code',
-        'currency_name',
-        'phone',
-        'postal_code_format',
-        'postal_code_regex',
-        'languages',
-        'geonameid',
-        'neighbours',
-        'equivalent_fips_code',
-    ],
-)
+@dataclass
+class CountryInfoRecord:
+    iso_alpha2: str
+    iso_alpha3: str
+    iso_numeric: str
+    fips_code: str
+    title: str
+    capital: str
+    area_in_sqkm: str
+    population: str
+    continent: str
+    tld: str
+    currency_code: str
+    currency_name: str
+    phone: str
+    postal_code_format: str
+    postal_code_regex: str
+    languages: str
+    geonameid: str
+    neighbours: str
+    equivalent_fips_code: str
 
 
-GeoNameRecord = namedtuple(
-    'GeoNameRecord',
-    [
-        'geonameid',
-        'title',
-        'ascii_title',
-        'alternatenames',
-        'latitude',
-        'longitude',
-        'fclass',
-        'fcode',
-        'country_id',
-        'cc2',
-        'admin1',
-        'admin2',
-        'admin3',
-        'admin4',
-        'population',
-        'elevation',
-        'dem',
-        'timezone',
-        'moddate',
-    ],
-)
+@dataclass
+class GeoNameRecord:
+    geonameid: str
+    title: str
+    ascii_title: str
+    alternatenames: str
+    latitude: str
+    longitude: str
+    fclass: str
+    fcode: str
+    country_id: str
+    cc2: str
+    admin1: str
+    admin2: str
+    admin3: str
+    admin4: str
+    population: str
+    elevation: str
+    dem: str
+    timezone: str
+    moddate: str
 
 
-GeoAdminRecord = namedtuple(
-    'GeoAdminRecord', ['code', 'title', 'ascii_title', 'geonameid']
-)
+@dataclass
+class GeoAdminRecord:
+    code: str
+    title: str
+    ascii_title: str
+    geonameid: str
 
-GeoAltNameRecord = namedtuple(
-    'GeoAltNameRecord',
-    [
-        'id',
-        'geonameid',
-        'lang',
-        'title',
-        'is_preferred_name',
-        'is_short_name',
-        'is_colloquial',
-        'is_historic',
-    ],
-)
+
+@dataclass
+class GeoAltNameRecord:
+    id: str  # noqa: A003
+    geonameid: str
+    lang: str
+    title: str
+    is_preferred_name: str
+    is_short_name: str
+    is_colloquial: str
+    is_historic: str
 
 
 def get_progressbar():

--- a/funnel/cli/periodic.py
+++ b/funnel/cli/periodic.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from collections import namedtuple
+from dataclasses import dataclass
 from datetime import timedelta
+from typing import Any
 import sys
 
 from flask.cli import AppGroup
@@ -18,7 +19,13 @@ from ..views.notification import dispatch_notification
 
 # --- Data sources ---------------------------------------------------------------------
 
-DataSource = namedtuple('DataSource', ['basequery', 'datecolumn'])
+
+@dataclass
+class DataSource:
+    """Source for data (query object and datetime column)."""
+
+    basequery: Any
+    datecolumn: Any
 
 
 def data_sources():

--- a/funnel/forms/notification.py
+++ b/funnel/forms/notification.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from collections import namedtuple
+from dataclasses import dataclass
+from typing import Callable, Optional
 
 from flask import Markup, url_for
 
@@ -16,21 +17,23 @@ __all__ = [
     'SetNotificationPreferenceForm',
 ]
 
-TransportLabels = namedtuple(
-    'TransportLabels',
-    [
-        'title',
-        'requirement',
-        'requirement_action',
-        'unsubscribe_form',
-        'unsubscribe_description',
-        'switch',
-        'enabled_main',
-        'enabled',
-        'disabled_main',
-        'disabled',
-    ],
-)
+
+@dataclass
+class TransportLabels:
+    """UI labels for a supported transport."""
+
+    title: str
+    requirement: str
+    requirement_action: Callable[[], Optional[str]]
+    unsubscribe_form: str
+    unsubscribe_description: str
+    switch: str
+    enabled_main: str
+    enabled: str
+    disabled_main: str
+    disabled: str
+
+
 transport_labels = {
     'email': TransportLabels(
         title=__("Email"),

--- a/funnel/models/contact_exchange.py
+++ b/funnel/models/contact_exchange.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
-from collections import namedtuple
+from dataclasses import dataclass
+from datetime import datetime
 from itertools import groupby
-from typing import Iterable, Optional, Set
+from typing import Collection, Iterable, Optional, Set
+from uuid import UUID
 
 from sqlalchemy.ext.associationproxy import association_proxy
 
@@ -17,9 +19,25 @@ from .user import User
 __all__ = ['ContactExchange']
 
 
-# Named tuples for returning contacts grouped by project and date
-ProjectId = namedtuple('ProjectId', ['id', 'uuid', 'uuid_b58', 'title', 'timezone'])
-DateCountContacts = namedtuple('DateCountContacts', ['date', 'count', 'contacts'])
+# Data classes for returning contacts grouped by project and date
+@dataclass
+class ProjectId:
+    """Holder for minimal :class:`~funnel.models.project.Project` information."""
+
+    id: int  # noqa: A003
+    uuid: UUID
+    uuid_b58: str
+    title: str
+    timezone: str
+
+
+@dataclass
+class DateCountContacts:
+    """Contacts per date of a Project's schedule."""
+
+    date: datetime
+    count: int
+    contacts: Collection[ContactExchange]
 
 
 class ContactExchange(TimestampMixin, RoleMixin, db.Model):

--- a/funnel/models/notification.py
+++ b/funnel/models/notification.py
@@ -74,12 +74,12 @@ is supported using an unusual primary and foreign key structure the in
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import (
     Callable,
     Dict,
     Generator,
-    NamedTuple,
     Optional,
     Sequence,
     Set,
@@ -133,7 +133,10 @@ notification_type_registry: Dict[str, Notification] = {}
 notification_web_types: Set[Notification] = set()
 
 
-class NotificationCategory(NamedTuple):
+@dataclass
+class NotificationCategory:
+    """Category for a notification."""
+
     priority_id: int
     title: str
     available_for: Callable[[User], bool]

--- a/funnel/registry.py
+++ b/funnel/registry.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from collections import OrderedDict
+from dataclasses import dataclass
 from functools import wraps
-from typing import List, NamedTuple, Optional, Tuple
+from typing import Collection, List, Optional, Tuple
 import re
 
 from flask import Response, abort, jsonify, request
@@ -136,7 +137,8 @@ class ResourceRegistry(OrderedDict):
         return wrapper
 
 
-class LoginProviderData(NamedTuple):
+@dataclass
+class LoginProviderData:
     """User data supplied by a LoginProvider."""
 
     userid: str
@@ -148,7 +150,7 @@ class LoginProviderData(NamedTuple):
     oauth_refresh_token: Optional[str] = None
     oauth_refresh_expiry: Optional[str] = None
     email: Optional[str] = None
-    emails: List[str] = []
+    emails: Collection[str] = ()
     emailclaim: Optional[str] = None
     phone: Optional[str] = None
     phoneclaim: Optional[str] = None

--- a/funnel/transports/email/send.py
+++ b/funnel/transports/email/send.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from email.utils import formataddr, getaddresses, parseaddr
-from typing import Dict, List, NamedTuple, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from flask import current_app
 from flask_mailman import EmailMultiAlternatives
@@ -30,7 +31,8 @@ __all__ = [
 EmailRecipient = Union[User, Tuple[Optional[str], str], str]
 
 
-class EmailAttachment(NamedTuple):
+@dataclass
+class EmailAttachment:
     """An email attachment. Must have content, filename and mimetype."""
 
     content: str

--- a/funnel/views/helpers.py
+++ b/funnel/views/helpers.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from base64 import urlsafe_b64encode
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from hashlib import blake2b
 from os import urandom
-from typing import Any, Callable, Dict, NamedTuple, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 from urllib.parse import unquote, urljoin, urlsplit
 import gzip
 import zlib
@@ -104,7 +105,8 @@ class SessionTimeouts(dict):
 session_timeouts: Dict[str, timedelta] = SessionTimeouts()
 
 
-class OtpData(NamedTuple):
+@dataclass
+class OtpData:
     """Data in an OTP request."""
 
     reason: str

--- a/funnel/views/index.py
+++ b/funnel/views/index.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import NamedTuple
+from dataclasses import dataclass
 import os.path
 
 from flask import Response, g, jsonify, render_template, url_for
@@ -15,7 +15,8 @@ from ..forms import SavedProjectForm
 from ..models import Project, db
 
 
-class PolicyPage(NamedTuple):
+@dataclass
+class PolicyPage:
     path: str
     title: str
 

--- a/funnel/views/notifications/organization_membership_notification.py
+++ b/funnel/views/notifications/organization_membership_notification.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import List, NamedTuple, Optional, cast
+from dataclasses import dataclass
+from typing import Collection, Optional, cast
 
 from flask import Markup, escape, render_template
 
@@ -20,12 +21,13 @@ from ...transports.sms import MessageTemplate
 from ..notification import RenderNotification
 
 
-class DecisionFactor(NamedTuple):
+@dataclass
+class DecisionFactor:
     """Evaluation criteria for the content of notification (for grants/edits only)."""
 
     template: str
     is_subject: bool = False
-    rtypes: List[str] = []
+    rtypes: Collection[str] = ()
     is_owner: Optional[bool] = None
     is_actor: Optional[bool] = None
 

--- a/funnel/views/project.py
+++ b/funnel/views/project.py
@@ -1,4 +1,4 @@
-from collections import namedtuple
+from dataclasses import dataclass
 from types import SimpleNamespace
 import csv
 import io
@@ -59,14 +59,19 @@ from .login_session import requires_login, requires_site_editor
 from .mixins import DraftViewMixin, ProfileViewMixin, ProjectViewMixin
 from .notification import dispatch_notification
 
-CountWords = namedtuple(
-    'CountWords', ['unregistered', 'registered', 'not_following', 'following']
-)
+
+@dataclass
+class CountWords:
+    """Labels for a count of registrations."""
+
+    unregistered: str
+    registered: str
+    not_following: str
+    following: str
+
 
 registration_count_messages = [
-    CountWords(
-        __("Be the first to register!"), None, __("Be the first follower!"), None
-    ),
+    CountWords(__("Be the first to register!"), '', __("Be the first follower!"), ''),
     CountWords(
         __("One registration so far"),
         __("You have registered"),

--- a/funnel/views/siteadmin.py
+++ b/funnel/views/siteadmin.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections import Counter, namedtuple
+from collections import Counter
 from dataclasses import dataclass, field
 from datetime import timedelta
 from functools import wraps
@@ -54,6 +54,12 @@ class AuthClientUserReport:
     title: str
     website: str
     counts: Dict[str, int] = field(default_factory=counts_template.copy)
+
+
+@dataclass
+class ReportCounter:
+    report_type: int
+    frequency: int
 
 
 def requires_siteadmin(f):
@@ -339,8 +345,6 @@ class SiteadminView(ClassView):
                 + [report_form.report_type.data]
             )
             # if there is already a report for this comment
-            ReportCounter = namedtuple('ReportCounter', ['report_type', 'frequency'])
-
             most_common_two = [
                 ReportCounter(report_type, frequency)
                 for report_type, frequency in report_counter.most_common(2)

--- a/funnel/views/sitemap.py
+++ b/funnel/views/sitemap.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import NamedTuple, Optional, Tuple, Union
+from typing import Optional, Tuple, Union
 
 from flask import abort, render_template, url_for
 
@@ -36,12 +37,14 @@ class ChangeFreq(str, Enum):
         return self.value
 
 
-class SitemapIndex(NamedTuple):
+@dataclass
+class SitemapIndex:
     loc: str
     lastmod: Optional[datetime] = None
 
 
-class SitemapPage(NamedTuple):
+@dataclass
+class SitemapPage:
     loc: str
     lastmod: Optional[datetime] = None
     changefreq: Optional[ChangeFreq] = None


### PR DESCRIPTION
Python 3.7's dataclass system is generally better performing than NamedTuple and avoids the side-effect of tuple access. This PR migrates all uses of `namedtuple` and `NamedTuple` with the exception of the `UserAndAnchor` class in `models/utils.py`, where tuple access is beneficial. No other changes are included.