### PR TITLE
Fix Babel processing in two places

### DIFF
--- a/funnel/models/session.py
+++ b/funnel/models/session.py
@@ -7,10 +7,9 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, Optional, Type
 from uuid import UUID  # noqa: F401 # pylint: disable=unused-import
 
-from flask_babel import get_locale
+from flask_babel import format_date, get_locale
 from werkzeug.utils import cached_property
 
-from babel.dates import format_date
 from isoweek import Week
 
 from baseframe import localize_timezone
@@ -643,9 +642,7 @@ class __Project:
                         weeks[weekid]['upcoming'] = True
                     weeks[weekid]['dates'][wdate] += session_count
                     if 'month' not in weeks[weekid]:
-                        weeks[weekid]['month'] = format_date(
-                            wdate, 'MMM', locale=get_locale()
-                        )
+                        weeks[weekid]['month'] = format_date(wdate, 'MMM')
         # Extract sorted weeks as a list
         weeks_list = [v for k, v in sorted(weeks.items())]
 
@@ -656,7 +653,7 @@ class __Project:
             week['dates'] = [
                 {
                     'isoformat': date.isoformat(),
-                    'day': format_date(date, 'd', get_locale()),
+                    'day': format_date(date, 'd'),
                     'count': count,
                     'day_start_at': (
                         session_dates_dict[date]['day_start_at']
@@ -679,10 +676,7 @@ class __Project:
             'locale': get_locale(),
             'weeks': weeks_list,
             'today': now.date().isoformat(),
-            'days': [
-                format_date(day, 'EEE', locale=get_locale())
-                for day in Week.thisweek().days()
-            ],
+            'days': [format_date(day, 'EEE') for day in Week.thisweek().days()],
         }
 
     @with_roles(read={'all'}, datasets={'primary', 'without_parent'})

--- a/funnel/views/project.py
+++ b/funnel/views/project.py
@@ -5,7 +5,8 @@ from types import SimpleNamespace
 import csv
 import io
 
-from flask import Response, abort, current_app, flash, render_template, request
+from flask import Markup, Response, abort, current_app, flash, render_template, request
+from flask_babel import format_number
 
 from baseframe import _, __, forms
 from baseframe.forms import render_delete_sqla, render_form, render_message
@@ -77,64 +78,64 @@ registration_count_messages = [
     ),
     CountWords(
         __("Two registrations so far"),
-        __("You & one other"),
+        __("You &amp; one other"),
         __("Two followers so far"),
-        __("You & one other"),
+        __("You &amp; one other"),
     ),
     CountWords(
         __("Three registrations so far"),
-        __("You & two others"),
+        __("You &amp; two others"),
         __("Three followers so far"),
-        __("You & two others"),
+        __("You &amp; two others"),
     ),
     CountWords(
         __("Four registrations so far"),
-        __("You & three others"),
+        __("You &amp; three others"),
         __("Four followers so far"),
-        __("You & three others"),
+        __("You &amp; three others"),
     ),
     CountWords(
         __("Five registrations so far"),
-        __("You & four others"),
+        __("You &amp; four others"),
         __("Five followers so far"),
-        __("You & four others"),
+        __("You &amp; four others"),
     ),
     CountWords(
         __("Six registrations so far"),
-        __("You & five others"),
+        __("You &amp; five others"),
         __("Six followers so far"),
-        __("You & five others"),
+        __("You &amp; five others"),
     ),
     CountWords(
         __("Seven registrations so far"),
-        __("You & six others"),
+        __("You &amp; six others"),
         __("Seven followers so far"),
-        __("You & six others"),
+        __("You &amp; six others"),
     ),
     CountWords(
         __("Eight registrations so far"),
-        __("You & seven others"),
+        __("You &amp; seven others"),
         __("Eight followers so far"),
-        __("You & seven others"),
+        __("You &amp; seven others"),
     ),
     CountWords(
         __("Nine registrations so far"),
-        __("You & eight others"),
+        __("You &amp; eight others"),
         __("Nine followers so far"),
-        __("You & eight others"),
+        __("You &amp; eight others"),
     ),
     CountWords(
         __("Ten registrations so far"),
-        __("You & nine others"),
+        __("You &amp; nine others"),
         __("Ten followers so far"),
-        __("You & nine others"),
+        __("You &amp; nine others"),
     ),
 ]
 numeric_count = CountWords(
     __("{num} registrations so far"),
-    __("You & {num} others"),
+    __("You &amp; {num} others"),
     __("{num} followers so far"),
-    __("You & {num} others"),
+    __("You &amp; {num} others"),
 )
 
 
@@ -148,12 +149,12 @@ def get_registration_text(count: int, registered=False, follow_mode=False) -> st
             return registration_count_messages[count].following
         return registration_count_messages[count].not_following
     if registered and not follow_mode:
-        return numeric_count.registered.format(num=count - 1)
+        return Markup(numeric_count.registered.format(num=format_number(count - 1)))
     if not registered and not follow_mode:
-        return numeric_count.unregistered.format(num=count)
+        return Markup(numeric_count.unregistered.format(num=format_number(count)))
     if registered and follow_mode:
-        return numeric_count.following.format(num=count - 1)
-    return numeric_count.not_following.format(num=count)
+        return Markup(numeric_count.following.format(num=format_number(count - 1)))
+    return Markup(numeric_count.not_following.format(num=format_number(count)))
 
 
 @Project.features('rsvp')

--- a/tests/unit/views/project_test.py
+++ b/tests/unit/views/project_test.py
@@ -3,7 +3,7 @@
 from funnel.views.project import get_registration_text
 
 
-def test_registration_text() -> None:
+def test_registration_text(app_context) -> None:
     assert get_registration_text(count=0, registered=False).startswith("Be the first")
     assert get_registration_text(count=1, registered=True).startswith(
         "You are the first"
@@ -14,4 +14,4 @@ def test_registration_text() -> None:
     assert get_registration_text(count=5, registered=False).startswith("Five")
     # More than ten
     assert get_registration_text(count=33, registered=True).startswith("You &amp; 32")
-    assert get_registration_text(count=3209, registered=False).startswith("3209")
+    assert get_registration_text(count=3209, registered=False).startswith("3,209")


### PR DESCRIPTION
Lazy strings are required to be HTML-escaped at source and have a `__html__` attr that marks them as safe, but turns out `lazystr.format()` produces a plain `str` and has to be recast as Markup again.

This idiocy was previously brought up at https://github.com/python-babel/flask-babel/issues/121 and dismissed as expected behaviour.

Flask-Babel has wrappers for Babel functions that automatically supply locale, so this PR switches over.