### PR TITLE
Add explicit timeout for all requests

### DIFF
--- a/funnel/cli/periodic.py
+++ b/funnel/cli/periodic.py
@@ -249,12 +249,12 @@ def growthstats():
     requests.post(
         f'https://api.telegram.org/bot{app.config["TELEGRAM_STATS_APIKEY"]}'
         f'/sendMessage',
+        timeout=30,
         data={
             'chat_id': app.config['TELEGRAM_STATS_CHATID'],
             'parse_mode': 'markdown',
             'text': message,
         },
-        timeout=30,
     )
 
 

--- a/funnel/extapi/boxoffice.py
+++ b/funnel/extapi/boxoffice.py
@@ -28,7 +28,7 @@ class Boxoffice:
             self.base_url,
             f'ic/{ic}/orders?access_token={self.access_token}',
         )
-        return requests.get(url).json().get('orders')
+        return requests.get(url, timeout=30).json().get('orders')
 
     def get_tickets(self, ic):
         tickets = []

--- a/funnel/extapi/explara.py
+++ b/funnel/extapi/explara.py
@@ -47,7 +47,10 @@ class ExplaraAPI:
                 'toRecord': to_record,
             }
             attendee_response = requests.post(
-                self.url_for('attendee-list'), headers=self.headers, data=payload
+                self.url_for('attendee-list'),
+                timeout=30,
+                headers=self.headers,
+                data=payload,
             ).json()
             if not attendee_response.get('attendee'):
                 completed = True

--- a/funnel/forms/account.py
+++ b/funnel/forms/account.py
@@ -114,7 +114,7 @@ def pwned_password_validator(_form, field) -> None:
     prefix, suffix = phash[:5], phash[5:]
 
     try:
-        rv = requests.get(f'https://api.pwnedpasswords.com/range/{prefix}')
+        rv = requests.get(f'https://api.pwnedpasswords.com/range/{prefix}', timeout=10)
         if rv.status_code != 200:
             # API call had an error and we can't proceed with validation.
             return

--- a/funnel/loginproviders/github.py
+++ b/funnel/loginproviders/github.py
@@ -49,6 +49,7 @@ class GitHubProvider(LoginProvider):
         try:
             response = requests.post(
                 self.token_url,
+                timeout=30,
                 headers={'Accept': 'application/json'},
                 params={
                     'client_id': self.key,

--- a/funnel/loginproviders/linkedin.py
+++ b/funnel/loginproviders/linkedin.py
@@ -65,6 +65,7 @@ class LinkedInProvider(LoginProvider):
         try:
             response = requests.post(
                 self.token_url,
+                timeout=30,
                 headers={'Accept': 'application/json'},
                 params={
                     'grant_type': 'authorization_code',

--- a/funnel/loginproviders/zoom.py
+++ b/funnel/loginproviders/zoom.py
@@ -53,6 +53,7 @@ class ZoomProvider(LoginProvider):
         try:
             response = requests.post(
                 self.token_url,
+                timeout=30,
                 headers={
                     'Accept': 'application/x-www-form-urlencoded',
                     'Authorization': 'Basic '

--- a/funnel/transports/sms/send.py
+++ b/funnel/transports/sms/send.py
@@ -104,6 +104,7 @@ def send_via_exotel(phone: str, message: SmsTemplate, callback: bool = True) -> 
     try:
         r = requests.post(
             f'https://twilix.exotel.in/v1/Accounts/{sid}/Sms/send.json',
+            timeout=30,
             auth=(sid, token),
             data=payload,
         )


### PR DESCRIPTION
The `requests` library has a default _indefinite_ timeout which can cause a render failure for the user. This PR adds explicit timeouts wherever they were missing, using 30 seconds for critical calls and 10 seconds for non-critical calls (pwned password validation).