### PR TITLE
Update decorator typing

### DIFF
--- a/funnel/executor.py
+++ b/funnel/executor.py
@@ -1,14 +1,17 @@
+"""Wrapper for Flask-Executor that manages database sessions."""
+
+from __future__ import annotations
+
 from functools import wraps
-from typing import Any, Callable, TypeVar, cast
+from typing import cast
 
 from flask_executor import Executor
 from flask_executor.executor import ExecutorJob, FutureProxy
 
-# https://mypy.readthedocs.io/en/stable/generics.html#declaring-decorators
-F = TypeVar('F', bound=Callable[..., Any])
+from .typing import WrappedFunc
 
 
-def remove_db_session(f: F) -> F:
+def remove_db_session(f: WrappedFunc) -> WrappedFunc:
     """
     Remove the database session after calling the wrapped function.
 
@@ -30,7 +33,7 @@ def remove_db_session(f: F) -> F:
             db.session.remove()
         return result
 
-    return cast(F, wrapper)
+    return cast(WrappedFunc, wrapper)
 
 
 class ExecutorWrapper:
@@ -48,20 +51,22 @@ class ExecutorWrapper:
         """Initialize executor with an app."""
         return self.executor.init_app(app)
 
-    def submit(self, fn: F, *args, **kwargs) -> FutureProxy:
+    def submit(self, fn: WrappedFunc, *args, **kwargs) -> FutureProxy:
         """Submit a parallel task."""
         return self.executor.submit(remove_db_session(fn), *args, **kwargs)
 
-    def submit_stored(self, future_key, fn: F, *args, **kwargs) -> FutureProxy:
+    def submit_stored(
+        self, future_key, fn: WrappedFunc, *args, **kwargs
+    ) -> FutureProxy:
         """Submit a parallel task and store the result against the given future_key."""
         return self.executor.submit_stored(
             future_key, remove_db_session(fn), *args, **kwargs
         )
 
-    def map(self, fn: F, *iterables, **kwargs):  # noqa: A003
+    def map(self, fn: WrappedFunc, *iterables, **kwargs):  # noqa: A003
         """Perform a map operation."""
         return self.executor.map(remove_db_session(fn), *iterables, **kwargs)
 
-    def job(self, fn: F) -> ExecutorJob:
+    def job(self, fn: WrappedFunc) -> ExecutorJob:
         """Decorate a job worker."""
         return self.executor.job(remove_db_session(fn))

--- a/funnel/registry.py
+++ b/funnel/registry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections import OrderedDict
 from dataclasses import dataclass
 from functools import wraps
-from typing import Collection, List, Optional, Tuple
+from typing import Collection, List, Optional, Tuple, cast
 import re
 
 from flask import Response, abort, jsonify, request
@@ -14,6 +14,7 @@ from baseframe import _
 from baseframe.signals import exception_catchall
 
 from .models import AuthToken, UserExternalId
+from .typing import WrappedFunc
 
 # Bearer token, as per
 # http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-15#section-2.1
@@ -55,9 +56,9 @@ class ResourceRegistry(OrderedDict):
                 },
             )
 
-        def wrapper(f):
+        def decorator(f: WrappedFunc) -> WrappedFunc:
             @wraps(f)
-            def decorated_function():
+            def wrapper():
                 if request.method == 'GET':
                     args = request.args
                 elif request.method in ['POST', 'PUT', 'DELETE']:
@@ -133,9 +134,9 @@ class ResourceRegistry(OrderedDict):
                 'trusted': trusted,
                 'f': f,
             }
-            return decorated_function
+            return cast(WrappedFunc, wrapper)
 
-        return wrapper
+        return decorator
 
 
 @dataclass

--- a/funnel/typing.py
+++ b/funnel/typing.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Set, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple, TypeVar, Union
 from uuid import UUID
 
 from werkzeug.wrappers import Response  # Base class for Flask Response
@@ -18,6 +18,8 @@ __all__ = [
     'ReturnRenderWith',
     'ReturnResponse',
     'ReturnView',
+    'WrappedFunc',
+    'ReturnDecorator',
     'T',
 ]
 
@@ -60,6 +62,11 @@ ReturnView = Union[
 
 #: Type used to indicate that a decorator returns its decorated attribute
 T = TypeVar('T')
+
+#: Type used for functions and methods wrapped in a decorator
+WrappedFunc = TypeVar('WrappedFunc', bound=Callable[..., Any])
+#: Return type for decorator factories
+ReturnDecorator = Callable[[WrappedFunc], WrappedFunc]
 
 #: Return type of the `migrate_user` and `migrate_profile` methods
 OptionalMigratedTables = Optional[Union[List[str], Tuple[str], Set[str]]]

--- a/funnel/views/siteadmin.py
+++ b/funnel/views/siteadmin.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from datetime import timedelta
 from functools import wraps
 from io import StringIO
-from typing import Dict, Optional
+from typing import Dict, Optional, cast
 import csv
 
 from sqlalchemy.dialects.postgresql import INTERVAL
@@ -32,7 +32,7 @@ from ..models import (
     auth_client_user_session,
     db,
 )
-from ..typing import ReturnRenderWith, ReturnResponse, ReturnView
+from ..typing import ReturnRenderWith, ReturnResponse, ReturnView, WrappedFunc
 from ..utils import abort_null
 from .login_session import requires_login
 
@@ -66,28 +66,28 @@ class ReportCounter:
     frequency: int
 
 
-def requires_siteadmin(f):
+def requires_siteadmin(f: WrappedFunc) -> WrappedFunc:
     """Decorate a view to require siteadmin privilege."""
 
     @wraps(f)
-    def decorated_function(*args, **kwargs):
+    def wrapper(*args, **kwargs):
         if not current_auth.user or not current_auth.user.is_site_admin:
             abort(403)
         return f(*args, **kwargs)
 
-    return decorated_function
+    return cast(WrappedFunc, wrapper)
 
 
-def requires_comment_moderator(f):
+def requires_comment_moderator(f: WrappedFunc) -> WrappedFunc:
     """Decorate a view to require comment moderator privilege."""
 
     @wraps(f)
-    def decorated_function(*args, **kwargs):
+    def wrapper(*args, **kwargs):
         if not current_auth.user or not current_auth.user.is_comment_moderator:
             abort(403)
         return f(*args, **kwargs)
 
-    return decorated_function
+    return cast(WrappedFunc, wrapper)
 
 
 @route('/siteadmin')

--- a/tests/integration/views/test_oauth.py
+++ b/tests/integration/views/test_oauth.py
@@ -8,7 +8,7 @@ from funnel.models import AuthToken
 def test_authcode_requires_login(client):
     """The authcode endpoint requires a login."""
     rv = client.get('/api/1/auth')
-    assert rv.status_code == 302
+    assert rv.status_code == 303
     assert urlsplit(rv.location).path == '/login'
 
 


### PR DESCRIPTION
All decorators are now fully typed. One use case of a class decorator has been restored to a function decorator as mypy is now capable of typechecking it. The internal function names in decorators have been standardized to `wrapper` and `decorator`.

Small change in functionality: login decorators now use `render_redirect` for safety in HTML fragment renders.