### PR TITLE
Revert "Disable styling changes for markdown heading anchors."

### DIFF
--- a/funnel/assets/sass/components/_layout.scss
+++ b/funnel/assets/sass/components/_layout.scss
@@ -303,21 +303,18 @@ blockquote {
   h5,
   h6 {
     a {
-      color: inherit;
+      color: $mui-text-dark;
+      display: none;
     }
-    // a {
-    //   color: $mui-text-dark;
-    //   display: none;
-    // }
-    // &:hover a {
-    //   display: inline;
-    // }
-    // @media (any-pointer: coarse) {
-    //   a {
-    //     display: inline;
-    //     color: $mui-text-accent;
-    //   }
-    // }
+    &:hover a {
+      display: inline;
+    }
+    @media (any-pointer: coarse) {
+      a {
+        display: inline;
+        color: $mui-text-accent;
+      }
+    }
   }
 
   img {


### PR DESCRIPTION
This reverts commit 04af9f363209ddd33ec2b14283b895577f82dca2.