### PR TITLE
Replace JsonDict with a better-maintained implementation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,7 +66,7 @@ repos:
           - toml==0.10.2
           - tomli==2.0.1
   - repo: https://github.com/PyCQA/isort
-    rev: v5.11.3
+    rev: 5.11.4
     hooks:
       - id: isort
         additional_dependencies:

--- a/funnel/models/__init__.py
+++ b/funnel/models/__init__.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Callable, TypeVar
 
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.dialects import postgresql
+from sqlalchemy_json import mutable_json_type
 from sqlalchemy_utils import LocaleType, TimezoneType, TSVectorType, UUIDType
 import sqlalchemy as sa  # noqa
 import sqlalchemy.orm  # Required to make sa.orm work  # noqa
@@ -18,7 +19,6 @@ from coaster.sqlalchemy import (
     BaseScopedIdNameMixin,
     BaseScopedNameMixin,
     CoordinatesMixin,
-    JsonDict,
     NoIdMixin,
     RegistryMixin,
     RoleMixin,
@@ -48,6 +48,8 @@ else:
         def declarative_mixin(cls: T) -> T:
             return cls
 
+
+json_type: postgresql.JSONB = mutable_json_type(dbtype=postgresql.JSONB, nested=True)
 
 db = SQLAlchemy()
 # This must be set _before_ any of the models are imported

--- a/funnel/models/draft.py
+++ b/funnel/models/draft.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from werkzeug.datastructures import MultiDict
 
-from . import JsonDict, NoIdMixin, UUIDType, db, sa
+from . import NoIdMixin, UUIDType, db, json_type, sa
 
 __all__ = ['Draft']
 
@@ -16,7 +16,7 @@ class Draft(NoIdMixin, db.Model):  # type: ignore[name-defined]
 
     table = sa.Column(sa.UnicodeText, primary_key=True)
     table_row_id = sa.Column(UUIDType(binary=False), primary_key=True)
-    body = sa.Column(JsonDict, nullable=False, server_default='{}')
+    body = sa.Column(json_type, nullable=False, server_default='{}')
     revision = sa.Column(UUIDType(binary=False))
 
     @property

--- a/funnel/models/project.py
+++ b/funnel/models/project.py
@@ -18,7 +18,6 @@ from .. import app
 from ..typing import OptionalMigratedTables
 from . import (
     BaseScopedNameMixin,
-    JsonDict,
     Mapped,
     MarkdownCompositeDocument,
     TimestampMixin,
@@ -27,6 +26,7 @@ from . import (
     UrlType,
     UuidMixin,
     db,
+    json_type,
     sa,
 )
 from .comment import SET_TYPE, Commentset
@@ -108,7 +108,7 @@ class Project(UuidMixin, BaseScopedNameMixin, db.Model):  # type: ignore[name-de
         read={'all'},
         datasets={'primary', 'without_parent', 'related'},
     )
-    parsed_location = sa.Column(JsonDict, nullable=False, server_default='{}')
+    parsed_location = sa.Column(json_type, nullable=False, server_default='{}')
 
     website = with_roles(
         sa.Column(UrlType, nullable=True),
@@ -193,7 +193,7 @@ class Project(UuidMixin, BaseScopedNameMixin, db.Model):  # type: ignore[name-de
         datasets={'primary', 'without_parent'},
     )
     boxoffice_data = with_roles(
-        sa.Column(JsonDict, nullable=False, server_default='{}'),
+        sa.Column(json_type, nullable=False, server_default='{}'),
         # This is an attribute, but we deliberately use `call` instead of `read` to
         # block this from dictionary enumeration. FIXME: Break up this dictionary into
         # individual columns with `all` access for ticket embed id and `promoter`

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -8,6 +8,9 @@
 # the 'revision' command, regardless of autogenerate
 # revision_environment = false
 
+compare_type = True
+compare_server_default = True
+render_as_batch = False
 
 # Logging configuration
 [loggers]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ from_first = true
 # add_imports = 'from __future__ import annotations'
 known_future_library = ['__future__', 'six']
 known_first_party = ['baseframe', 'coaster', 'funnel']
-known_sqlalchemy = ['alembic', 'sqlalchemy', 'sqlalchemy_utils', 'flask_sqlalchemy', 'psycopg2']
+known_sqlalchemy = ['alembic', 'sqlalchemy', 'sqlalchemy_utils', 'flask_sqlalchemy', 'psycopg2', 'sqlalchemy_json']
 known_flask = [
   'flask',
   'click',
@@ -141,9 +141,9 @@ env_files = ['.env', '.env.testing']
 
 [tool.pyright]
 venv = 'hasgeek'
-
 reportMissingImports = true
 reportMissingTypeStubs = false
+reportShadowedImports = false
 
 pythonVersion = '3.7'
 

--- a/requirements.in
+++ b/requirements.in
@@ -56,6 +56,7 @@ requests
 rich
 rq
 SQLAlchemy>=1.4.33
+sqlalchemy-json
 SQLAlchemy-Utils
 tweepy
 twilio

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ async-timeout==4.0.2
     # via
     #   aiohttp
     #   redis
-attrs==22.1.0
+attrs==22.2.0
     # via aiohttp
 babel==2.11.0
     # via
@@ -286,7 +286,7 @@ paramiko==2.12.0
     # via fabric3
 passlib==1.7.4
     # via -r requirements.in
-phonenumbers==8.13.2
+phonenumbers==8.13.3
     # via -r requirements.in
 premailer==3.10.0
     # via -r requirements.in
@@ -431,6 +431,7 @@ six==1.16.0
     #   python-dateutil
     #   requests-file
     #   requests-mock
+    #   sqlalchemy-json
     #   tuspy
 sqlalchemy==1.4.45
     # via
@@ -438,8 +439,11 @@ sqlalchemy==1.4.45
     #   alembic
     #   coaster
     #   flask-sqlalchemy
+    #   sqlalchemy-json
     #   sqlalchemy-utils
     #   wtforms-sqlalchemy
+sqlalchemy-json==0.5.0
+    # via -r requirements.in
 sqlalchemy-utils==0.38.3
     # via
     #   -r requirements.in

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,7 +6,7 @@
 #
 astroid==2.12.13
     # via pylint
-attrs==22.1.0
+attrs==22.2.0
     # via
     #   cattrs
     #   flake8-bugbear
@@ -107,7 +107,7 @@ importlib-metadata==5.2.0
     #   flask
 iniconfig==1.1.1
     # via pytest
-isort==5.11.3
+isort==5.11.4
     # via
     #   -r requirements_dev.in
     #   flake8-isort
@@ -259,7 +259,7 @@ types-python-dateutil==2.8.19.5
     # via -r requirements_dev.in
 types-pytz==2022.7.0.0
     # via -r requirements_dev.in
-types-requests==2.28.11.5
+types-requests==2.28.11.6
     # via -r requirements_dev.in
 types-setuptools==65.6.0.2
     # via -r requirements_dev.in

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -8,7 +8,7 @@ async-generator==1.10
     # via
     #   trio
     #   trio-websocket
-attrs==22.1.0
+attrs==22.2.0
     # via
     #   outcome
     #   pytest


### PR DESCRIPTION
The `sqlalchemy_json` library has far better mutation tracking than the JsonDict type in Coaster, so we should switch.