### PR TITLE
Upgrade pip-audit in pre-commit and python packages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
       - id: pip-compile-multi-verify
         files: ^requirements/.*\.(in|txt)$
   - repo: https://github.com/pypa/pip-audit
-    rev: v2.5.3
+    rev: v2.5.4
     hooks:
       - id: pip-audit
         args: [

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -13,11 +13,15 @@
     #   baseframe
 aiohttp==3.8.4
     # via
+    #   aiohttp-retry
     #   geoip2
     #   tuspy
+    #   twilio
+aiohttp-retry==2.8.3
+    # via twilio
 aiosignal==1.3.1
     # via aiohttp
-alembic==1.10.2
+alembic==1.10.3
     # via
     #   -r requirements/base.in
     #   flask-migrate
@@ -33,7 +37,9 @@ async-timeout==4.0.2
     # via
     #   aiohttp
     #   redis
-attrs==22.2.0
+asyncio==3.4.3
+    # via twilio
+attrs==23.1.0
     # via aiohttp
 babel==2.12.1
     # via
@@ -51,7 +57,7 @@ bleach==6.0.0
     # via
     #   baseframe
     #   coaster
-blinker==1.5
+blinker==1.6.2
     # via
     #   -r requirements/base.in
     #   coaster
@@ -81,9 +87,9 @@ click==8.1.3
     #   flask
     #   nltk
     #   rq
-crontab==1.0.0
+crontab==1.0.1
     # via rq-scheduler
-cryptography==40.0.1
+cryptography==40.0.2
     # via
     #   -r requirements/base.in
     #   pyopenssl
@@ -102,7 +108,7 @@ dnspython==2.3.0
     #   pyisemail
 emoji==2.2.0
     # via baseframe
-filelock==3.10.7
+filelock==3.11.0
     # via tldextract
 flask==2.2.3
     # via
@@ -126,7 +132,7 @@ flask-assets==2.0
     #   -r requirements/base.in
     #   baseframe
     #   coaster
-flask-babel==3.0.1
+flask-babel==3.1.0
     # via
     #   -r requirements/base.in
     #   baseframe
@@ -173,7 +179,9 @@ geoip2==4.6.0
 grapheme==0.6.0
     # via baseframe
 greenlet==2.0.2
-    # via -r requirements/base.in
+    # via
+    #   -r requirements/base.in
+    #   sqlalchemy
 html2text==2020.1.16
     # via -r requirements/base.in
 html5lib==1.1
@@ -184,7 +192,7 @@ httplib2==0.22.0
     # via
     #   oauth2
     #   oauth2client
-icalendar==5.0.4
+icalendar==5.0.5
     # via -r requirements/base.in
 idna==3.4
     # via
@@ -192,10 +200,6 @@ idna==3.4
     #   requests
     #   tldextract
     #   yarl
-importlib-metadata==6.1.0
-    # via
-    #   flask
-    #   markdown
 isoweek==1.3.3
     # via coaster
 itsdangerous==2.0.1
@@ -270,17 +274,17 @@ oauthlib==3.2.2
     #   tweepy
 orderedmultidict==1.0.1
     # via furl
-packaging==23.0
+packaging==23.1
     # via marshmallow
 passlib==1.7.4
     # via -r requirements/base.in
-phonenumbers==8.13.8
+phonenumbers==8.13.9
     # via -r requirements/base.in
 premailer==3.10.0
     # via -r requirements/base.in
 progressbar2==4.2.0
     # via -r requirements/base.in
-psycopg2-binary==2.9.5
+psycopg2-binary==2.9.6
     # via -r requirements/base.in
 pyasn1==0.4.8
     # via
@@ -299,7 +303,7 @@ pycparser==2.21
     # via cffi
 pyexecjs==1.5.1
     # via coaster
-pygments==2.14.0
+pygments==2.15.0
     # via
     #   -r requirements/base.in
     #   rich
@@ -310,7 +314,7 @@ pyisemail==2.0.1
     #   mxsniff
 pyjwt==2.6.0
     # via twilio
-pymdown-extensions==9.10
+pymdown-extensions==9.11
     # via coaster
 pyopenssl==23.1.1
     # via
@@ -334,7 +338,7 @@ python-dotenv==0.21.1
     # via -r requirements/base.in
 python-utils==3.5.2
     # via progressbar2
-pytz==2022.7.1
+pytz==2023.3
     # via
     #   -r requirements/base.in
     #   baseframe
@@ -350,7 +354,7 @@ pyyaml==6.0
     #   pymdown-extensions
 qrcode==7.4.2
     # via -r requirements/base.in
-redis==4.5.3
+redis==4.5.4
     # via
     #   baseframe
     #   flask-redis
@@ -384,7 +388,7 @@ requests-mock==1.10.0
     # via baseframe
 requests-oauthlib==1.3.1
     # via tweepy
-rich==13.3.3
+rich==13.3.4
     # via -r requirements/base.in
 rq==1.13.0
     # via
@@ -403,7 +407,7 @@ semantic-version==2.10.0
     # via
     #   baseframe
     #   coaster
-sentry-sdk==1.18.0
+sentry-sdk==1.19.1
     # via baseframe
 six==1.16.0
     # via
@@ -420,7 +424,7 @@ six==1.16.0
     #   requests-mock
     #   sqlalchemy-json
     #   tuspy
-sqlalchemy==2.0.7
+sqlalchemy==2.0.9
     # via
     #   -r requirements/base.in
     #   alembic
@@ -431,7 +435,7 @@ sqlalchemy==2.0.7
     #   wtforms-sqlalchemy
 sqlalchemy-json==0.5.0
     # via -r requirements/base.in
-sqlalchemy-utils==0.40.0
+sqlalchemy-utils==0.41.0
     # via
     #   -r requirements/base.in
     #   coaster
@@ -451,7 +455,7 @@ tuspy==1.0.0
     # via pyvimeo
 tweepy==4.13.0
     # via -r requirements/base.in
-twilio==7.17.0
+twilio==8.0.0
     # via -r requirements/base.in
 typing-extensions==4.5.0
     # via
@@ -505,8 +509,6 @@ wtforms-sqlalchemy==0.3
     # via baseframe
 yarl==1.8.2
     # via aiohttp
-zipp==3.15.0
-    # via importlib-metadata
 zxcvbn==4.4.28
     # via -r requirements/base.in
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,11 +12,11 @@
     # via
     #   -r requirements/base.in
     #   baseframe
-astroid==2.15.1
+astroid==2.15.3
     # via pylint
 bandit==1.7.5
     # via -r requirements/dev.in
-black==23.1.0
+black==23.3.0
     # via -r requirements/dev.in
 build==0.10.0
     # via pip-tools
@@ -48,7 +48,7 @@ flake8-bugbear==23.3.23
     # via -r requirements/dev.in
 flake8-builtins==2.1.0
     # via -r requirements/dev.in
-flake8-comprehensions==3.11.1
+flake8-comprehensions==3.12.0
     # via -r requirements/dev.in
 flake8-docstrings==1.7.0
     # via -r requirements/dev.in
@@ -87,7 +87,7 @@ mccabe==0.7.0
     # via
     #   flake8
     #   pylint
-mypy==1.1.1
+mypy==1.2.0
     # via -r requirements/dev.in
 nodeenv==1.7.0
     # via pre-commit
@@ -99,7 +99,7 @@ pep8-naming==0.13.3
     # via -r requirements/dev.in
 pip-compile-multi==2.6.2
     # via -r requirements/dev.in
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via pip-compile-multi
 platformdirs==3.2.0
     # via
@@ -108,7 +108,7 @@ platformdirs==3.2.0
     #   virtualenv
 po2json==0.2.2
     # via -r requirements/dev.in
-pre-commit==3.2.1
+pre-commit==3.2.2
     # via -r requirements/dev.in
 pycodestyle==2.10.0
     # via
@@ -118,7 +118,7 @@ pydocstyle==6.3.0
     # via flake8-docstrings
 pyflakes==3.0.1
     # via flake8
-pylint==2.17.1
+pylint==2.17.2
     # via
     #   -r requirements/dev.in
     #   pylint-pytest
@@ -162,23 +162,23 @@ types-maxminddb==1.5.0
     # via
     #   -r requirements/dev.in
     #   types-geoip2
-types-pyopenssl==23.1.0.1
+types-pyopenssl==23.1.0.2
     # via types-redis
-types-python-dateutil==2.8.19.11
+types-python-dateutil==2.8.19.12
     # via -r requirements/dev.in
-types-pytz==2023.2.0.1
+types-pytz==2023.3.0.0
     # via -r requirements/dev.in
-types-redis==4.5.3.0
+types-redis==4.5.4.1
     # via -r requirements/dev.in
-types-requests==2.28.11.16
+types-requests==2.28.11.17
     # via -r requirements/dev.in
-types-setuptools==67.6.0.5
+types-setuptools==67.6.0.7
     # via -r requirements/dev.in
-types-six==1.16.21.7
+types-six==1.16.21.8
     # via -r requirements/dev.in
-types-toml==0.10.8.5
+types-toml==0.10.8.6
     # via -r requirements/dev.in
-types-urllib3==1.26.25.9
+types-urllib3==1.26.25.10
     # via types-requests
 types-werkzeug==1.0.9
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -14,7 +14,7 @@
     #   baseframe
 async-generator==1.10
     # via trio
-beautifulsoup4==4.12.0
+beautifulsoup4==4.12.2
     # via -r requirements/test.in
 colorama==0.4.6
     # via -r requirements/test.in
@@ -28,10 +28,7 @@ coveralls==3.3.1
 docopt==0.6.2
     # via coveralls
 exceptiongroup==1.1.1
-    # via
-    #   pytest
-    #   trio
-    #   trio-websocket
+    # via trio-websocket
 h11==0.14.0
     # via wsproto
 iniconfig==2.0.0
@@ -48,7 +45,7 @@ pluggy==1.0.0
     # via pytest
 py==1.11.0
     # via pytest-html
-pytest==7.2.2
+pytest==7.3.1
     # via
     #   -r requirements/test.in
     #   pytest-base-url
@@ -96,10 +93,6 @@ sttable==0.0.1
     # via -r requirements/test.in
 tenacity==8.2.2
     # via pytest-selenium
-tomli==2.0.1
-    # via
-    #   coverage
-    #   pytest
 tomlkit==0.11.7
     # via -r requirements/test.in
 trio==0.22.0


### PR DESCRIPTION
Upgrade python packages. pip-tools 6.12.3 was not compatible with latest version of pip(23.1).Update pip-audit version to 2.5.4 to overcome https://github.com/pypa/pip-audit/issues/552