### PR TITLE
Rerun tests that are time-sensitive and flaky

### DIFF
--- a/tests/unit/models/test_auth_client_AuthToken.py
+++ b/tests/unit/models/test_auth_client_AuthToken.py
@@ -36,6 +36,7 @@ class TestAuthToken(TestDatabaseFixture):
         assert existing_token != auth_token.token
         assert existing_secret != auth_token.secret
 
+    @pytest.mark.flaky(reruns=1)  # Rerun in case assert based on the timedelta fails
     def test_authtoken_is_valid(self) -> None:
         """Test for verifying if AuthToken's token is valid."""
         auth_client = self.fixtures.auth_client

--- a/tests/unit/models/test_project.py
+++ b/tests/unit/models/test_project.py
@@ -23,6 +23,7 @@ def invalidate_cache(project):
             pass
 
 
+@pytest.mark.flaky(reruns=1)  # Rerun in case assert with timedelta fails
 def test_cfp_state_draft(db_session, new_organization, new_project) -> None:
     assert new_project.cfp_start_at is None
     assert new_project.state.DRAFT

--- a/tests/unit/views/test_session_temp_vars.py
+++ b/tests/unit/views/test_session_temp_vars.py
@@ -56,6 +56,7 @@ def _timeout_var():
     session_timeouts.pop('test_timeout')
 
 
+@pytest.mark.flaky(reruns=1)  # Rerun in case assert with timedelta fails
 @pytest.mark.usefixtures('_timeout_var')
 def test_session_temp_vars(client) -> None:
     with client.session_transaction() as session:


### PR DESCRIPTION
Tests that use timedelta to pick a date that's outside the expected running time can occasionally fail if the runtime is unexpectedly slow. This patch applies the `flaky` mark from `pytest-rerunfailures` to re-run these tests a second time.