### PR TITLE
Explicitly require multiprocessing with `fork` on all platforms

### DIFF
--- a/devserver.py
+++ b/devserver.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """Development server with multi-app switching."""
 
+from typing import Any
 import os
 import sys
 
@@ -9,6 +10,14 @@ from werkzeug import run_simple
 
 from coaster.utils import getbool
 
+
+def rq_background_worker(*args: Any, **kwargs: Any) -> Any:
+    """Import, create and start a new RQ worker in the background process."""
+    from funnel import rq  # pylint: disable=import-outside-toplevel
+
+    return rq.get_worker().work(*args, **kwargs)
+
+
 if __name__ == '__main__':
     load_dotenv()
     sys.path.insert(0, os.path.dirname(__file__))
@@ -16,7 +25,6 @@ if __name__ == '__main__':
     os.environ.setdefault('FLASK_DEBUG', '1')
     debug_mode = os.environ['FLASK_DEBUG'].lower() not in {'0', 'false', 'no'}
 
-    from funnel import rq
     from funnel.devtest import BackgroundWorker, devtest_app
 
     # Set debug mode on apps
@@ -26,7 +34,7 @@ if __name__ == '__main__':
     if os.environ.get('WERKZEUG_RUN_MAIN') == 'true':
         # Only start RQ worker within the reloader environment
         background_rq = BackgroundWorker(
-            rq.get_worker().work,
+            rq_background_worker,
             mock_transports=bool(getbool(os.environ.get('MOCK_TRANSPORTS', True))),
         )
         background_rq.start()

--- a/funnel/typing.py
+++ b/funnel/typing.py
@@ -53,13 +53,6 @@ ReturnDecorator = Callable[[WrappedFunc], WrappedFunc]
 #: Return type of the `migrate_user` and `migrate_profile` methods
 OptionalMigratedTables = Optional[Union[List[str], Tuple[str], Set[str]]]
 
-#: JSON and Jinja2 compatible dict type. Cannot be a strict definition because a JSON
-#: structure can have a nested dict with the same rules, requiring recursion. Mypy does
-#: not support recursive types: https://github.com/python/mypy/issues/731. Both JSON
-#: and Jinja2 templates require the dictionary key to be a string.
-RenderWithDict = Dict[str, object]
-
-
 #: Return type for Response objects
 ReturnResponse = Response
 

--- a/funnel/typing.py
+++ b/funnel/typing.py
@@ -8,6 +8,8 @@ from flask.typing import ResponseReturnValue
 from typing_extensions import ParamSpec
 from werkzeug.wrappers import Response  # Base class for Flask Response
 
+from coaster.views import ReturnRenderWith
+
 __all__ = [
     'T',
     'P',
@@ -41,14 +43,7 @@ ResponseTypes = Union[
 ]
 
 #: Return type for Flask views (formats accepted by :func:`~flask.make_response`)
-ReturnView = Union[
-    ResponseTypes,  # Only a response
-    Tuple[ResponseTypes, ResponseStatusCode],  # Response + status code
-    Tuple[ResponseTypes, ResponseHeaders],  # Response + headers
-    Tuple[
-        ResponseTypes, ResponseStatusCode, ResponseHeaders
-    ],  # Response + status code + headers
-]
+ReturnView = ResponseReturnValue
 
 #: Type used for functions and methods wrapped in a decorator
 WrappedFunc = TypeVar('WrappedFunc', bound=Callable)
@@ -64,13 +59,6 @@ OptionalMigratedTables = Optional[Union[List[str], Tuple[str], Set[str]]]
 #: and Jinja2 templates require the dictionary key to be a string.
 RenderWithDict = Dict[str, object]
 
-#: Return type for @render_with decorated views, a subset of Flask view return types
-ReturnRenderWith = Union[
-    RenderWithDict,  # A dict of template variables
-    Tuple[RenderWithDict, int],  # Dict + HTTP status code
-    Tuple[RenderWithDict, int, Dict[str, str]],  # Dict + status code + HTTP headers
-    Response,  # Fully formed Response object
-]
 
 #: Return type for Response objects
 ReturnResponse = Response


### PR DESCRIPTION
**Originally:** Attempt switching away from `fork` to `spawn`. If this works as intended, it will remove the need for `OBJC_DISABLE_INITIALIZE_FORK_SAFETY=yes` on macOS.

**Update:** `spawn` doesn't work at all, so commit to `fork` or nothing.