### PR TITLE
Avoid immutable annotations on fkey+relationship

### DIFF
--- a/funnel/models/commentset_membership.py
+++ b/funnel/models/commentset_membership.py
@@ -7,7 +7,7 @@ from uuid import UUID  # noqa: F401 # pylint: disable=unused-import
 
 from werkzeug.utils import cached_property
 
-from coaster.sqlalchemy import DynamicAssociationProxy, Query, immutable, with_roles
+from coaster.sqlalchemy import DynamicAssociationProxy, Query, with_roles
 
 from . import Mapped, db, sa
 from .comment import Comment, Commentset
@@ -45,23 +45,19 @@ class CommentsetMembership(
         }
     }
 
-    commentset_id: Mapped[int] = immutable(
-        sa.Column(
-            sa.Integer,
-            sa.ForeignKey('commentset.id', ondelete='CASCADE'),
-            nullable=False,
-        )
+    commentset_id: Mapped[int] = sa.Column(
+        sa.Integer,
+        sa.ForeignKey('commentset.id', ondelete='CASCADE'),
+        nullable=False,
     )
-    commentset: Mapped[Commentset] = immutable(
-        sa.orm.relationship(
-            Commentset,
-            backref=sa.orm.backref(
-                'subscriber_memberships',
-                lazy='dynamic',
-                cascade='all',
-                passive_deletes=True,
-            ),
-        )
+    commentset: Mapped[Commentset] = sa.orm.relationship(
+        Commentset,
+        backref=sa.orm.backref(
+            'subscriber_memberships',
+            lazy='dynamic',
+            cascade='all',
+            passive_deletes=True,
+        ),
     )
 
     parent_id: int = sa.orm.synonym('commentset_id')

--- a/funnel/models/membership_mixin.py
+++ b/funnel/models/membership_mixin.py
@@ -120,13 +120,13 @@ class ImmutableMembershipMixin(UuidMixin, BaseMixin):
 
     #: Start time of membership, ordinarily a mirror of created_at except
     #: for records created when the member table was added to the database
-    granted_at: Mapped[datetime_type] = immutable(
-        with_roles(
+    granted_at: Mapped[datetime_type] = with_roles(
+        immutable(
             sa.Column(
                 sa.TIMESTAMP(timezone=True), nullable=False, default=sa.func.utcnow()
-            ),
-            read={'subject', 'editor'},
-        )
+            )
+        ),
+        read={'subject', 'editor'},
     )
     #: End time of membership, ordinarily a mirror of updated_at
     revoked_at: Mapped[Optional[datetime_type]] = with_roles(
@@ -134,16 +134,16 @@ class ImmutableMembershipMixin(UuidMixin, BaseMixin):
         read={'subject', 'editor'},
     )
     #: Record type
-    record_type: Mapped[int] = immutable(
-        with_roles(
+    record_type: Mapped[int] = with_roles(
+        immutable(
             sa.Column(
                 sa.Integer,
                 StateManager.check_constraint('record_type', MEMBERSHIP_RECORD_TYPE),
                 default=MEMBERSHIP_RECORD_TYPE.DIRECT_ADD,
                 nullable=False,
-            ),
-            read={'subject', 'editor'},
-        )
+            )
+        ),
+        read={'subject', 'editor'},
     )
 
     @cached_property
@@ -389,7 +389,7 @@ class ImmutableUserMembershipMixin(ImmutableMembershipMixin):
     @classmethod
     def user(cls) -> Mapped[User]:
         """User who is the subject of this membership record."""
-        return immutable(sa.orm.relationship(User, foreign_keys=[cls.user_id]))
+        return sa.orm.relationship(User, foreign_keys=[cls.user_id])
 
     @declared_attr
     @classmethod
@@ -511,7 +511,7 @@ class ImmutableProfileMembershipMixin(ImmutableMembershipMixin):
     @classmethod
     def profile(cls) -> Mapped[Profile]:
         """Account that is the subject of this membership record."""
-        return immutable(sa.orm.relationship(Profile, foreign_keys=[cls.profile_id]))
+        return sa.orm.relationship(Profile, foreign_keys=[cls.profile_id])
 
     @declared_attr
     @classmethod

--- a/funnel/models/notification.py
+++ b/funnel/models/notification.py
@@ -308,15 +308,13 @@ class Notification(NoIdMixin, db.Model):  # type: ignore[name-defined]
     type_: Mapped[str] = immutable(sa.Column('type', sa.Unicode, nullable=False))
 
     #: Id of user that triggered this notification
-    user_id: Mapped[Optional[int]] = immutable(
-        sa.Column(
-            sa.Integer, sa.ForeignKey('user.id', ondelete='SET NULL'), nullable=True
-        )
+    user_id: Mapped[Optional[int]] = sa.Column(
+        sa.Integer, sa.ForeignKey('user.id', ondelete='SET NULL'), nullable=True
     )
     #: User that triggered this notification. Optional, as not all notifications are
     #: caused by user activity. Used to optionally exclude user from receiving
     #: notifications of their own activity
-    user: Mapped[Optional[User]] = immutable(sa.orm.relationship(User))
+    user: Mapped[Optional[User]] = sa.orm.relationship(User)
 
     #: UUID of document that the notification refers to
     document_uuid: Mapped[UUID] = immutable(
@@ -711,7 +709,7 @@ class UserNotification(
 
     #: User being notified (backref defined below, outside the model)
     user: Mapped[User] = with_roles(
-        immutable(sa.orm.relationship(User)), read={'owner'}, grants={'owner'}
+        sa.orm.relationship(User), read={'owner'}, grants={'owner'}
     )
 
     #: Random eventid, shared with the Notification instance
@@ -720,16 +718,13 @@ class UserNotification(
         read={'owner'},
     )
 
-    #: Id of notification that this user received
-    notification_id: Mapped[UUID] = immutable(
-        sa.Column(UUIDType(binary=False), nullable=False)
-    )  # fkey in __table_args__ below
+    #: Id of notification that this user received (fkey in __table_args__ below)
+    notification_id: Mapped[UUID] = sa.Column(UUIDType(binary=False), nullable=False)
+
     #: Notification that this user received
     notification = with_roles(
-        immutable(
-            sa.orm.relationship(
-                Notification, backref=sa.orm.backref('recipients', lazy='dynamic')
-            )
+        sa.orm.relationship(
+            Notification, backref=sa.orm.backref('recipients', lazy='dynamic')
         ),
         read={'owner'},
     )
@@ -1137,17 +1132,15 @@ class NotificationPreferences(BaseMixin, db.Model):  # type: ignore[name-defined
     __allow_unmapped__ = True
 
     #: Id of user whose preferences are represented here
-    user_id = immutable(
-        sa.Column(
-            sa.Integer,
-            sa.ForeignKey('user.id', ondelete='CASCADE'),
-            nullable=False,
-            index=True,
-        )
+    user_id = sa.Column(
+        sa.Integer,
+        sa.ForeignKey('user.id', ondelete='CASCADE'),
+        nullable=False,
+        index=True,
     )
     #: User whose preferences are represented here
     user = with_roles(
-        immutable(sa.orm.relationship(User, back_populates='notification_preferences')),
+        sa.orm.relationship(User, back_populates='notification_preferences'),
         read={'owner'},
         grants={'owner'},
     )

--- a/funnel/models/organization_membership.py
+++ b/funnel/models/organization_membership.py
@@ -83,23 +83,19 @@ class OrganizationMembership(
     }
 
     #: Organization that this membership is being granted on
-    organization_id = immutable(
-        sa.Column(
-            sa.Integer,
-            sa.ForeignKey('organization.id', ondelete='CASCADE'),
-            nullable=False,
-        )
+    organization_id = sa.Column(
+        sa.Integer,
+        sa.ForeignKey('organization.id', ondelete='CASCADE'),
+        nullable=False,
     )
-    organization = immutable(
-        with_roles(
-            sa.orm.relationship(
-                Organization,
-                backref=sa.orm.backref(
-                    'memberships', lazy='dynamic', cascade='all', passive_deletes=True
-                ),
+    organization = with_roles(
+        sa.orm.relationship(
+            Organization,
+            backref=sa.orm.backref(
+                'memberships', lazy='dynamic', cascade='all', passive_deletes=True
             ),
-            grants_via={None: {'admin': 'profile_admin', 'owner': 'profile_owner'}},
-        )
+        ),
+        grants_via={None: {'admin': 'profile_admin', 'owner': 'profile_owner'}},
     )
     parent_id: Mapped[int] = sa.orm.synonym('organization_id')
     parent_id_column = 'organization_id'

--- a/funnel/models/project_membership.py
+++ b/funnel/models/project_membership.py
@@ -7,7 +7,7 @@ from uuid import UUID  # noqa: F401 # pylint: disable=unused-import
 
 from werkzeug.utils import cached_property
 
-from coaster.sqlalchemy import DynamicAssociationProxy, immutable, with_roles
+from coaster.sqlalchemy import DynamicAssociationProxy, with_roles
 
 from . import Mapped, db, declared_attr, sa
 from .helpers import reopen
@@ -103,24 +103,20 @@ class ProjectCrewMembership(
         },
     }
 
-    project_id: Mapped[int] = immutable(
-        sa.Column(
-            sa.Integer, sa.ForeignKey('project.id', ondelete='CASCADE'), nullable=False
-        )
+    project_id: Mapped[int] = sa.Column(
+        sa.Integer, sa.ForeignKey('project.id', ondelete='CASCADE'), nullable=False
     )
-    project: Mapped[Project] = immutable(
-        with_roles(
-            sa.orm.relationship(
-                Project,
-                backref=sa.orm.backref(
-                    'crew_memberships',
-                    lazy='dynamic',
-                    cascade='all',
-                    passive_deletes=True,
-                ),
+    project: Mapped[Project] = with_roles(
+        sa.orm.relationship(
+            Project,
+            backref=sa.orm.backref(
+                'crew_memberships',
+                lazy='dynamic',
+                cascade='all',
+                passive_deletes=True,
             ),
-            grants_via={None: project_membership_role_map},
-        )
+        ),
+        grants_via={None: project_membership_role_map},
     )
     parent_id: Mapped[int] = sa.orm.synonym('project_id')
     parent_id_column = 'project_id'

--- a/funnel/models/proposal_membership.py
+++ b/funnel/models/proposal_membership.py
@@ -81,30 +81,27 @@ class ProposalMembership(  # type: ignore[misc]
 
     revoke_on_subject_delete = False
 
-    proposal_id: Mapped[int] = immutable(
-        with_roles(
-            sa.Column(
-                sa.Integer,
-                sa.ForeignKey('proposal.id', ondelete='CASCADE'),
-                nullable=False,
-            ),
-            read={'subject', 'editor'},
+    proposal_id: Mapped[int] = with_roles(
+        sa.Column(
+            sa.Integer,
+            sa.ForeignKey('proposal.id', ondelete='CASCADE'),
+            nullable=False,
         ),
+        read={'subject', 'editor'},
     )
-    proposal: Mapped[Proposal] = immutable(
-        with_roles(
-            sa.orm.relationship(
-                Proposal,
-                backref=sa.orm.backref(
-                    'all_memberships',
-                    lazy='dynamic',
-                    cascade='all',
-                    passive_deletes=True,
-                ),
+
+    proposal: Mapped[Proposal] = with_roles(
+        sa.orm.relationship(
+            Proposal,
+            backref=sa.orm.backref(
+                'all_memberships',
+                lazy='dynamic',
+                cascade='all',
+                passive_deletes=True,
             ),
-            read={'subject', 'editor'},
-            grants_via={None: {'editor'}},
         ),
+        read={'subject', 'editor'},
+        grants_via={None: {'editor'}},
     )
     parent_id: Mapped[int] = sa.orm.synonym('proposal_id')
     parent_id_column = 'proposal_id'

--- a/funnel/models/sponsor_membership.py
+++ b/funnel/models/sponsor_membership.py
@@ -86,21 +86,17 @@ class ProjectSponsorMembership(  # type: ignore[misc]
 
     revoke_on_subject_delete = False
 
-    project_id: Mapped[int] = immutable(
-        sa.Column(
-            sa.Integer, sa.ForeignKey('project.id', ondelete='CASCADE'), nullable=False
-        )
+    project_id: Mapped[int] = sa.Column(
+        sa.Integer, sa.ForeignKey('project.id', ondelete='CASCADE'), nullable=False
     )
-    project: Mapped[Project] = immutable(
-        sa.orm.relationship(
-            Project,
-            backref=sa.orm.backref(
-                'all_sponsor_memberships',
-                lazy='dynamic',
-                cascade='all',
-                passive_deletes=True,
-            ),
-        )
+    project: Mapped[Project] = sa.orm.relationship(
+        Project,
+        backref=sa.orm.backref(
+            'all_sponsor_memberships',
+            lazy='dynamic',
+            cascade='all',
+            passive_deletes=True,
+        ),
     )
     parent_id: Mapped[int] = sa.orm.synonym('project_id')
     parent_id_column = 'project_id'
@@ -219,21 +215,17 @@ class ProposalSponsorMembership(  # type: ignore[misc]
 
     revoke_on_subject_delete = False
 
-    proposal_id: Mapped[int] = immutable(
-        sa.Column(
-            sa.Integer, sa.ForeignKey('proposal.id', ondelete='CASCADE'), nullable=False
-        )
+    proposal_id: Mapped[int] = sa.Column(
+        sa.Integer, sa.ForeignKey('proposal.id', ondelete='CASCADE'), nullable=False
     )
-    proposal: Mapped[Proposal] = immutable(
-        sa.orm.relationship(
-            Proposal,
-            backref=sa.orm.backref(
-                'all_sponsor_memberships',
-                lazy='dynamic',
-                cascade='all',
-                passive_deletes=True,
-            ),
-        )
+    proposal: Mapped[Proposal] = sa.orm.relationship(
+        Proposal,
+        backref=sa.orm.backref(
+            'all_sponsor_memberships',
+            lazy='dynamic',
+            cascade='all',
+            passive_deletes=True,
+        ),
     )
     parent_id: Mapped[int] = sa.orm.synonym('proposal_id')
     parent_id_column = 'proposal_id'

--- a/tests/unit/models/test_notification.py
+++ b/tests/unit/models/test_notification.py
@@ -294,14 +294,9 @@ def test_user_notification_preferences(notification_types, db_session) -> None:
     )
 
     # There cannot be two sets of preferences for the same notification type
-    # For this test we use `user_id` instead of `user` because SQLAlchemy 2.0 has a
-    # test-breaking change: given `user`, it will populate `user_id` during the commit,
-    # and upon having an `IntegrityError` will attempt to reset `user_id` to None,
-    # thereby triggering the column's immutable annotation and causing a new error.
     db_session.add(
         models.NotificationPreferences(
-            notification_type=nt.TestNewUpdateNotification.pref_type,
-            user_id=user.id,
+            notification_type=nt.TestNewUpdateNotification.pref_type, user=user
         )
     )
     with pytest.raises(IntegrityError):


### PR DESCRIPTION
SQLAlchemy 2.0 unsets automatically-set attributes during a transaction rollback on a foreign key/relationship pair. This is messing with the immutable annotation, so it is temporarily removed pending further investigation.