### PR TITLE
Remove enabling navigator.virtualKeyboard.overlaysContent

### DIFF
--- a/funnel/assets/sass/components/_header.scss
+++ b/funnel/assets/sass/components/_header.scss
@@ -7,7 +7,7 @@
   position: fixed;
   left: 0;
   right: 0;
-  bottom: calc(env(keyboard-inset-height, 0px));
+  bottom: 0;
 
   .header__nav {
     height: $mui-header-height;
@@ -42,7 +42,7 @@
 
         .search-form {
           position: fixed;
-          bottom: calc(env(keyboard-inset-height, 0px) + #{$mui-header-height});
+          bottom: $mui-header-height;
           width: 100%;
           left: 0;
           box-shadow: 0 1px 3px rgba(158, 158, 158, 0.12),

--- a/funnel/templates/layout.html.jinja2
+++ b/funnel/templates/layout.html.jinja2
@@ -340,11 +340,6 @@
     {% endif %}
     window.Hasgeek.Config.shorturlApi = {{ url_for('create_shortlink')|tojson }};
     window.Hasgeek.Config.markNotificationReadUrl = {{ url_for('notification_mark_read', eventid_b58='eventid_b58')|tojson }};
-
-    // To calculate height of keyboard to position keyboard switcher above it
-    if ("virtualKeyboard" in navigator) {
-      navigator.virtualKeyboard.overlaysContent = true;
-    }
 </script>
 <script src="{{ built_asset('app.js') }}" type="text/javascript"></script>
 {% block serviceworker %}


### PR DESCRIPTION
Removing navigator.virtualKeyboard.overlaysContent since it is not supported in all browsers and breaks for elements inside a form without position fixed