### PR TITLE
Grant project_* roles within Project too, and drop transition validator

### DIFF
--- a/funnel/models/notification.py
+++ b/funnel/models/notification.py
@@ -763,7 +763,7 @@ class UserNotification(
     notification_id: Mapped[UUID] = sa.orm.mapped_column(sa.Uuid, nullable=False)
 
     #: Notification that this user received
-    notification = with_roles(
+    notification: Mapped[Notification] = with_roles(
         sa.orm.relationship(
             Notification, backref=sa.orm.backref('recipients', lazy='dynamic')
         ),

--- a/funnel/models/notification.py
+++ b/funnel/models/notification.py
@@ -906,21 +906,18 @@ class UserNotification(
         """Whether this notification has been marked as revoked."""
         return self.revoked_at is not None
 
-    @is_revoked.setter  # type: ignore[no-redef]
-    def is_revoked(self, value: bool) -> None:
+    @is_revoked.inplace.setter
+    def _is_revoked_setter(self, value: bool) -> None:
         if value:
             if not self.revoked_at:
                 self.revoked_at = sa.func.utcnow()
         else:
             self.revoked_at = None
 
-    # PyLint complains because the hybrid property doesn't resemble the mixin's property
-    # pylint: disable=no-self-argument,arguments-renamed,invalid-overridden-method
-    @is_revoked.expression  # type: ignore[no-redef]
-    def is_revoked(cls):
+    @is_revoked.inplace.expression
+    @classmethod
+    def _is_revoked_expression(cls):
         return cls.revoked_at.isnot(None)
-
-    # pylint: enable=no-self-argument,arguments-renamed,invalid-overridden-method
 
     with_roles(is_revoked, rw={'owner'})
 

--- a/funnel/models/profile.py
+++ b/funnel/models/profile.py
@@ -259,6 +259,16 @@ class Profile(
         'ACTIVE_AND_PUBLIC', state.PUBLIC, lambda profile: profile.is_active
     )
 
+    state.add_conditional_state(
+        'PUBLISHABLE',
+        state.NOT_PUBLIC,
+        lambda profile: (
+            profile.reserved is False
+            and profile.is_active
+            and (profile.user is None or profile.user.features.not_likely_throwaway)
+        ),
+    )
+
     def __repr__(self) -> str:
         """Represent :class:`Profile` as a string."""
         return f'<Profile "{self.name}">'
@@ -479,14 +489,9 @@ class Profile(
 
     @with_roles(call={'owner'})
     @state.transition(
-        state.NOT_PUBLIC,
+        state.PUBLISHABLE,
         state.PUBLIC,
         title=__("Make public"),
-        if_=lambda profile: (
-            profile.reserved is False
-            and profile.is_active
-            and (profile.user is None or profile.user.features.not_likely_throwaway)
-        ),
     )
     def make_public(self) -> None:
         """Make an account public if it is eligible."""

--- a/funnel/models/project_membership.py
+++ b/funnel/models/project_membership.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Dict, Set, Union
+from typing import Set
 from uuid import UUID  # noqa: F401 # pylint: disable=unused-import
 
 from werkzeug.utils import cached_property
@@ -18,20 +18,18 @@ from .user import User
 __all__ = ['ProjectCrewMembership', 'project_child_role_map']
 
 #: Roles in a project and their remapped names in objects attached to a project
-project_child_role_map: Dict[str, str] = {
-    'editor': 'project_editor',
-    'promoter': 'project_promoter',
-    'usher': 'project_usher',
-    'crew': 'project_crew',
-    'participant': 'project_participant',
-    'reader': 'reader',
+project_child_role_map = {
+    'editor': {'project_editor'},
+    'promoter': {'project_promoter'},
+    'usher': {'project_usher'},
+    'crew': {'project_crew'},
+    'participant': {'project_participant'},
+    'reader': {'reader'},
 }
 
 #: ProjectCrewMembership maps project's `profile_admin` role to membership's `editor`
 #: role in addition to the recurring role grant map
-project_membership_role_map: Dict[str, Union[str, Set[str]]] = {
-    'profile_admin': {'profile_admin', 'editor'}
-}
+project_membership_role_map = {'profile_admin': {'profile_admin', 'editor'}}
 project_membership_role_map.update(project_child_role_map)
 
 
@@ -195,7 +193,15 @@ class __Project:
             ),
             viewonly=True,
         ),
-        grants_via={'user': {'editor', 'promoter', 'usher', 'participant', 'crew'}},
+        grants_via={
+            'user': {
+                'editor': {'editor', 'project_editor'},
+                'promoter': {'promoter', 'project_promoter'},
+                'usher': {'usher', 'project_usher'},
+                'participant': {'participant', 'project_participant'},
+                'crew': {'crew', 'project_crew'},
+            }
+        },
     )
 
     active_editor_memberships = sa.orm.relationship(

--- a/funnel/models/rsvp.py
+++ b/funnel/models/rsvp.py
@@ -200,7 +200,9 @@ class __Project:
     def active_rsvps(self):
         return self.rsvps.join(User).filter(Rsvp.state.YES, User.state.ACTIVE)
 
-    with_roles(active_rsvps, grants_via={Rsvp.user: {'participant'}})
+    with_roles(
+        active_rsvps, grants_via={Rsvp.user: {'participant', 'project_participant'}}
+    )
 
     @overload
     def rsvp_for(self, user: User, create: Literal[True]) -> Rsvp:

--- a/funnel/models/venue.py
+++ b/funnel/models/venue.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import List
 from uuid import UUID  # noqa: F401 # pylint: disable=unused-import
+import itertools
 
 from sqlalchemy.ext.orderinglist import ordering_list
 
@@ -117,7 +118,7 @@ class VenueRoom(UuidMixin, BaseScopedNameMixin, db.Model):  # type: ignore[name-
     venue: Mapped[Venue] = with_roles(
         sa.orm.relationship(Venue, back_populates='rooms'),
         # Since Venue already remaps Project roles, we just want the remapped role names
-        grants_via={None: set(project_child_role_map.values())},
+        grants_via={None: set(itertools.chain(*project_child_role_map.values()))},
     )
     parent: Mapped[Venue] = sa.orm.synonym('venue')
     description = MarkdownCompositeBasic.create(

--- a/funnel/templates/notifications/project_starting_email.html.jinja2
+++ b/funnel/templates/notifications/project_starting_email.html.jinja2
@@ -3,7 +3,7 @@
 {%- block content -%}
 
 <p>
-  {%- trans project=view.project.joined_title, start_time=view.session.start_at_localized|time -%}
+  {%- trans project=view.project.joined_title, start_time=(view.session or view.project).start_at_localized|time -%}
     <b>{{ project }}</b> starts at {{ start_time }}
   {%- endtrans -%}
 </p>

--- a/funnel/templates/notifications/project_starting_web.html.jinja2
+++ b/funnel/templates/notifications/project_starting_web.html.jinja2
@@ -7,7 +7,7 @@
 
 {%- block content -%}
   <p>
-    {% trans project=view.project.joined_title, url=view.project.url_for(), start_time=view.session.start_at_localized|time -%}
+    {% trans project=view.project.joined_title, url=view.project.url_for(), start_time=(view.session or view.project).start_at_localized|time -%}
       <a href="{{ url }}">{{ project }}</a> starts at {{ start_time }}
     {%- endtrans %}
   </p>

--- a/funnel/views/api/resource.py
+++ b/funnel/views/api/resource.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any, Container, Dict, List, Optional, cast
+from typing import Any, Container, Dict, List, Optional, Union, cast
 
 from flask import abort, jsonify, render_template, request
+from typing_extensions import Literal
 
 from baseframe import __
 from coaster.auth import current_auth
@@ -126,11 +127,15 @@ def resource_error(error, description=None, uri=None) -> Response:
     return response
 
 
-def api_result(status, _jsonp=False, **params) -> Response:
+def api_result(
+    status: Union[Literal['ok'], Literal['error'], Literal[200], Literal[201]],
+    _jsonp: bool = False,
+    **params: Any,
+) -> Response:
     """Return an API result."""
     status_code = 200
     if status in (200, 201):
-        status_code = status
+        status_code = status  # type: ignore[assignment]
         status = 'ok'
     elif status == 'error':
         status_code = 422

--- a/funnel/views/notifications/project_starting_notification.py
+++ b/funnel/views/notifications/project_starting_notification.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Optional
+
 from flask import render_template
 
 from baseframe import _, __
@@ -18,7 +20,7 @@ class RenderProjectStartingNotification(RenderNotification):
     """Notify crew and participants when the project's schedule is about to start."""
 
     project: Project
-    session: Session
+    session: Optional[Session]
     aliases = {'document': 'project', 'fragment': 'session'}
     emoji_prefix = "⏰ "
     reason = __("You are receiving this because you have registered for this project")
@@ -31,7 +33,7 @@ class RenderProjectStartingNotification(RenderNotification):
     def email_subject(self):
         return self.emoji_prefix + _("{project} starts at {time}").format(
             project=self.project.joined_title,
-            time=time_filter(self.session.start_at_localized),
+            time=time_filter((self.session or self.project).start_at_localized),
         )
 
     def email_content(self):
@@ -43,7 +45,7 @@ class RenderProjectStartingNotification(RenderNotification):
         return OneLineTemplate(
             text1=_("{project} starts at {time}.").format(
                 project=self.project.joined_title,
-                time=time_filter(self.session.start_at_localized),
+                time=time_filter((self.session or self.project).start_at_localized),
             ),
             url=shortlink(
                 self.project.url_for(_external=True, **self.tracking_tags('sms')),


### PR DESCRIPTION
ProjectStartingNotification depends on the `project_crew` and `project_participant` roles, which it expects to find in the Session model, but which are not granted in the project itself. The notification is dispatched on projects with no session, causing a discovery of 0 users.