### PR TITLE
Gracefully handle email recipient rejection by the SMTP server

### DIFF
--- a/devserver.py
+++ b/devserver.py
@@ -7,6 +7,8 @@ import sys
 from flask.cli import load_dotenv
 from werkzeug import run_simple
 
+from coaster.utils import getbool
+
 if __name__ == '__main__':
     load_dotenv()
     sys.path.insert(0, os.path.dirname(__file__))
@@ -23,7 +25,10 @@ if __name__ == '__main__':
     background_rq = None
     if os.environ.get('WERKZEUG_RUN_MAIN') == 'true':
         # Only start RQ worker within the reloader environment
-        background_rq = BackgroundWorker(rq.get_worker().work, mock_transports=True)
+        background_rq = BackgroundWorker(
+            rq.get_worker().work,
+            mock_transports=bool(getbool(os.environ.get('MOCK_TRANSPORTS', True))),
+        )
         background_rq.start()
 
     run_simple(

--- a/funnel/proxies/request.py
+++ b/funnel/proxies/request.py
@@ -133,7 +133,7 @@ def _get_request_wants() -> RequestWants:
     return RequestWants()
 
 
-request_wants = LocalProxy(_get_request_wants)
+request_wants: RequestWants = LocalProxy(_get_request_wants)  # type: ignore[assignment]
 
 
 def response_varies(response: ResponseType) -> ResponseType:

--- a/funnel/transports/sms/send.py
+++ b/funnel/transports/sms/send.py
@@ -226,7 +226,7 @@ def send_via_twilio(
             ) from exc
         app.logger.error("Unhandled Twilio error %d: %s", exc.code, exc.msg)
         raise TransportTransactionError(
-            _("Hasgeek was unable to send a message to this phone number")
+            _("Hasgeek cannot send an SMS message to this phone number at this time")
         ) from exc
 
 

--- a/tests/integration/views/login_test.py
+++ b/tests/integration/views/login_test.py
@@ -487,7 +487,7 @@ def test_sms_otp_not_sent(client, csrf_token) -> None:
             ),
         )
 
-    assert "Unable to send an OTP to your phone number" in rv1.data.decode()
+    assert "Hasgeek cannot send" in rv1.data.decode()
     assert "Use password to login" in rv1.data.decode()
 
 
@@ -652,7 +652,7 @@ def test_phone_otp_not_sent(client, csrf_token, phone_number, message_fragment) 
         )
         assert rv1.status_code == 200
         assert rv1.form('form-passwordlogin') is not None
-        assert 'Unable to send an OTP to your phone number' in rv1.data.decode()
+        assert "Hasgeek cannot send" in rv1.data.decode()
         assert message_fragment in rv1.data.decode()
 
 


### PR DESCRIPTION
A string in the form `anything@123` will pass as an email address in the login form, but will be rejected by the SMTP server. This patch recasts the SMTP error as a form validation error.

A test is included. Since Flask-Mailman will silently drop email in a test environment, the test has to mock Flask-Mailman instead of the underlying `smtplib.SMTP.sendmail` where the error is raised in production. 