### PR TITLE
Fix `next_session_at` for projects without sessions

### DIFF
--- a/funnel/models/session.py
+++ b/funnel/models/session.py
@@ -308,6 +308,7 @@ class __Project:
                     sa.select([Project.start_at.label('start_at')])
                     .where(Project.start_at.isnot(None))
                     .where(Project.start_at >= sa.func.utcnow())
+                    .correlate(Project)  # type: ignore[arg-type]
                 )
             )
             .scalar_subquery()  # sqlalchemy-stubs doesn't know of this

--- a/tests/unit/models/test_session.py
+++ b/tests/unit/models/test_session.py
@@ -289,7 +289,7 @@ def test_long_session_fail(db_session, new_project) -> None:
         ),
     ],
 )
-def test_next_session_at(
+def test_next_session_at_property(
     db_session,
     project_expo2010,
     project_dates: Optional[Tuple[datetime, datetime]],
@@ -318,3 +318,7 @@ def test_next_session_at(
         assert project_expo2010.next_session_at == project_expo2010.start_at
     else:
         assert project_expo2010.next_session_at == sessions[expected_session].start_at
+
+
+# TODO: Test next_session_at as a SQL expression, as used in in the index view's
+# order_by clause

--- a/tests/unit/models/test_session.py
+++ b/tests/unit/models/test_session.py
@@ -3,8 +3,10 @@
 
 from datetime import datetime, timedelta
 from types import SimpleNamespace
+from typing import Dict, List, Optional, Tuple
 
 from sqlalchemy.exc import IntegrityError
+import sqlalchemy as sa
 
 from pytz import utc
 import pytest
@@ -15,7 +17,7 @@ from funnel import models
 
 
 @pytest.fixture()
-def block_of_sessions(db_session, new_project):
+def block_of_sessions(db_session, new_project) -> SimpleNamespace:
 
     # DocType HTML5's schedule, but using UTC to simplify testing
     # https://hasgeek.com/doctypehtml5/bangalore/schedule
@@ -103,7 +105,7 @@ def block_of_sessions(db_session, new_project):
     return SimpleNamespace(**locals())
 
 
-def find_projects(starting_times, within, gap):
+def find_projects(starting_times, within, gap) -> Dict[datetime, models.Project]:
     # Keep the timestamps at which projects were found, plus the project. Criteria:
     # starts at `timestamp` + up to `within` period, with `gap` from prior sessions
     return {
@@ -116,8 +118,8 @@ def find_projects(starting_times, within, gap):
     }
 
 
-def test_project_starting_at(db_session, block_of_sessions) -> None:
-
+def test_project_starting_at(block_of_sessions) -> None:
+    """Test Project.starting_at finds projects by starting time accurately."""
     block_of_sessions.refresh()
 
     # Loop through the day at 5 min intervals from 8 AM, looking for start time
@@ -184,7 +186,7 @@ def test_project_starting_at(db_session, block_of_sessions) -> None:
 
 
 def test_long_session_fail(db_session, new_project) -> None:
-    """Sessions cannot exceed 24 hours."""
+    """Confirm sessions cannot exceed 24 hours."""
     # Less than 24 hours is fine:
     db_session.add(
         models.Session(
@@ -218,3 +220,101 @@ def test_long_session_fail(db_session, new_project) -> None:
     )
     with pytest.raises(IntegrityError):
         db_session.commit()
+
+
+@pytest.mark.parametrize(
+    ('project_dates', 'session_dates', 'expected_session'),
+    [
+        pytest.param(None, [], None, id='no-dates'),
+        pytest.param(
+            (
+                sa.func.utcnow() - timedelta(minutes=2),
+                sa.func.utcnow() - timedelta(minutes=1),
+            ),
+            [],
+            None,
+            id='past-project',
+        ),
+        pytest.param(
+            (
+                sa.func.utcnow() - timedelta(minutes=1),
+                sa.func.utcnow() + timedelta(minutes=1),
+            ),
+            [],
+            None,
+            id='live-project',
+        ),
+        pytest.param(
+            (
+                sa.func.utcnow() + timedelta(minutes=1),
+                sa.func.utcnow() + timedelta(minutes=2),
+            ),
+            [],
+            -1,  # Signifies match with project.start_at
+            id='future-project',
+        ),
+        pytest.param(
+            None,
+            [
+                (
+                    sa.func.utcnow() - timedelta(minutes=2),
+                    sa.func.utcnow() - timedelta(minutes=1),
+                ),
+            ],
+            None,
+            id='past-session',
+        ),
+        pytest.param(
+            None,
+            [
+                (
+                    sa.func.utcnow() - timedelta(minutes=2),
+                    sa.func.utcnow() - timedelta(minutes=1),
+                ),
+                (
+                    sa.func.utcnow() - timedelta(minutes=1),
+                    sa.func.utcnow() + timedelta(minutes=1),
+                ),
+                (
+                    sa.func.utcnow() + timedelta(minutes=1),
+                    sa.func.utcnow() + timedelta(minutes=2),
+                ),
+                (
+                    sa.func.utcnow() + timedelta(minutes=2),
+                    sa.func.utcnow() + timedelta(minutes=3),
+                ),
+            ],
+            2,  # Matches immediate next session, skipping past (0) and ongoing (1)
+            id='next-session',
+        ),
+    ],
+)
+def test_next_session_at(
+    db_session,
+    project_expo2010,
+    project_dates: Optional[Tuple[datetime, datetime]],
+    session_dates: List[Tuple[datetime, datetime]],
+    expected_session: Optional[int],
+) -> None:
+    """Test next_session_at to work for projects with sessions and without."""
+    if project_dates:
+        project_expo2010.start_at, project_expo2010.end_at = project_dates
+    sessions = []
+    for counter, dates in enumerate(session_dates):
+        new_session = models.Session(
+            project=project_expo2010,
+            start_at=dates[0],
+            end_at=dates[1],
+            title=str(counter),
+            description=str(counter),
+        )
+        db_session.add(new_session)
+        sessions.append(new_session)
+    db_session.commit()  # This forces conversion from SQL dates to datetimes
+
+    if expected_session is None:
+        assert project_expo2010.next_session_at is None
+    elif expected_session == -1:
+        assert project_expo2010.next_session_at == project_expo2010.start_at
+    else:
+        assert project_expo2010.next_session_at == sessions[expected_session].start_at


### PR DESCRIPTION
Projects that have dates but no sessions were reporting `next_session_at` as `None`. This change fixes it, defaulting to `Project.start_at` when there is no Session.