### PR TITLE
API endpoint for shortlinks to in-app content

### DIFF
--- a/funnel/views/api/__init__.py
+++ b/funnel/views/api/__init__.py
@@ -1,4 +1,14 @@
 """API views."""
 # flake8: noqa
 
-from . import account, email_events, geoname, markdown, oauth, pwa, resource, sms_events
+from . import (
+    account,
+    email_events,
+    geoname,
+    markdown,
+    oauth,
+    pwa,
+    resource,
+    shortlink,
+    sms_events,
+)

--- a/funnel/views/api/resource.py
+++ b/funnel/views/api/resource.py
@@ -132,6 +132,8 @@ def api_result(status, _jsonp=False, **params) -> Response:
     if status in (200, 201):
         status_code = status
         status = 'ok'
+    elif status == 'error':
+        status_code = 422
     params['status'] = status
     if _jsonp:
         response = jsonp(params)

--- a/funnel/views/api/shortlink.py
+++ b/funnel/views/api/shortlink.py
@@ -1,8 +1,8 @@
 """API view for creating a shortlink to any content on the website."""
 
-from typing import Dict, Optional, Tuple
+from typing import Dict, Optional, Tuple, Union
 
-from url_normalize import url_normalize
+from furl import furl
 
 from baseframe import _
 from coaster.auth import current_auth
@@ -19,10 +19,12 @@ from ..helpers import app_url_for, validate_is_app_url
 @app.route('/api/1/shortlink/create', methods=['POST'])
 @requestform(('url', abort_null), ('shorter', getbool), ('name', abort_null))
 def create_shortlink(
-    url: str, shorter: bool = True, name: Optional[str] = None
+    url: Union[str, furl], shorter: bool = True, name: Optional[str] = None
 ) -> Tuple[Dict[str, str], int]:
     """Create a shortlink that's valid for URLs in the app."""
     # Validate URL to be local before allowing a shortlink to it.
+    if url:
+        url = furl(url)
     if not url or not validate_is_app_url(url):
         return {
             'status': 'error',
@@ -41,7 +43,7 @@ def create_shortlink(
         except ValueError:
             existing = Shortlink.get(name)
             # existing will be None if the internal record is marked as disabled
-            if existing is None or str(existing.url) != url_normalize(str(url)):
+            if existing is None or str(existing.url) != str(url):
                 return {
                     'status': 'error',
                     'error': 'unavailable',

--- a/funnel/views/api/shortlink.py
+++ b/funnel/views/api/shortlink.py
@@ -1,0 +1,60 @@
+"""API view for creating a shortlink to any content on the website."""
+
+from typing import Dict, Optional, Tuple
+
+from url_normalize import url_normalize
+
+from baseframe import _
+from coaster.auth import current_auth
+from coaster.utils import getbool
+from coaster.views import requestform
+
+from ... import app, shortlinkapp
+from ...models import Shortlink, db
+from ...utils import abort_null
+from ..helpers import app_url_for, validate_is_app_url
+
+
+# Add future hasjobapp route here
+@app.route('/api/1/shortlink/create', methods=['POST'])
+@requestform(('url', abort_null), ('shorter', getbool), ('name', abort_null))
+def create_shortlink(
+    url: str, shorter: bool = True, name: Optional[str] = None
+) -> Tuple[Dict[str, str], int]:
+    """Create a shortlink that's valid for URLs in the app."""
+    # Validate URL to be local before allowing a shortlink to it.
+    if not url or not validate_is_app_url(url):
+        return {
+            'status': 'error',
+            'error': 'url_invalid',
+            'error_description': _("This URL is not valid for a shortlink"),
+        }, 422
+    if name:
+        if not current_auth.user or not current_auth.user.is_site_editor:
+            return {
+                'status': 'error',
+                'error': 'unauthorized',
+                'error_description': _("A custom name requires special authorization"),
+            }, 403
+        try:
+            sl = Shortlink.new(url, shorter=shorter, name=name)
+        except ValueError:
+            existing = Shortlink.get(name)
+            # existing will be None if the internal record is marked as disabled
+            if existing is None or str(existing.url) != url_normalize(str(url)):
+                return {
+                    'status': 'error',
+                    'error': 'unavailable',
+                    'error_description': _("This name is not available"),
+                }, 422
+            sl = existing  # Return existing if both name and URL URL is matching
+    else:
+        sl = Shortlink.new(url, shorter=shorter, reuse=True)
+    status_code = 201 if sl.is_new else 200
+    db.session.add(sl)
+    db.session.commit()
+    return {
+        'status': 'ok',
+        'shortlink': app_url_for(shortlinkapp, 'link', name=sl.name, _external=True),
+        'url': url,
+    }, status_code

--- a/funnel/views/notifications/account_notification.py
+++ b/funnel/views/notifications/account_notification.py
@@ -49,6 +49,7 @@ class RenderAccountPasswordNotification(RenderNotification):
                 " your password or contact support at {email}."
             ).format(email=app.config['SITE_SUPPORT_EMAIL']),
             url=shortlink(
-                url_for('reset', _external=True, **self.tracking_tags('sms'))
+                url_for('reset', _external=True, **self.tracking_tags('sms')),
+                shorter=True,
             ),
         )

--- a/funnel/views/notifications/comment_notification.py
+++ b/funnel/views/notifications/comment_notification.py
@@ -55,7 +55,8 @@ class RenderCommentReportReceivedNotification(RenderNotification):
                     report=self.report.uuid_b58,
                     _external=True,
                     **self.tracking_tags('sms'),
-                )
+                ),
+                shorter=True,
             ),
         )
 
@@ -162,6 +163,7 @@ class CommentNotification(RenderNotification):
         return OneLineTemplate(
             text1=self.activity_template_inline().format(actor=self.actor.pickername),
             url=shortlink(
-                self.comment.url_for(_external=True, **self.tracking_tags('sms'))
+                self.comment.url_for(_external=True, **self.tracking_tags('sms')),
+                shorter=True,
             ),
         )

--- a/funnel/views/notifications/project_starting_notification.py
+++ b/funnel/views/notifications/project_starting_notification.py
@@ -46,6 +46,7 @@ class RenderProjectStartingNotification(RenderNotification):
                 time=time_filter(self.session.start_at_localized),
             ),
             url=shortlink(
-                self.project.url_for(_external=True, **self.tracking_tags('sms'))
+                self.project.url_for(_external=True, **self.tracking_tags('sms')),
+                shorter=True,
             ),
         )

--- a/funnel/views/notifications/proposal_notification.py
+++ b/funnel/views/notifications/proposal_notification.py
@@ -61,7 +61,8 @@ class RenderProposalReceivedNotification(RenderNotification):
             ),
             text2=self.proposal.title,
             url=shortlink(
-                self.proposal.url_for(_external=True, **self.tracking_tags('sms'))
+                self.proposal.url_for(_external=True, **self.tracking_tags('sms')),
+                shorter=True,
             ),
         )
 
@@ -103,6 +104,7 @@ class RenderProposalSubmittedNotification(RenderNotification):
             ),
             text2=self.proposal.title,
             url=shortlink(
-                self.proposal.url_for(_external=True, **self.tracking_tags('sms'))
+                self.proposal.url_for(_external=True, **self.tracking_tags('sms')),
+                shorter=True,
             ),
         )

--- a/funnel/views/notifications/rsvp_notification.py
+++ b/funnel/views/notifications/rsvp_notification.py
@@ -98,7 +98,10 @@ class RenderRegistrationConfirmationNotification(RegistrationBase, RenderNotific
                     next_at, self.datetime_format_sms, locale=get_locale()
                 ),
             ),
-            url=shortlink(project.url_for(_external=True, **self.tracking_tags('sms'))),
+            url=shortlink(
+                project.url_for(_external=True, **self.tracking_tags('sms')),
+                shorter=True,
+            ),
         )
 
 

--- a/funnel/views/notifications/update_notification.py
+++ b/funnel/views/notifications/update_notification.py
@@ -50,6 +50,7 @@ class RenderNewUpdateNotification(RenderNotification):
             ),
             text2=self.update.title,
             url=shortlink(
-                self.update.url_for(_external=True, **self.tracking_tags('sms'))
+                self.update.url_for(_external=True, **self.tracking_tags('sms')),
+                shorter=True,
             ),
         )

--- a/requirements.in
+++ b/requirements.in
@@ -55,7 +55,6 @@ SQLAlchemy-Utils
 tweepy
 twilio
 typing-extensions
-url-normalize
 user-agents
 Werkzeug>=2.0.2  # https://github.com/pallets/werkzeug/pull/2237
 whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -423,7 +423,6 @@ six==1.16.0
     #   requests-file
     #   requests-mock
     #   tuspy
-    #   url-normalize
 sqlalchemy==1.4.39
     # via
     #   -r requirements.in
@@ -471,8 +470,6 @@ uglipyjs==0.2.5
     # via coaster
 unidecode==1.3.4
     # via coaster
-url-normalize==1.4.3
-    # via -r requirements.in
 urllib3==1.26.11
     # via
     #   geoip2

--- a/tests/unit/views/test_api_shortlink.py
+++ b/tests/unit/views/test_api_shortlink.py
@@ -1,0 +1,158 @@
+"""Test shortlink API views."""
+
+from flask import url_for
+
+from furl import furl
+import pytest
+
+from funnel import app, shortlinkapp
+from funnel.models import SiteMembership
+
+
+@pytest.fixture()
+def create_shortlink():
+    """URL for creating a shortlink."""
+    with app.app_context():
+        return url_for('create_shortlink')
+
+
+@pytest.fixture()
+def user_rincewind_site_editor(db_session, user_rincewind):
+    sm = SiteMembership(
+        user=user_rincewind, granted_by=user_rincewind, is_site_editor=True
+    )
+    db_session.add(sm)
+    db_session.flush()
+    return sm
+
+
+def test_create_invalid_shortlink(client, user_rincewind, create_shortlink):
+    """Creating a shortlink via API with invalid data will fail."""
+    # A GET request will fail
+    rv = client.get(create_shortlink)
+    assert rv.status_code == 405
+
+    # An external URL will be rejected
+    rv = client.post(create_shortlink, data={'url': 'https://example.com'})
+    assert rv.status_code == 422
+    assert rv.json['error'] == 'url_invalid'
+
+    # A relative URL will be rejected
+    rv = client.post(
+        create_shortlink, data={'url': user_rincewind.profile.url_for(_external=False)}
+    )
+    assert rv.status_code == 422
+    assert rv.json['error'] == 'url_invalid'
+
+    # A full URL to a 404 path will be rejected
+    rv = client.post(
+        create_shortlink,
+        data={'url': f'http://{app.config["SERVER_NAME"]}/this/is/not/a/valid/url'},
+    )
+    assert rv.status_code == 422
+    assert rv.json['error'] == 'url_invalid'
+
+
+def test_create_shortlink(client, user_rincewind, create_shortlink):
+    """Creating a shortlink via API with valid data will pass."""
+    # A valid URL to an app path will be accepted
+    rv = client.post(
+        create_shortlink, data={'url': user_rincewind.profile.url_for(_external=True)}
+    )
+    assert rv.status_code == 201
+    sl1 = furl(rv.json['shortlink'])
+    assert sl1.netloc == app.config['SHORTLINK_DOMAIN']
+    assert len(str(sl1.path)) <= 5  # API defaults to the shorter form (max 4 chars)
+
+    # Asking for it again will return the same link
+    rv = client.post(
+        create_shortlink, data={'url': user_rincewind.profile.url_for(_external=True)}
+    )
+    assert rv.status_code == 200
+    sl2 = furl(rv.json['shortlink'])
+    assert sl1 == sl2
+
+    # A valid URL can include extra query parameters
+    rv = client.post(
+        create_shortlink,
+        data={
+            'url': user_rincewind.profile.url_for(
+                _external=True, utm_campaign='webshare'
+            )
+        },
+    )
+    assert rv.status_code == 201
+    sl3 = furl(rv.json['shortlink'])
+    assert sl3.netloc == app.config['SHORTLINK_DOMAIN']
+    assert len(str(sl3.path)) <= 5  # API defaults to the shorter form (max 4 chars)
+    assert sl3.path != sl1.path  # We got a different shortlink
+    assert rv.json['url'] == user_rincewind.profile.url_for(
+        _external=True, utm_campaign='webshare'
+    )
+
+
+def test_create_shortlink_longer(client, user_rincewind, create_shortlink):
+    rv = client.post(
+        create_shortlink,
+        data={'url': user_rincewind.profile.url_for(_external=True), 'shorter': '0'},
+    )
+    assert rv.status_code == 201
+    sl1 = furl(rv.json['shortlink'])
+    assert sl1.netloc == app.config['SHORTLINK_DOMAIN']
+    assert len(str(sl1.path)) > 5  # The shortlink is no longer limited to 4 chars
+
+
+def test_create_shortlink_name_unauthorized(client, user_rincewind, create_shortlink):
+    """Asking for a custom name will fail if the user is not a site editor."""
+    rv = client.post(
+        create_shortlink,
+        data={
+            'url': user_rincewind.profile.url_for(_external=True),
+            'name': 'rincewind',
+        },
+    )
+    assert rv.status_code == 403
+    assert rv.json['error'] == 'unauthorized'
+
+
+@pytest.mark.usefixtures('user_rincewind_site_editor')
+def test_create_shortlink_name_authorized(
+    client, login, user_rincewind, user_wolfgang, create_shortlink
+):
+    """Asking for a custom name will work for site editors."""
+    login.as_(user_rincewind)
+    rv = client.post(
+        create_shortlink,
+        data={
+            'url': user_rincewind.profile.url_for(_external=True),
+            'name': 'rincewind',
+        },
+    )
+    assert rv.status_code == 201
+    assert (
+        rv.json['shortlink'] == f'http://{shortlinkapp.config["SERVER_NAME"]}/rincewind'
+    )
+
+    # Asking for it again will return the same short link
+    rv = client.post(
+        create_shortlink,
+        data={
+            'url': user_rincewind.profile.url_for(_external=True),
+            'name': 'rincewind',
+        },
+    )
+    assert rv.status_code == 200
+    assert (
+        rv.json['shortlink'] == f'http://{shortlinkapp.config["SERVER_NAME"]}/rincewind'
+    )
+
+    # But a custom name cannot be reused for another URL
+    rv = client.post(
+        create_shortlink,
+        data={
+            'url': user_wolfgang.profile.url_for(_external=True),
+            'name': 'rincewind',
+        },
+    )
+    assert rv.status_code == 422
+    assert rv.json['error'] == 'unavailable'


### PR DESCRIPTION
This PR adds an API endpoint to support #1434's need for dynamic shortlink generation (ie, generate shortlink only when share intent/dropdown is invoked).

The API endpoint is public-access and does not record the authenticating user that generated a shortlink. However, it limits URLs to those recognised to be served by the host app, including having a valid path. A custom name can be provided for the shortlink stub if the calling user is a site editor.