### PR TITLE
Fix decorator typing and sync isort and ruff config

### DIFF
--- a/devserver.py
+++ b/devserver.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 """Development server with multi-app switching."""
 
-from typing import Any
 import os
 import sys
+from typing import Any
 
 from flask.cli import load_dotenv
 from werkzeug import run_simple

--- a/funnel/__init__.py
+++ b/funnel/__init__.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
-from typing import cast
 import json
 import logging
 import os.path
+from datetime import timedelta
+from typing import cast
 
+import geoip2.database
 from flask import Flask
 from flask_babel import get_locale
 from flask_executor import Executor
@@ -17,11 +18,10 @@ from flask_migrate import Migrate
 from flask_redis import FlaskRedis
 from flask_rq2 import RQ
 from whitenoise import WhiteNoise
-import geoip2.database
 
+import coaster.app
 from baseframe import Bundle, Version, assets, baseframe
 from baseframe.blueprint import THEME_FILES
-import coaster.app
 
 from ._version import __version__
 

--- a/funnel/cli/geodata.py
+++ b/funnel/cli/geodata.py
@@ -2,22 +2,22 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from datetime import datetime
-from decimal import Decimal
-from typing import Optional
-from urllib.parse import urljoin
 import csv
 import os
 import sys
 import time
 import zipfile
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from typing import Optional
+from urllib.parse import urljoin
 
-from flask.cli import AppGroup
-from unidecode import unidecode
 import click
 import requests
 import rich.progress
+from flask.cli import AppGroup
+from unidecode import unidecode
 
 from coaster.utils import getbool
 

--- a/funnel/cli/periodic/stats.py
+++ b/funnel/cli/periodic/stats.py
@@ -2,21 +2,21 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, Optional, Sequence, Union, cast, overload
-from urllib.parse import unquote
-import asyncio
-
-from asgiref.sync import async_to_sync
-from dataclasses_json import DataClassJsonMixin
-from dateutil.relativedelta import relativedelta
-from furl import furl
 from typing_extensions import Literal
+from urllib.parse import unquote
+
 import click
 import httpx
 import pytz
 import telegram
+from asgiref.sync import async_to_sync
+from dataclasses_json import DataClassJsonMixin
+from dateutil.relativedelta import relativedelta
+from furl import furl
 
 from coaster.utils import midnight_to_utc, utcnow
 

--- a/funnel/devtest.py
+++ b/funnel/devtest.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from secrets import token_urlsafe
-from typing import Any, Callable, Dict, Iterable, List, NamedTuple, Optional, Tuple
 import atexit
 import gc
 import inspect
@@ -13,12 +11,13 @@ import signal
 import socket
 import time
 import weakref
-
-from flask import Flask
+from secrets import token_urlsafe
+from typing import Any, Callable, Dict, Iterable, List, NamedTuple, Optional, Tuple
 from typing_extensions import Protocol
 
-from . import app as main_app
-from . import shortlinkapp, transports, unsubscribeapp
+from flask import Flask
+
+from . import app as main_app, shortlinkapp, transports, unsubscribeapp
 from .models import db
 from .typing import ReturnView
 

--- a/funnel/extapi/boxoffice.py
+++ b/funnel/extapi/boxoffice.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 from urllib.parse import urljoin
 
-from flask import current_app
 import requests
+from flask import current_app
 
 from ..utils import extract_twitter_handle
 

--- a/funnel/forms/account.py
+++ b/funnel/forms/account.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from hashlib import sha1
 from typing import Dict, Iterable, Optional
 
-from flask_babel import ngettext
 import requests
+from flask_babel import ngettext
 
 from baseframe import _, __, forms
 from coaster.utils import sorted_timezones

--- a/funnel/forms/helpers.py
+++ b/funnel/forms/helpers.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from typing import Optional, Sequence
+from typing_extensions import Literal
 
 from flask import flash
-from typing_extensions import Literal
 
 from baseframe import _, __, forms
 from coaster.auth import current_auth

--- a/funnel/forms/project.py
+++ b/funnel/forms/project.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Optional
 import re
+from typing import Optional
 
 from baseframe import _, __, forms
 from baseframe.forms.sqlalchemy import AvailableName

--- a/funnel/forms/venue.py
+++ b/funnel/forms/venue.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import gettext
 import re
 
-from flask_babel import get_locale
 import pycountry
+from flask_babel import get_locale
 
 from baseframe import _, __, forms
 from baseframe.forms.sqlalchemy import QuerySelectField

--- a/funnel/loginproviders/github.py
+++ b/funnel/loginproviders/github.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import requests
 from flask import current_app, redirect, request
 from furl import furl
 from sentry_sdk import capture_exception
-import requests
 
 from baseframe import _
 

--- a/funnel/loginproviders/google.py
+++ b/funnel/loginproviders/google.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import requests
 from flask import current_app, redirect, request, session
 from oauth2client import client
 from sentry_sdk import capture_exception
-import requests
 
 from baseframe import _
 

--- a/funnel/loginproviders/linkedin.py
+++ b/funnel/loginproviders/linkedin.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from secrets import token_urlsafe
 
+import requests
 from flask import current_app, redirect, request, session
 from furl import furl
 from sentry_sdk import capture_exception
-import requests
 
 from baseframe import _
 

--- a/funnel/loginproviders/twitter.py
+++ b/funnel/loginproviders/twitter.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from flask import redirect, request
 import tweepy
+from flask import redirect, request
 
 from baseframe import _
 

--- a/funnel/loginproviders/zoom.py
+++ b/funnel/loginproviders/zoom.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from base64 import b64encode
 
+import requests
 from flask import current_app, redirect, request, session
 from furl import furl
 from sentry_sdk import capture_exception
-import requests
 
 from baseframe import _
 

--- a/funnel/models/__init__.py
+++ b/funnel/models/__init__.py
@@ -4,12 +4,12 @@
 
 from __future__ import annotations
 
+import sqlalchemy as sa
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import DeclarativeBase, Mapped, declarative_mixin, declared_attr
 from sqlalchemy_utils import LocaleType, TimezoneType, TSVectorType
-import sqlalchemy as sa
 
 from coaster.sqlalchemy import (
     BaseIdNameMixin,

--- a/funnel/models/auth_client.py
+++ b/funnel/models/auth_client.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import urllib.parse
 from datetime import datetime, timedelta
 from hashlib import blake2b, sha256
 from typing import (
@@ -15,7 +16,6 @@ from typing import (
     cast,
     overload,
 )
-import urllib.parse
 
 from sqlalchemy.orm import attribute_keyed_dict, load_only
 from sqlalchemy.orm.query import Query as QueryBaseClass
@@ -23,8 +23,7 @@ from werkzeug.utils import cached_property
 
 from baseframe import _
 from coaster.sqlalchemy import with_roles
-from coaster.utils import buid as make_buid
-from coaster.utils import newsecret, require_one_of, utcnow
+from coaster.utils import buid as make_buid, newsecret, require_one_of, utcnow
 
 from ..typing import OptionalMigratedTables
 from . import (
@@ -357,11 +356,13 @@ class AuthClientCredential(BaseMixin, Model):
         sa.TIMESTAMP(timezone=True), nullable=True
     )
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         return f'<AuthClientCredential {self.name} {self.title!r}>'
 
-    def secret_is(self, candidate: str, upgrade_hash: bool = False):
+    def secret_is(self, candidate: Optional[str], upgrade_hash: bool = False) -> bool:
         """Test if the candidate secret matches."""
+        if not candidate:
+            return False
         if self.secret_hash.startswith('blake2b$32$'):
             return (
                 self.secret_hash

--- a/funnel/models/contact_exchange.py
+++ b/funnel/models/contact_exchange.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from datetime import date as date_type
-from datetime import datetime
+from datetime import date as date_type, datetime
 from itertools import groupby
 from typing import Collection, List, Optional, Sequence, Tuple
 from uuid import UUID

--- a/funnel/models/email_address.py
+++ b/funnel/models/email_address.py
@@ -2,20 +2,20 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional, Set, Type, Union, cast, overload
 import hashlib
 import unicodedata
+from typing import Any, List, Optional, Set, Type, Union, cast, overload
+from typing_extensions import Literal
 
+import base58
+import idna
 from pyisemail import is_email
 from pyisemail.diagnosis import BaseDiagnosis
 from sqlalchemy import event, inspect
 from sqlalchemy.orm import Mapper
 from sqlalchemy.orm.attributes import NO_VALUE
 from sqlalchemy.sql.expression import ColumnElement
-from typing_extensions import Literal
 from werkzeug.utils import cached_property
-import base58
-import idna
 
 from coaster.sqlalchemy import StateManager, auto_init_default, immutable, with_roles
 from coaster.utils import LabeledEnum, require_one_of

--- a/funnel/models/geoname.py
+++ b/funnel/models/geoname.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import re
 from decimal import Decimal
 from typing import Collection, Dict, List, Optional, Union, cast
-import re
 
 from sqlalchemy.dialects.postgresql import ARRAY
 

--- a/funnel/models/helpers.py
+++ b/funnel/models/helpers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os.path
+import re
 from dataclasses import dataclass
 from textwrap import dedent
 from typing import (
@@ -18,13 +20,10 @@ from typing import (
     TypeVar,
     cast,
 )
-import os.path
-import re
 
 from better_profanity import profanity
 from furl import furl
-from markupsafe import Markup
-from markupsafe import escape as html_escape
+from markupsafe import Markup, escape as html_escape
 from sqlalchemy.dialects.postgresql import TSQUERY
 from sqlalchemy.dialects.postgresql.base import (
     RESERVED_WORDS as POSTGRESQL_RESERVED_WORDS,

--- a/funnel/models/notification.py
+++ b/funnel/models/notification.py
@@ -100,12 +100,12 @@ from typing import (
     Union,
     cast,
 )
+from typing_extensions import Protocol
 from uuid import UUID, uuid4
 
 from sqlalchemy import event
 from sqlalchemy.orm import column_keyed_dict
 from sqlalchemy.orm.exc import NoResultFound
-from typing_extensions import Protocol
 from werkzeug.utils import cached_property
 
 from baseframe import __

--- a/funnel/models/phone_number.py
+++ b/funnel/models/phone_number.py
@@ -2,17 +2,17 @@
 
 from __future__ import annotations
 
-from typing import Any, Optional, Set, Type, Union, overload
 import hashlib
+from typing import Any, Optional, Set, Type, Union, overload
+from typing_extensions import Literal
 
+import base58
+import phonenumbers
 from sqlalchemy import event, inspect
 from sqlalchemy.orm import Mapper
 from sqlalchemy.orm.attributes import NO_VALUE
 from sqlalchemy.sql.expression import ColumnElement
-from typing_extensions import Literal
 from werkzeug.utils import cached_property
-import base58
-import phonenumbers
 
 from baseframe import _
 from coaster.sqlalchemy import immutable, with_roles

--- a/funnel/models/rsvp.py
+++ b/funnel/models/rsvp.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 from typing import Dict, Optional, Tuple, Union, cast, overload
+from typing_extensions import Literal
 
 from flask import current_app
-from typing_extensions import Literal
 from werkzeug.utils import cached_property
 
 from baseframe import __

--- a/funnel/models/shortlink.py
+++ b/funnel/models/shortlink.py
@@ -2,16 +2,16 @@
 
 from __future__ import annotations
 
+import hashlib
+import re
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 from os import urandom
 from typing import Any, Iterable, Optional, Union, overload
-import hashlib
-import re
+from typing_extensions import Literal
 
 from furl import furl
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.hybrid import Comparator
-from typing_extensions import Literal
 
 from coaster.sqlalchemy import immutable, with_roles
 

--- a/funnel/models/sync_ticket.py
+++ b/funnel/models/sync_ticket.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterable, List, Optional, Sequence
 import base64
 import os
+from typing import Any, Iterable, List, Optional, Sequence
 
 from coaster.sqlalchemy import LazyRoleSet
 

--- a/funnel/models/types.py
+++ b/funnel/models/types.py
@@ -1,10 +1,11 @@
 """Python to SQLAlchemy type mappings."""
 
+from typing_extensions import Annotated, TypeAlias
+
+import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import mapped_column
 from sqlalchemy_json import mutable_json_type
-from typing_extensions import Annotated, TypeAlias
-import sqlalchemy as sa
 
 from coaster.sqlalchemy import (
     bigint,

--- a/funnel/models/user.py
+++ b/funnel/models/user.py
@@ -2,17 +2,17 @@
 
 from __future__ import annotations
 
-from datetime import timedelta
-from typing import Iterable, Iterator, List, Optional, Set, Union, cast, overload
-from uuid import UUID
 import hashlib
 import itertools
+from datetime import timedelta
+from typing import Iterable, Iterator, List, Optional, Set, Union, cast, overload
+from typing_extensions import Literal
+from uuid import UUID
 
+import phonenumbers
 from passlib.hash import argon2, bcrypt
 from sqlalchemy.ext.associationproxy import association_proxy
-from typing_extensions import Literal
 from werkzeug.utils import cached_property
-import phonenumbers
 
 from baseframe import __
 from coaster.sqlalchemy import (

--- a/funnel/models/utils.py
+++ b/funnel/models/utils.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from typing import NamedTuple, Optional, Set, Union, overload
-
-from sqlalchemy import PrimaryKeyConstraint, UniqueConstraint
 from typing_extensions import Literal
+
 import phonenumbers
+from sqlalchemy import PrimaryKeyConstraint, UniqueConstraint
 
 from .. import app
 from ..typing import OptionalMigratedTables

--- a/funnel/models/venue.py
+++ b/funnel/models/venue.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from typing import List
 import itertools
+from typing import List
 
 from sqlalchemy.ext.orderinglist import ordering_list
 

--- a/funnel/proxies/request.py
+++ b/funnel/proxies/request.py
@@ -3,20 +3,20 @@
 from __future__ import annotations
 
 from functools import wraps
-from typing import Any, Callable, Optional, Set, TypeVar, cast
+from typing import TYPE_CHECKING, Callable, Optional, Set
 
 from flask import has_request_context, request
 from werkzeug.local import LocalProxy
 from werkzeug.utils import cached_property
 
-from ..typing import ResponseType, ReturnDecorator
+from ..typing import ResponseType, T
 
 __all__ = ['request_wants']
 
-TestFunc = TypeVar('TestFunc', bound=Callable[['RequestWants'], Any])
 
-
-def test_uses(*headers: str) -> ReturnDecorator:
+def test_uses(
+    *headers: str,
+) -> Callable[[Callable[[RequestWants], T]], cached_property[Optional[T]]]:
     """
     Identify HTTP headers accessed in this test, to be set in the response Vary header.
 
@@ -24,15 +24,15 @@ def test_uses(*headers: str) -> ReturnDecorator:
     method into a cached property.
     """
 
-    def decorator(f: TestFunc) -> TestFunc:
+    def decorator(f: Callable[[RequestWants], T]) -> cached_property[Optional[T]]:
         @wraps(f)
-        def wrapper(self: RequestWants) -> Any:
+        def wrapper(self: RequestWants) -> Optional[T]:
             self.response_vary.update(headers)
             if not has_request_context():
-                return False
+                return None
             return f(self)
 
-        return cast(TestFunc, cached_property(wrapper))
+        return cached_property(wrapper)
 
     return decorator
 
@@ -116,6 +116,11 @@ class RequestWants:
 
     # --- End of request_wants tests ---------------------------------------------------
 
+    if TYPE_CHECKING:
+
+        def _get_current_object(self) -> RequestWants:
+            """Type hint for the LocalProxy wrapper method."""
+
 
 def _get_request_wants() -> RequestWants:
     """Get request_wants from the request."""
@@ -138,5 +143,5 @@ request_wants: RequestWants = LocalProxy(_get_request_wants)  # type: ignore[ass
 
 def response_varies(response: ResponseType) -> ResponseType:
     """App ``after_request`` handler to set response ``Vary`` header."""
-    response.vary.update(request_wants.response_vary)  # type: ignore[union-attr]
+    response.vary.update(request_wants.response_vary)
     return response

--- a/funnel/registry.py
+++ b/funnel/registry.py
@@ -2,19 +2,20 @@
 
 from __future__ import annotations
 
+import re
 from collections import OrderedDict
 from dataclasses import dataclass
 from functools import wraps
-from typing import Callable, Collection, List, NoReturn, Optional, Tuple, cast
-import re
+from typing import Any, Callable, Collection, List, NoReturn, Optional, Tuple
 
 from flask import Response, abort, jsonify, request
+from werkzeug.datastructures import MultiDict
 
 from baseframe import _
 from baseframe.signals import exception_catchall
 
 from .models import AuthToken, UserExternalId
-from .typing import ReturnDecorator, ReturnResponse, WrappedFunc
+from .typing import P, ReturnResponse
 
 # Bearer token, as per
 # http://tools.ietf.org/html/draft-ietf-oauth-v2-bearer-15#section-2.1
@@ -30,7 +31,7 @@ class ResourceRegistry(OrderedDict):
         description: Optional[str] = None,
         trusted: bool = False,
         scope: Optional[str] = None,
-    ) -> ReturnDecorator:
+    ) -> Callable[[Callable[P, Any]], Callable[[], ReturnResponse]]:
         """
         Decorate a resource function.
 
@@ -56,7 +57,9 @@ class ResourceRegistry(OrderedDict):
                 },
             )
 
-        def decorator(f: WrappedFunc) -> Callable[..., ReturnResponse]:
+        def decorator(
+            f: Callable[[AuthToken, MultiDict, MultiDict], Any]
+        ) -> Callable[[], ReturnResponse]:
             @wraps(f)
             def wrapper() -> ReturnResponse:
                 if request.method == 'GET':
@@ -133,7 +136,7 @@ class ResourceRegistry(OrderedDict):
                 'trusted': trusted,
                 'f': f,
             }
-            return cast(WrappedFunc, wrapper)
+            return wrapper
 
         return decorator
 

--- a/funnel/transports/email/aws_ses/sns_notifications.py
+++ b/funnel/transports/email/aws_ses/sns_notifications.py
@@ -2,18 +2,18 @@
 
 from __future__ import annotations
 
-from enum import Enum, IntFlag
-from typing import Dict, Pattern, Sequence, cast
 import base64
 import re
+from enum import Enum, IntFlag
+from typing import Dict, Pattern, Sequence, cast
 
+import requests
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric.padding import PKCS1v15
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from cryptography.hazmat.primitives.hashes import SHA1
-import requests
 
 __all__ = [
     'SnsNotificationType',

--- a/funnel/transports/email/send.py
+++ b/funnel/transports/email/send.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import smtplib
 from dataclasses import dataclass
 from email.utils import formataddr, getaddresses, parseaddr
 from typing import Dict, List, Optional, Tuple, Union
-import smtplib
 
 from flask import current_app
 from flask_mailman import EmailMultiAlternatives

--- a/funnel/transports/sms/send.py
+++ b/funnel/transports/sms/send.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable, List, Optional, Tuple, Union, cast
 
-from flask import url_for
-from twilio.base.exceptions import TwilioRestException
-from twilio.rest import Client
 import itsdangerous
 import phonenumbers
 import requests
+from flask import url_for
+from twilio.base.exceptions import TwilioRestException
+from twilio.rest import Client
 
 from baseframe import _
 

--- a/funnel/transports/sms/template.py
+++ b/funnel/transports/sms/template.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import re
 from string import Formatter
 from typing import Any, ClassVar, Dict, Optional, Pattern, cast
-import re
 
 from flask import Flask
 

--- a/funnel/typing.py
+++ b/funnel/typing.py
@@ -2,59 +2,41 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, TypeVar, Union
+from typing import List, Optional, Set, Tuple, TypeVar, Union
+from typing_extensions import ParamSpec, TypeAlias
 
 from flask.typing import ResponseReturnValue
-from typing_extensions import ParamSpec
 from werkzeug.wrappers import Response  # Base class for Flask Response
 
 from coaster.views import ReturnRenderWith
 
 __all__ = [
     'T',
+    'T_co',
     'P',
     'OptionalMigratedTables',
     'ReturnRenderWith',
     'ReturnResponse',
     'ReturnView',
-    'WrappedFunc',
-    'ReturnDecorator',
     'ResponseType',
     'ResponseReturnValue',
 ]
 
 #: Type used to indicate type continuity within a block of code
 T = TypeVar('T')
+T_co = TypeVar('T_co', covariant=True)
 #: Type used to indicate parameter continuity within a block of code
 P = ParamSpec('P')
 
 
-#: Flask response headers can be a dict or list of key-value pairs
-ResponseHeaders = Union[Dict[str, str], List[Tuple[str, str]]]
-
-#: Flask views accept a response status code that is either an int or a string
-ResponseStatusCode = Union[int, str]
-
-#: Flask views can return a Response, a string or a JSON dictionary
-ResponseTypes = Union[
-    str,  # A string (typically `render_template`)
-    Response,  # Fully formed response object
-    Dict[str, Any],  # JSON response
-]
-
 #: Return type for Flask views (formats accepted by :func:`~flask.make_response`)
-ReturnView = ResponseReturnValue
-
-#: Type used for functions and methods wrapped in a decorator
-WrappedFunc = TypeVar('WrappedFunc', bound=Callable)
-#: Return type for decorator factories
-ReturnDecorator = Callable[[WrappedFunc], WrappedFunc]
+ReturnView: TypeAlias = ResponseReturnValue
 
 #: Return type of the `migrate_user` and `migrate_profile` methods
-OptionalMigratedTables = Optional[Union[List[str], Tuple[str], Set[str]]]
+OptionalMigratedTables: TypeAlias = Optional[Union[List[str], Tuple[str], Set[str]]]
 
 #: Return type for Response objects
-ReturnResponse = Response
+ReturnResponse: TypeAlias = Response
 
 #: Response typevar
 ResponseType = TypeVar('ResponseType', bound=Response)

--- a/funnel/utils/markdown/base.py
+++ b/funnel/utils/markdown/base.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import (
     Any,
@@ -14,12 +15,11 @@ from typing import (
     Union,
     overload,
 )
-import re
+from typing_extensions import Literal
 
 from markdown_it import MarkdownIt
 from markupsafe import Markup
 from mdit_py_plugins import anchors, container, deflist, footnote, tasklists
-from typing_extensions import Literal
 
 from coaster.utils import make_name
 from coaster.utils.text import normalize_spaces_multiline

--- a/funnel/utils/markdown/mdit_plugins/embeds.py
+++ b/funnel/utils/markdown/mdit_plugins/embeds.py
@@ -7,9 +7,9 @@ and mdit_py_plugins.colon_fence.
 
 from __future__ import annotations
 
+import re
 from collections.abc import MutableMapping, Sequence
 from math import floor
-import re
 
 from markdown_it import MarkdownIt
 from markdown_it.common.utils import charCodeAt

--- a/funnel/utils/markdown/mdit_plugins/sub_tag.py
+++ b/funnel/utils/markdown/mdit_plugins/sub_tag.py
@@ -7,8 +7,8 @@ https://github.com/markdown-it/markdown-it-sub/blob/master/dist/markdown-it-sub.
 
 from __future__ import annotations
 
-from collections.abc import MutableMapping, Sequence
 import re
+from collections.abc import MutableMapping, Sequence
 
 from markdown_it import MarkdownIt
 from markdown_it.renderer import OptionsDict, RendererHTML

--- a/funnel/utils/markdown/mdit_plugins/sup_tag.py
+++ b/funnel/utils/markdown/mdit_plugins/sup_tag.py
@@ -7,8 +7,8 @@ https://github.com/markdown-it/markdown-it-sup/blob/master/dist/markdown-it-sup.
 
 from __future__ import annotations
 
-from collections.abc import MutableMapping, Sequence
 import re
+from collections.abc import MutableMapping, Sequence
 
 from markdown_it import MarkdownIt
 from markdown_it.renderer import OptionsDict, RendererHTML

--- a/funnel/utils/markdown/mdit_plugins/toc.py
+++ b/funnel/utils/markdown/mdit_plugins/toc.py
@@ -12,16 +12,16 @@ Step 3: Turn the nested tree into HTML code.
 
 from __future__ import annotations
 
+import re
 from collections.abc import MutableMapping, Sequence
 from functools import reduce
 from typing import Dict, List, Optional
-import re
+from typing_extensions import TypedDict
 
 from markdown_it import MarkdownIt
 from markdown_it.renderer import OptionsDict, RendererHTML
 from markdown_it.rules_inline import StateInline
 from markdown_it.token import Token
-from typing_extensions import TypedDict
 
 from coaster.utils import make_name
 

--- a/funnel/utils/misc.py
+++ b/funnel/utils/misc.py
@@ -2,15 +2,15 @@
 
 from __future__ import annotations
 
-from hashlib import blake2b
-from typing import List, Optional, Union, overload
 import io
 import urllib.parse
+from hashlib import blake2b
+from typing import List, Optional, Union, overload
 
-from flask import abort
 import phonenumbers
 import qrcode
 import qrcode.image.svg
+from flask import abort
 
 __all__ = [
     'blake2b160_hex',

--- a/funnel/utils/mustache.py
+++ b/funnel/utils/mustache.py
@@ -1,9 +1,9 @@
 """Mustache templating support."""
 
-from copy import copy
-from typing import Callable
 import functools
 import types
+from copy import copy
+from typing import Callable
 
 from chevron import render
 from markupsafe import escape as html_escape

--- a/funnel/views/account.py
+++ b/funnel/views/account.py
@@ -6,10 +6,10 @@ from string import capwords
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
-from flask import abort, current_app, flash, redirect, render_template, request, url_for
-from markupsafe import Markup, escape
 import geoip2.errors
 import user_agents
+from flask import abort, current_app, flash, redirect, render_template, request, url_for
+from markupsafe import Markup, escape
 
 from baseframe import _, forms
 from baseframe.forms import render_delete_sqla, render_form, render_message

--- a/funnel/views/account_delete.py
+++ b/funnel/views/account_delete.py
@@ -1,14 +1,15 @@
 """Helper functions for account delete validation."""
 
 from dataclasses import dataclass
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, TypeVar
 
 from baseframe import __
 
 from ..models import User
-from ..typing import ReturnDecorator, WrappedFunc
 
 # --- Delete validator registry --------------------------------------------------------
+
+ValidatorFunc = TypeVar('ValidatorFunc', bound=Callable[[User], bool])
 
 
 @dataclass
@@ -28,10 +29,10 @@ account_delete_validators: List[DeleteValidator] = []
 
 def delete_validator(
     title: str, message: str, name: Optional[str] = None
-) -> ReturnDecorator:
+) -> Callable[[ValidatorFunc], ValidatorFunc]:
     """Register an account delete validator."""
 
-    def decorator(func: WrappedFunc) -> WrappedFunc:
+    def decorator(func: ValidatorFunc) -> ValidatorFunc:
         """Create a DeleteValidator."""
         account_delete_validators.append(
             DeleteValidator(func, name or func.__name__, title, message)

--- a/funnel/views/account_reset.py
+++ b/funnel/views/account_reset.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
+import itsdangerous
 from flask import current_app, flash, redirect, request, session, url_for
 from flask_babel import ngettext
 from markupsafe import Markup, escape
-import itsdangerous
 
 from baseframe import _
 from baseframe.forms import render_form, render_message

--- a/funnel/views/api/email_events.py
+++ b/funnel/views/api/email_events.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from email.utils import parseaddr
 from typing import List, Optional, Sequence
 
-from flask import current_app, request
 import requests
+from flask import current_app, request
 
 from baseframe import statsd
 

--- a/funnel/views/api/resource.py
+++ b/funnel/views/api/resource.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from typing import Any, Container, Dict, List, Optional, Union, cast
+from typing_extensions import Literal
 
 from flask import abort, jsonify, render_template, request
-from typing_extensions import Literal
+from werkzeug.datastructures import MultiDict
 
 from baseframe import __
 from coaster.auth import current_auth
@@ -44,7 +45,7 @@ def get_userinfo(
     auth_client: AuthClient,
     scope: Container[str] = (),
     user_session: Optional[UserSession] = None,
-    get_permissions=True,
+    get_permissions: bool = True,
 ) -> ReturnResource:
     """Return userinfo for a given user, auth client and scope."""
     if '*' in scope or 'id' in scope or 'id/*' in scope:
@@ -470,7 +471,9 @@ def login_beacon_json(client_id: str) -> ReturnView:
 
 @app.route('/api/1/id')
 @resource_registry.resource('id', __("Read your name and basic account data"))
-def resource_id(authtoken: AuthToken, args: dict, files=None) -> ReturnResource:
+def resource_id(
+    authtoken: AuthToken, args: MultiDict, files: Optional[MultiDict] = None
+) -> ReturnResource:
     """Return user's basic identity."""
     if 'all' in args and getbool(args['all']):
         return get_userinfo(
@@ -489,7 +492,9 @@ def resource_id(authtoken: AuthToken, args: dict, files=None) -> ReturnResource:
 
 @app.route('/api/1/session/verify', methods=['POST'])
 @resource_registry.resource('session/verify', __("Verify user session"), scope='id')
-def session_verify(authtoken: AuthToken, args: dict, files=None) -> ReturnResource:
+def session_verify(
+    authtoken: AuthToken, args: MultiDict, files: Optional[MultiDict] = None
+) -> ReturnResource:
     """Verify a UserSession."""
     sessionid = abort_null(args['sessionid'])
     user_session = UserSession.authenticate(buid=sessionid, silent=True)
@@ -509,7 +514,9 @@ def session_verify(authtoken: AuthToken, args: dict, files=None) -> ReturnResour
 
 @app.route('/api/1/email')
 @resource_registry.resource('email', __("Read your email address"))
-def resource_email(authtoken: AuthToken, args: dict, files=None) -> ReturnResource:
+def resource_email(
+    authtoken: AuthToken, args: MultiDict, files: Optional[MultiDict] = None
+) -> ReturnResource:
     """Return user's email addresses."""
     if 'all' in args and getbool(args['all']):
         return {
@@ -525,7 +532,9 @@ def resource_email(authtoken: AuthToken, args: dict, files=None) -> ReturnResour
 
 @app.route('/api/1/phone')
 @resource_registry.resource('phone', __("Read your phone number"))
-def resource_phone(authtoken: AuthToken, args: dict, files=None) -> ReturnResource:
+def resource_phone(
+    authtoken: AuthToken, args: MultiDict, files: Optional[MultiDict] = None
+) -> ReturnResource:
     """Return user's phone numbers."""
     if 'all' in args and getbool(args['all']):
         return {
@@ -542,7 +551,7 @@ def resource_phone(authtoken: AuthToken, args: dict, files=None) -> ReturnResour
     trusted=True,
 )
 def resource_login_providers(
-    authtoken: AuthToken, args: dict, files=None
+    authtoken: AuthToken, args: MultiDict, files: Optional[MultiDict] = None
 ) -> ReturnResource:
     """Return user's login providers' data."""
     service: Optional[str] = abort_null(args.get('service'))
@@ -564,7 +573,7 @@ def resource_login_providers(
     'organizations', __("Read the organizations you are a member of")
 )
 def resource_organizations(
-    authtoken: AuthToken, args: dict, files=None
+    authtoken: AuthToken, args: MultiDict, files: Optional[MultiDict] = None
 ) -> ReturnResource:
     """Return user's organizations and teams that they are a member of."""
     return get_userinfo(
@@ -577,7 +586,9 @@ def resource_organizations(
 
 @app.route('/api/1/teams')
 @resource_registry.resource('teams', __("Read the list of teams in your organizations"))
-def resource_teams(authtoken: AuthToken, args: dict, files=None) -> ReturnResource:
+def resource_teams(
+    authtoken: AuthToken, args: MultiDict, files: Optional[MultiDict] = None
+) -> ReturnResource:
     """Return user's organizations' teams."""
     return get_userinfo(
         authtoken.effective_user,

--- a/funnel/views/contact.py
+++ b/funnel/views/contact.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
+import csv
 from datetime import datetime, timedelta
 from io import StringIO
 from typing import Dict, Optional
-import csv
 
 from flask import Response, current_app, render_template, request
 from sqlalchemy.exc import IntegrityError

--- a/funnel/views/helpers.py
+++ b/funnel/views/helpers.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import gzip
+import zlib
 from base64 import urlsafe_b64encode
 from contextlib import nullcontext
 from datetime import datetime, timedelta
@@ -9,9 +11,8 @@ from hashlib import blake2b
 from os import urandom
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 from urllib.parse import unquote, urljoin, urlsplit
-import gzip
-import zlib
 
+import brotli
 from flask import (
     Flask,
     Response,
@@ -26,13 +27,10 @@ from flask import (
     url_for,
 )
 from furl import furl
-from pytz import common_timezones
-from pytz import timezone as pytz_timezone
-from pytz import utc
+from pytz import common_timezones, timezone as pytz_timezone, utc
 from werkzeug.exceptions import MethodNotAllowed, NotFound
 from werkzeug.routing import BuildError, RequestRedirect
 from werkzeug.urls import url_quote
-import brotli
 
 from baseframe import cache, statsd
 from coaster.sqlalchemy import RoleMixin
@@ -489,7 +487,7 @@ def compress_response(response: ResponseType) -> None:
         if algorithm is not None:
             response.set_data(compress(response.get_data(), algorithm))
             response.headers['Content-Encoding'] = algorithm
-            response.vary.add('Accept-Encoding')  # type: ignore[union-attr]
+            response.vary.add('Accept-Encoding')
 
 
 # --- Template helpers -----------------------------------------------------------------

--- a/funnel/views/index.py
+++ b/funnel/views/index.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 import os.path
+from dataclasses import dataclass
 
 from flask import Response, g, render_template
 from markupsafe import Markup

--- a/funnel/views/jobs.py
+++ b/funnel/views/jobs.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from collections import defaultdict
 from functools import wraps
+from typing import Callable
+from typing_extensions import Protocol
 
-from flask import g
 import requests
+from flask import g
 
 from baseframe import statsd
 
@@ -23,16 +25,31 @@ from ..models import (
     db,
 )
 from ..signals import emailaddress_refcount_dropping, phonenumber_refcount_dropping
-from ..typing import ResponseType, ReturnDecorator, WrappedFunc
+from ..typing import P, ResponseType, T_co
 from .helpers import app_context
 
 
-def rqjob(queue: str = 'funnel', **rqargs) -> ReturnDecorator:
+class RqJobProtocol(Protocol[P, T_co]):
+    """Protocol for an RQ job function."""
+
+    def __call__(self, *args: P.args, **kwargs: P.kwargs) -> T_co:
+        ...
+
+    # TODO: Replace return type with job id type
+    def queue(self, *args: P.args, **kwargs: P.kwargs) -> None:
+        ...
+
+    # TODO: Add other methods and attrs (queue_name, schedule, cron, ...)
+
+
+def rqjob(
+    queue: str = 'funnel', **rqargs
+) -> Callable[[Callable[P, T_co]], RqJobProtocol[P, T_co]]:
     """Decorate an RQ job with app context."""
 
-    def decorator(f: WrappedFunc):
+    def decorator(f: Callable[P, T_co]) -> RqJobProtocol[P, T_co]:
         @wraps(f)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T_co:
             with app_context():
                 return f(*args, **kwargs)
 
@@ -42,7 +59,7 @@ def rqjob(queue: str = 'funnel', **rqargs) -> ReturnDecorator:
 
 
 @rqjob()
-def import_tickets(ticket_client_id):
+def import_tickets(ticket_client_id: int) -> None:
     """Import tickets from Boxoffice."""
     ticket_client = TicketClient.query.get(ticket_client_id)
     if ticket_client is not None:
@@ -60,7 +77,7 @@ def import_tickets(ticket_client_id):
 
 
 @rqjob()
-def tag_locations(project_id):
+def tag_locations(project_id: int) -> None:
     """
     Tag a project with geoname locations.
 
@@ -172,7 +189,7 @@ def forget_email(email_hash: str) -> None:
 
 
 @rqjob()
-def forget_phone(phone_hash) -> None:
+def forget_phone(phone_hash: str) -> None:
     """Remove a phone number if it has no inbound references."""
     phone_number = PhoneNumber.get(phone_hash=phone_hash)
     if phone_number is not None and phone_number.refcount() == 0:

--- a/funnel/views/login.py
+++ b/funnel/views/login.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import urllib.parse
 from datetime import timedelta
 from secrets import token_urlsafe
 from typing import TYPE_CHECKING, Union
-import urllib.parse
 
+import itsdangerous
 from flask import (
     abort,
     current_app,
@@ -17,7 +18,6 @@ from flask import (
     session,
     url_for,
 )
-import itsdangerous
 
 from baseframe import _, __, forms, statsd
 from baseframe.forms import render_message

--- a/funnel/views/notification.py
+++ b/funnel/views/notification.py
@@ -9,11 +9,11 @@ from email.utils import formataddr
 from functools import wraps
 from itertools import filterfalse, zip_longest
 from typing import Any, Callable, ClassVar, Dict, List, Optional, Union
+from typing_extensions import Literal
 from uuid import uuid4
 
 from flask import url_for
 from flask_babel import force_locale
-from typing_extensions import Literal
 from werkzeug.utils import cached_property
 
 from baseframe import __, statsd

--- a/funnel/views/notification_preferences.py
+++ b/funnel/views/notification_preferences.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from datetime import datetime, timedelta
 from typing import Optional
 
-from flask import abort, current_app, flash, redirect, request, session, url_for
 import itsdangerous
+from flask import abort, current_app, flash, redirect, request, session, url_for
 
 from baseframe import _, __
 from baseframe.forms import render_form, render_message

--- a/funnel/views/otp.py
+++ b/funnel/views/otp.py
@@ -6,10 +6,10 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Dict, Generic, Optional, Type, TypeVar, Union
 
+import phonenumbers
 from flask import current_app, flash, render_template, request, session, url_for
 from werkzeug.exceptions import Forbidden, RequestTimeout, TooManyRequests
 from werkzeug.utils import cached_property
-import phonenumbers
 
 from baseframe import _
 from coaster.auth import current_auth

--- a/funnel/views/project.py
+++ b/funnel/views/project.py
@@ -1,9 +1,9 @@
 """Views for projects."""
 
-from dataclasses import dataclass
-from types import SimpleNamespace
 import csv
 import io
+from dataclasses import dataclass
+from types import SimpleNamespace
 
 from flask import Response, abort, current_app, flash, render_template, request
 from flask_babel import format_number

--- a/funnel/views/search.py
+++ b/funnel/views/search.py
@@ -2,15 +2,15 @@
 
 from __future__ import annotations
 
+import re
 from html import unescape as html_unescape
 from typing import Any, Dict, List, Optional, Type, TypeVar
+from typing_extensions import TypedDict
 from urllib.parse import quote as urlquote
-import re
 
 from flask import request, url_for
 from markupsafe import Markup
 from sqlalchemy.sql import expression
-from typing_extensions import TypedDict
 
 from baseframe import __
 from coaster.views import (

--- a/funnel/views/siteadmin.py
+++ b/funnel/views/siteadmin.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
+import csv
 from collections import Counter
 from dataclasses import dataclass, field
 from datetime import timedelta
 from functools import wraps
 from io import StringIO
-from typing import Any, Dict, Optional, cast
-import csv
+from typing import Any, Callable, Dict, Optional
 
 from flask import abort, current_app, flash, render_template, request, url_for
 from sqlalchemy.dialects.postgresql import INTERVAL
@@ -36,7 +36,7 @@ from ..models import (
     db,
     sa,
 )
-from ..typing import ReturnRenderWith, ReturnResponse, ReturnView, WrappedFunc
+from ..typing import P, ReturnRenderWith, ReturnResponse, ReturnView, T
 from ..utils import abort_null
 from .helpers import render_redirect
 from .login_session import requires_login
@@ -71,64 +71,64 @@ class ReportCounter:
     frequency: int
 
 
-def requires_siteadmin(f: WrappedFunc) -> WrappedFunc:
+def requires_siteadmin(f: Callable[P, T]) -> Callable[P, T]:
     """Decorate a view to require siteadmin privilege."""
 
     @wraps(f)
-    def wrapper(*args, **kwargs) -> Any:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
         if not current_auth.user or not current_auth.user.is_site_admin:
             abort(403)
         return f(*args, **kwargs)
 
-    return cast(WrappedFunc, wrapper)
+    return wrapper
 
 
-def requires_site_editor(f: WrappedFunc) -> WrappedFunc:
+def requires_site_editor(f: Callable[P, T]) -> Callable[P, T]:
     """Decorate a view to require site editor privilege."""
 
     @wraps(f)
-    def wrapper(*args, **kwargs) -> Any:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
         if not current_auth.user or not current_auth.user.is_site_editor:
             abort(403)
         return f(*args, **kwargs)
 
-    return cast(WrappedFunc, wrapper)
+    return wrapper
 
 
-def requires_user_moderator(f: WrappedFunc) -> WrappedFunc:
+def requires_user_moderator(f: Callable[P, T]) -> Callable[P, T]:
     """Decorate a view to require user moderator privilege."""
 
     @wraps(f)
-    def wrapper(*args, **kwargs) -> Any:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
         if not current_auth.user or not current_auth.user.is_user_moderator:
             abort(403)
         return f(*args, **kwargs)
 
-    return cast(WrappedFunc, wrapper)
+    return wrapper
 
 
-def requires_comment_moderator(f: WrappedFunc) -> WrappedFunc:
+def requires_comment_moderator(f: Callable[P, T]) -> Callable[P, T]:
     """Decorate a view to require comment moderator privilege."""
 
     @wraps(f)
-    def wrapper(*args, **kwargs) -> Any:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
         if not current_auth.user or not current_auth.user.is_comment_moderator:
             abort(403)
         return f(*args, **kwargs)
 
-    return cast(WrappedFunc, wrapper)
+    return wrapper
 
 
-def requires_sysadmin(f: WrappedFunc) -> WrappedFunc:
+def requires_sysadmin(f: Callable[P, T]) -> Callable[P, T]:
     """Decorate a view to require sysadmin privilege."""
 
     @wraps(f)
-    def wrapper(*args, **kwargs) -> Any:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> Any:
         if not current_auth.user or not current_auth.user.is_sysadmin:
             abort(403)
         return f(*args, **kwargs)
 
-    return cast(WrappedFunc, wrapper)
+    return wrapper
 
 
 @route('/siteadmin')

--- a/funnel/views/video.py
+++ b/funnel/views/video.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from datetime import datetime
 from typing import Optional, Union, cast
+from typing_extensions import TypedDict
 
+import requests
+import vimeo
 from flask import current_app
 from pytz import utc
 from sentry_sdk import capture_exception
-from typing_extensions import TypedDict
-import requests
-import vimeo
 
 from coaster.utils import parse_duration, parse_isoformat
 

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import logging
 from logging.config import fileConfig
 from typing import List
-import logging
 
 from alembic import context
 from flask import current_app

--- a/migrations/versions/047ebdac558b_complement_email_md5sum_with_blake2b.py
+++ b/migrations/versions/047ebdac558b_complement_email_md5sum_with_blake2b.py
@@ -6,14 +6,14 @@ Create Date: 2020-06-05 04:10:56.627503
 
 """
 
-from typing import Optional, Tuple, Union
 import hashlib
+from typing import Optional, Tuple, Union
 
+import progressbar.widgets
+import sqlalchemy as sa
 from alembic import op
 from progressbar import ProgressBar
 from sqlalchemy.sql import column, table
-import progressbar.widgets
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '047ebdac558b'

--- a/migrations/versions/061eefe61519_remove_auth_client_resource_and_.py
+++ b/migrations/versions/061eefe61519_remove_auth_client_resource_and_.py
@@ -8,8 +8,8 @@ Create Date: 2021-05-12 21:09:56.657928
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '061eefe61519'

--- a/migrations/versions/073e7961d5df_remove_bg_color_and_explore_url.py
+++ b/migrations/versions/073e7961d5df_remove_bg_color_and_explore_url.py
@@ -8,8 +8,8 @@ Create Date: 2020-05-21 15:48:14.035503
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 revision = '073e7961d5df'
 down_revision = '34a95ee0c3a0'

--- a/migrations/versions/07ebe99161d5_add_banner_image_url_to_sessio.py
+++ b/migrations/versions/07ebe99161d5_add_banner_image_url_to_sessio.py
@@ -10,8 +10,8 @@ Create Date: 2018-11-21 19:06:35.140390
 revision = '07ebe99161d5'
 down_revision = '60a132ae73f1'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/08cef852ca39_remove_schedule_state.py
+++ b/migrations/versions/08cef852ca39_remove_schedule_state.py
@@ -8,8 +8,8 @@ Create Date: 2021-04-27 06:02:19.879566
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '08cef852ca39'

--- a/migrations/versions/09562978e3de_move_aside_old_user_and_team_tables.py
+++ b/migrations/versions/09562978e3de_move_aside_old_user_and_team_tables.py
@@ -10,8 +10,8 @@ Create Date: 2020-04-06 22:42:04.717152
 revision = '09562978e3de'
 down_revision = '321b11b6a413'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # (old, new)
 renamed_tables = [

--- a/migrations/versions/0b25df40d307_add_labels.py
+++ b/migrations/versions/0b25df40d307_add_labels.py
@@ -10,8 +10,8 @@ Create Date: 2019-04-08 14:44:05.164533
 revision = '0b25df40d307'
 down_revision = 'ef93d256a8cf'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/0d462811a07f_team_public_flag.py
+++ b/migrations/versions/0d462811a07f_team_public_flag.py
@@ -8,8 +8,8 @@ Create Date: 2020-07-29 04:01:40.257520
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '0d462811a07f'

--- a/migrations/versions/0fae06340346_add_version_numbers_for_timestamped_.py
+++ b/migrations/versions/0fae06340346_add_version_numbers_for_timestamped_.py
@@ -8,8 +8,8 @@ Create Date: 2022-01-06 16:11:26.035319
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '0fae06340346'

--- a/migrations/versions/111c9755ae39_switch_to_timestamptz.py
+++ b/migrations/versions/111c9755ae39_switch_to_timestamptz.py
@@ -10,8 +10,8 @@ Create Date: 2019-05-09 19:01:53.976390
 revision = '111c9755ae39'
 down_revision = 'e679554261b2'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 migrate_table_columns = [
     ('attendee', 'created_at'),

--- a/migrations/versions/1195a2789872_proposal_video_blogp.py
+++ b/migrations/versions/1195a2789872_proposal_video_blogp.py
@@ -10,8 +10,8 @@ Create Date: 2014-02-23 02:36:49.955698
 revision = '1195a2789872'
 down_revision = '3c47ba103724'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/140c9b68d65b_team_model.py
+++ b/migrations/versions/140c9b68d65b_team_model.py
@@ -10,8 +10,8 @@ Create Date: 2014-04-07 03:22:09.472270
 revision = '140c9b68d65b'
 down_revision = '1bb2df0df8e2'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/14d1424b47_rsvp.py
+++ b/migrations/versions/14d1424b47_rsvp.py
@@ -10,8 +10,8 @@ Create Date: 2015-01-30 16:09:42.434798
 revision = '14d1424b47'
 down_revision = '1c496c114b6'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/14d7082476c0_proposalspace_image_.py
+++ b/migrations/versions/14d7082476c0_proposalspace_image_.py
@@ -10,8 +10,8 @@ Create Date: 2014-10-12 17:57:10.723917
 revision = '14d7082476c0'
 down_revision = '577689971aa0'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/18052b0cd282_scoped_id_for_propos.py
+++ b/migrations/versions/18052b0cd282_scoped_id_for_propos.py
@@ -10,9 +10,9 @@ Create Date: 2014-04-18 12:43:12.100890
 revision = '18052b0cd282'
 down_revision = '140c9b68d65b'
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql import column, table
-import sqlalchemy as sa
 
 
 def upgrade() -> None:

--- a/migrations/versions/1829e53eba75_add_search_vectors.py
+++ b/migrations/versions/1829e53eba75_add_search_vectors.py
@@ -12,9 +12,9 @@ down_revision = '752dee4ae101'
 
 from textwrap import dedent
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy_utils import TSVectorType
-import sqlalchemy as sa
 
 
 def upgrade() -> None:

--- a/migrations/versions/1925329c798a_added_venue_room_det.py
+++ b/migrations/versions/1925329c798a_added_venue_room_det.py
@@ -10,8 +10,8 @@ Create Date: 2013-11-05 19:48:59.132327
 revision = '1925329c798a'
 down_revision = '316aaa757c8c'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/19a1f7f2a365_project_datelocation_drop.py
+++ b/migrations/versions/19a1f7f2a365_project_datelocation_drop.py
@@ -9,8 +9,8 @@ Create Date: 2018-12-04 21:00:12.445853
 revision = '19a1f7f2a365'
 down_revision = '9a0d8fa7da29'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/1b8fc63c0fb0_remove_and_rename_obsolete_columns.py
+++ b/migrations/versions/1b8fc63c0fb0_remove_and_rename_obsolete_columns.py
@@ -13,9 +13,9 @@ down_revision = 'ea20c403b240'
 
 import json
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
-import sqlalchemy as sa
 
 default_part_labels = {
     "proposal": {

--- a/migrations/versions/1bb2df0df8e2_profiles_and_userbas.py
+++ b/migrations/versions/1bb2df0df8e2_profiles_and_userbas.py
@@ -10,8 +10,8 @@ Create Date: 2014-04-06 18:49:43.418238
 revision = '1bb2df0df8e2'
 down_revision = '523c53593e3c'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/1bd91b02ced3_merge_comment_notification_types.py
+++ b/migrations/versions/1bd91b02ced3_merge_comment_notification_types.py
@@ -8,9 +8,9 @@ Create Date: 2020-09-18 02:44:20.827703
 
 from typing import Optional, Tuple, Union
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql import column, table
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '1bd91b02ced3'

--- a/migrations/versions/1c9cbf3a1e5e_add_commenset_memberships.py
+++ b/migrations/versions/1c9cbf3a1e5e_add_commenset_memberships.py
@@ -9,11 +9,11 @@ Create Date: 2021-03-11 09:07:56.611054
 from typing import Optional, Tuple, Union
 from uuid import uuid4
 
+import progressbar.widgets
+import sqlalchemy as sa
 from alembic import op
 from progressbar import ProgressBar
 from sqlalchemy.sql import column, table
-import progressbar.widgets
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '1c9cbf3a1e5e'

--- a/migrations/versions/1d5e1a11661a_add_json_field_rsvp.py
+++ b/migrations/versions/1d5e1a11661a_add_json_field_rsvp.py
@@ -8,9 +8,9 @@ Create Date: 2023-03-17 23:55:04.066491
 
 from typing import Optional, Tuple, Union
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects.postgresql import JSONB
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = '1d5e1a11661a'

--- a/migrations/versions/1fcee2e6280_added_session.py
+++ b/migrations/versions/1fcee2e6280_added_session.py
@@ -10,8 +10,8 @@ Create Date: 2013-11-08 19:24:18.721591
 revision = '1fcee2e6280'
 down_revision = '1925329c798a'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/20c10335b553_add_project_livestream_urls.py
+++ b/migrations/versions/20c10335b553_add_project_livestream_urls.py
@@ -10,8 +10,8 @@ Create Date: 2019-12-13 21:13:14.307378
 revision = '20c10335b553'
 down_revision = 'c11dc931b903'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/2151c9f8e955_replace_allow_columns_with_has_columns.py
+++ b/migrations/versions/2151c9f8e955_replace_allow_columns_with_has_columns.py
@@ -8,9 +8,9 @@ Create Date: 2023-02-08 00:16:05.035943
 
 from typing import Optional, Tuple, Union
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision: str = '2151c9f8e955'

--- a/migrations/versions/21a7dfe8ab4d_proposal_redirects.py
+++ b/migrations/versions/21a7dfe8ab4d_proposal_redirects.py
@@ -10,8 +10,8 @@ Create Date: 2015-01-17 19:30:22.036714
 revision = '21a7dfe8ab4d'
 down_revision = '2a5516432f66'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/222b78a8508d_remove_organization_description.py
+++ b/migrations/versions/222b78a8508d_remove_organization_description.py
@@ -8,9 +8,9 @@ Create Date: 2020-05-05 01:32:02.241787
 
 from typing import Optional, Tuple, Union
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql import column, table
-import sqlalchemy as sa
 
 from coaster.gfm import markdown
 

--- a/migrations/versions/22fb4e1e3139_add_ticket_client.py
+++ b/migrations/versions/22fb4e1e3139_add_ticket_client.py
@@ -9,8 +9,8 @@ Create Date: 2015-05-13 16:51:14.399678
 revision = '22fb4e1e3139'
 down_revision = '40c4ad7c0909'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/2441cb4f44d4_legacy_profile_flag.py
+++ b/migrations/versions/2441cb4f44d4_legacy_profile_flag.py
@@ -10,8 +10,8 @@ Create Date: 2018-11-23 01:36:47.060182
 revision = '2441cb4f44d4'
 down_revision = 'd62b392b0f25'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/277ba2ca9e3e_add_proposal_sponsor_membership.py
+++ b/migrations/versions/277ba2ca9e3e_add_proposal_sponsor_membership.py
@@ -8,8 +8,8 @@ Create Date: 2022-01-04 16:26:51.717623
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '277ba2ca9e3e'

--- a/migrations/versions/284c10efdbce_deprecate_session_speaker_bio.py
+++ b/migrations/versions/284c10efdbce_deprecate_session_speaker_bio.py
@@ -9,11 +9,11 @@ Create Date: 2021-02-09 10:01:25.069803
 from textwrap import dedent
 from typing import Optional, Tuple, Union
 
+import progressbar.widgets
+import sqlalchemy as sa
 from alembic import op
 from progressbar import ProgressBar
 from sqlalchemy.sql import column, table
-import progressbar.widgets
-import sqlalchemy as sa
 
 from coaster.utils import markdown
 

--- a/migrations/versions/294362dc7e49_add_organization_state.py
+++ b/migrations/versions/294362dc7e49_add_organization_state.py
@@ -8,8 +8,8 @@ Create Date: 2021-08-10 18:04:27.259907
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '294362dc7e49'

--- a/migrations/versions/2a5516432f66_use_coordinatesmixin.py
+++ b/migrations/versions/2a5516432f66_use_coordinatesmixin.py
@@ -10,8 +10,8 @@ Create Date: 2015-01-17 12:16:51.529610
 revision = '2a5516432f66'
 down_revision = '2db4d4be1fdf'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/2c64e60b80a_contact_exchange.py
+++ b/migrations/versions/2c64e60b80a_contact_exchange.py
@@ -9,8 +9,8 @@ Create Date: 2015-04-15 17:04:28.666090
 revision = '2c64e60b80a'
 down_revision = '522d776a42ed'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/2cbfbcca4737_uuid_columns_for_proposal_and_session.py
+++ b/migrations/versions/2cbfbcca4737_uuid_columns_for_proposal_and_session.py
@@ -12,11 +12,11 @@ down_revision = 'cd8d073d7557'
 
 from uuid import uuid4
 
+import progressbar.widgets
+import sqlalchemy as sa
 from alembic import op
 from progressbar import ProgressBar
 from sqlalchemy.sql import column, table
-import progressbar.widgets
-import sqlalchemy as sa
 
 proposal = table('proposal', column('id', sa.Integer()), column('uuid', sa.Uuid()))
 

--- a/migrations/versions/2d2797b91909_schema_sync.py
+++ b/migrations/versions/2d2797b91909_schema_sync.py
@@ -8,8 +8,8 @@ Create Date: 2020-09-10 04:23:46.996917
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '2d2797b91909'

--- a/migrations/versions/2d55f804a4ed_remove_proposal_space_id_from_sync_.py
+++ b/migrations/versions/2d55f804a4ed_remove_proposal_space_id_from_sync_.py
@@ -10,9 +10,9 @@ Create Date: 2015-10-15 18:33:31.847676
 revision = '2d55f804a4ed'
 down_revision = '48ce908329c0'
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql import column, select, table
-import sqlalchemy as sa
 
 
 def upgrade() -> None:

--- a/migrations/versions/2d73dbe935dc_naming_fixes_for_event_models.py
+++ b/migrations/versions/2d73dbe935dc_naming_fixes_for_event_models.py
@@ -10,8 +10,8 @@ Create Date: 2015-09-30 14:12:47.074389
 revision = '2d73dbe935dc'
 down_revision = '380089617763'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/2db4d4be1fdf_proposal_space_redirect.py
+++ b/migrations/versions/2db4d4be1fdf_proposal_space_redirect.py
@@ -10,8 +10,8 @@ Create Date: 2015-01-16 02:14:52.672861
 revision = '2db4d4be1fdf'
 down_revision = 'a2115fab4c4'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/31253f116e1e_space_date_upto.py
+++ b/migrations/versions/31253f116e1e_space_date_upto.py
@@ -10,8 +10,8 @@ Create Date: 2013-11-14 22:15:44.749221
 revision = '31253f116e1e'
 down_revision = '4aedc1062818'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/316aaa757c8c_coaster_models.py
+++ b/migrations/versions/316aaa757c8c_coaster_models.py
@@ -10,9 +10,9 @@ Create Date: 2013-10-02 17:57:54.584815
 revision = '316aaa757c8c'
 down_revision = '9d513be1a96'
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
-import sqlalchemy as sa
 
 
 def upgrade() -> None:

--- a/migrations/versions/321b11b6a413_add_participant_uuid_field.py
+++ b/migrations/versions/321b11b6a413_add_participant_uuid_field.py
@@ -12,11 +12,11 @@ down_revision = '664141d5ec56'
 
 from uuid import uuid4
 
+import progressbar.widgets
+import sqlalchemy as sa
 from alembic import op
 from progressbar import ProgressBar
 from sqlalchemy.sql import column, table
-import progressbar.widgets
-import sqlalchemy as sa
 
 participant = table(
     'participant', column('id', sa.Integer()), column('uuid', sa.Uuid())

--- a/migrations/versions/347c236041d3_drop_old_state.py
+++ b/migrations/versions/347c236041d3_drop_old_state.py
@@ -9,9 +9,9 @@ Create Date: 2019-03-06 16:34:55.226219
 revision = '347c236041d3'
 down_revision = '4b80fb451c8e'
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql import column, table
-import sqlalchemy as sa
 
 
 class OLD_STATE:  # noqa: N801

--- a/migrations/versions/34a95ee0c3a0_site_membership_models.py
+++ b/migrations/versions/34a95ee0c3a0_site_membership_models.py
@@ -8,8 +8,8 @@ Create Date: 2020-05-14 16:32:52.553441
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '34a95ee0c3a0'

--- a/migrations/versions/380089617763_add_title_to_ticket_type.py
+++ b/migrations/versions/380089617763_add_title_to_ticket_type.py
@@ -10,8 +10,8 @@ Create Date: 2015-09-14 19:29:00.133699
 revision = '380089617763'
 down_revision = '39eed1e99156'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/382cde270594_create_lastuser_tables.py
+++ b/migrations/versions/382cde270594_create_lastuser_tables.py
@@ -8,8 +8,8 @@ Create Date: 2020-04-07 01:51:58.147168
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '382cde270594'

--- a/migrations/versions/38394aa411d0_remove_usergroup_model.py
+++ b/migrations/versions/38394aa411d0_remove_usergroup_model.py
@@ -10,9 +10,9 @@ Create Date: 2019-02-28 17:34:53.814507
 revision = '38394aa411d0'
 down_revision = 'e3bf172763bc'
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
-import sqlalchemy as sa
 
 
 def upgrade() -> None:

--- a/migrations/versions/39af75387b10_proposal_location_and_additional_data.py
+++ b/migrations/versions/39af75387b10_proposal_location_and_additional_data.py
@@ -10,8 +10,8 @@ Create Date: 2015-01-15 21:41:58.144843
 revision = '39af75387b10'
 down_revision = '50f58275fc1c'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 from coaster.sqlalchemy import JsonDict
 

--- a/migrations/versions/39eed1e99156_add_title_to_event.py
+++ b/migrations/versions/39eed1e99156_add_title_to_event.py
@@ -9,8 +9,8 @@ Create Date: 2015-07-07 19:34:04.129355
 revision = '39eed1e99156'
 down_revision = '4083b7bd0cc8'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/3afa589814a9_remove_sections.py
+++ b/migrations/versions/3afa589814a9_remove_sections.py
@@ -10,9 +10,9 @@ Create Date: 2019-06-06 15:06:04.690314
 revision = '3afa589814a9'
 down_revision = '1b8fc63c0fb0'
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
-import sqlalchemy as sa
 
 
 def upgrade() -> None:

--- a/migrations/versions/3b189f2e5c56_add_inherit_sections_to_proposal_space.py
+++ b/migrations/versions/3b189f2e5c56_add_inherit_sections_to_proposal_space.py
@@ -10,8 +10,8 @@ Create Date: 2015-12-29 13:04:34.484205
 revision = '3b189f2e5c56'
 down_revision = '416a2f958279'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/3c47ba103724_proposal_status.py
+++ b/migrations/versions/3c47ba103724_proposal_status.py
@@ -10,9 +10,9 @@ Create Date: 2014-01-28 00:09:39.231864
 revision = '3c47ba103724'
 down_revision = '6f98e24760d'
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql import column, table
-import sqlalchemy as sa
 
 
 # The PROPOSALSTATUS class as it was when this migration was created

--- a/migrations/versions/3d3df26524b7_commentset_membership.py
+++ b/migrations/versions/3d3df26524b7_commentset_membership.py
@@ -8,8 +8,8 @@ Create Date: 2020-12-04 13:03:31.208857
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '3d3df26524b7'

--- a/migrations/versions/4083b7bd0cc8_remove_id_from_contact_exchange.py
+++ b/migrations/versions/4083b7bd0cc8_remove_id_from_contact_exchange.py
@@ -9,8 +9,8 @@ Create Date: 2015-07-06 17:42:40.175382
 revision = '4083b7bd0cc8'
 down_revision = '22fb4e1e3139'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/41a4531be082_remove_account_name.py
+++ b/migrations/versions/41a4531be082_remove_account_name.py
@@ -8,10 +8,10 @@ Create Date: 2020-04-16 20:46:50.889210
 
 from typing import Optional, Tuple, Union
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.sql import column, table
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '41a4531be082'

--- a/migrations/versions/41b3af7e4449_migrating_preview_video_to_video_field.py
+++ b/migrations/versions/41b3af7e4449_migrating_preview_video_to_video_field.py
@@ -6,15 +6,15 @@ Create Date: 2020-04-15 10:36:15.558161
 
 """
 
-from textwrap import dedent
-from typing import Optional, Tuple, Union
 import csv
 import re
 import urllib.parse
+from textwrap import dedent
+from typing import Optional, Tuple, Union
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql import column, table
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '41b3af7e4449'

--- a/migrations/versions/436114dffa00_remove_proposalspace_content.py
+++ b/migrations/versions/436114dffa00_remove_proposalspace_content.py
@@ -10,8 +10,8 @@ Create Date: 2014-12-03 02:12:33.737669
 revision = '436114dffa00'
 down_revision = 'f8204bcd438'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 from coaster.sqlalchemy import JsonDict
 

--- a/migrations/versions/447728ca6d2e_add_buy_tickets_url.py
+++ b/migrations/versions/447728ca6d2e_add_buy_tickets_url.py
@@ -10,8 +10,8 @@ Create Date: 2015-04-06 16:43:50.255747
 revision = '447728ca6d2e'
 down_revision = '14d1424b47'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/4845fd12dbfd_keep_revoked_timestamp.py
+++ b/migrations/versions/4845fd12dbfd_keep_revoked_timestamp.py
@@ -8,8 +8,8 @@ Create Date: 2020-09-18 00:53:48.765903
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '4845fd12dbfd'

--- a/migrations/versions/488077138ee4_correct_database_and_model_.py
+++ b/migrations/versions/488077138ee4_correct_database_and_model_.py
@@ -11,9 +11,9 @@ Create Date: 2018-11-12 13:54:09.987761
 revision = '488077138ee4'
 down_revision = '2cbfbcca4737'
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.schema import CreateSequence, DropSequence, Sequence
-import sqlalchemy as sa
 
 from coaster.sqlalchemy import JsonDict
 

--- a/migrations/versions/4aedc1062818_session_edits.py
+++ b/migrations/versions/4aedc1062818_session_edits.py
@@ -10,8 +10,8 @@ Create Date: 2013-11-13 23:10:16.406404
 revision = '4aedc1062818'
 down_revision = '55097480a655'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/4b630fb42760_init.py
+++ b/migrations/versions/4b630fb42760_init.py
@@ -12,8 +12,8 @@ from typing import Optional
 revision = '4b630fb42760'
 down_revision: Optional[str] = None
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/4b7fe9b25c6c_removed_legacy_name_from_project.py
+++ b/migrations/versions/4b7fe9b25c6c_removed_legacy_name_from_project.py
@@ -10,9 +10,9 @@ Create Date: 2019-05-30 12:33:00.598454
 revision = '4b7fe9b25c6c'
 down_revision = '252f9a705901'
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql import column, table
-import sqlalchemy as sa
 
 project = table(
     'project',

--- a/migrations/versions/4b80fb451c8e_project_tri_state_columns.py
+++ b/migrations/versions/4b80fb451c8e_project_tri_state_columns.py
@@ -10,9 +10,9 @@ Create Date: 2019-02-07 01:55:47.123273
 revision = '4b80fb451c8e'
 down_revision = '9aa60ff2a0ea'
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql import column, table
-import sqlalchemy as sa
 
 
 class OLD_STATE:  # noqa: N801

--- a/migrations/versions/4dbf686f4380_added_location_to_pr.py
+++ b/migrations/versions/4dbf686f4380_added_location_to_pr.py
@@ -10,8 +10,8 @@ Create Date: 2013-11-08 23:35:43.433963
 revision = '4dbf686f4380'
 down_revision = '1fcee2e6280'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/4f805eefa9f4_urls_now_use_string_instead_of_text.py
+++ b/migrations/versions/4f805eefa9f4_urls_now_use_string_instead_of_text.py
@@ -8,8 +8,8 @@ Create Date: 2022-12-22 15:06:54.491988
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = '4f805eefa9f4'

--- a/migrations/versions/50a8f43b4e5f_remove_blogpost_column.py
+++ b/migrations/versions/50a8f43b4e5f_remove_blogpost_column.py
@@ -10,8 +10,8 @@ Create Date: 2014-12-03 03:46:34.962222
 revision = '50a8f43b4e5f'
 down_revision = '411fc4124fb5'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/522d776a42ed_event_models.py
+++ b/migrations/versions/522d776a42ed_event_models.py
@@ -9,8 +9,8 @@ Create Date: 2015-04-15 01:31:51.056264
 revision = '522d776a42ed'
 down_revision = '447728ca6d2e'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/523c53593e3c_proposalspace_explor.py
+++ b/migrations/versions/523c53593e3c_proposalspace_explor.py
@@ -10,8 +10,8 @@ Create Date: 2014-10-13 13:10:49.917013
 revision = '523c53593e3c'
 down_revision = '14d7082476c0'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/5290f9238875_feedback.py
+++ b/migrations/versions/5290f9238875_feedback.py
@@ -10,8 +10,8 @@ Create Date: 2013-09-16 21:48:11.320616
 revision = '5290f9238875'
 down_revision = '4b630fb42760'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/530c22761e27_fix_column_lengths.py
+++ b/migrations/versions/530c22761e27_fix_column_lengths.py
@@ -8,8 +8,8 @@ Create Date: 2020-04-20 16:19:22.597712
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '530c22761e27'

--- a/migrations/versions/542fd8471e84_match_old_to_new_user_and_team_columns.py
+++ b/migrations/versions/542fd8471e84_match_old_to_new_user_and_team_columns.py
@@ -8,8 +8,8 @@ Create Date: 2020-04-07 03:52:04.415019
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '542fd8471e84'

--- a/migrations/versions/55097480a655_event_timezone.py
+++ b/migrations/versions/55097480a655_event_timezone.py
@@ -10,8 +10,8 @@ Create Date: 2013-11-09 15:53:48.318340
 revision = '55097480a655'
 down_revision = '3a6b2ab00e3e'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/55b1ef63bee_admin_and_review_tea.py
+++ b/migrations/versions/55b1ef63bee_admin_and_review_tea.py
@@ -10,8 +10,8 @@ Create Date: 2014-04-19 19:30:27.529641
 revision = '55b1ef63bee'
 down_revision = '18052b0cd282'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/56ba15eff9ad_saved_projects_and_sessions.py
+++ b/migrations/versions/56ba15eff9ad_saved_projects_and_sessions.py
@@ -10,8 +10,8 @@ Create Date: 2019-07-04 14:32:53.383544
 revision = '56ba15eff9ad'
 down_revision = '5e06feda611d'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/570f4ea99cda_add_labels_to_proposal_space.py
+++ b/migrations/versions/570f4ea99cda_add_labels_to_proposal_space.py
@@ -10,9 +10,9 @@ Create Date: 2016-02-02 20:45:07.804542
 revision = '570f4ea99cda'
 down_revision = '3b189f2e5c56'
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql import column, table
-import sqlalchemy as sa
 
 from coaster.sqlalchemy import JsonDict
 

--- a/migrations/versions/577689971aa0_space_content.py
+++ b/migrations/versions/577689971aa0_space_content.py
@@ -10,8 +10,8 @@ Create Date: 2014-03-02 23:32:16.343014
 revision = '577689971aa0'
 down_revision = '1195a2789872'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 from coaster.sqlalchemy import JsonDict
 

--- a/migrations/versions/58588eba8cb8_room_bgcolor_default.py
+++ b/migrations/versions/58588eba8cb8_room_bgcolor_default.py
@@ -10,8 +10,8 @@ Create Date: 2013-11-18 15:46:41.943587
 revision = '58588eba8cb8'
 down_revision = '31253f116e1e'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 from funnel.models import VenueRoom
 

--- a/migrations/versions/5e06feda611d_session_start_and_end_column_names.py
+++ b/migrations/versions/5e06feda611d_session_start_and_end_column_names.py
@@ -10,8 +10,8 @@ Create Date: 2019-06-26 14:59:43.362731
 revision = '5e06feda611d'
 down_revision = 'b61a489d34a4'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/5f1ab3e04f73_drop_support_for_128_bit_blake2b_hash_.py
+++ b/migrations/versions/5f1ab3e04f73_drop_support_for_128_bit_blake2b_hash_.py
@@ -6,15 +6,15 @@ Create Date: 2020-10-07 10:24:32.491617
 
 """
 
-from typing import Optional, Tuple, Union
 import hashlib
+from typing import Optional, Tuple, Union
 
+import progressbar.widgets
+import sqlalchemy as sa
 from alembic import op
 from progressbar import ProgressBar
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.sql import column, table
-import progressbar.widgets
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '5f1ab3e04f73'

--- a/migrations/versions/5f465411775c_project_end_at_after_start_at.py
+++ b/migrations/versions/5f465411775c_project_end_at_after_start_at.py
@@ -8,9 +8,9 @@ Create Date: 2021-06-03 02:46:53.673764
 
 from typing import Optional, Tuple, Union
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql import column
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '5f465411775c'

--- a/migrations/versions/60a132ae73f1_url_field_leng.py
+++ b/migrations/versions/60a132ae73f1_url_field_leng.py
@@ -10,8 +10,8 @@ Create Date: 2018-11-20 18:01:51.811819
 revision = '60a132ae73f1'
 down_revision = 'd6b1904bea0e'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/60ee1687f59c_project_cfp_end_at_after_cfp_start_at.py
+++ b/migrations/versions/60ee1687f59c_project_cfp_end_at_after_cfp_start_at.py
@@ -8,9 +8,9 @@ Create Date: 2021-06-03 15:34:31.913604
 
 from typing import Optional, Tuple, Union
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql import column
-import sqlalchemy as sa
 
 cfp_start_at = column('start_at', sa.TIMESTAMP)
 cfp_end_at = column('end_at', sa.TIMESTAMP)

--- a/migrations/versions/62d770006955_drop_old_user_and_team_columns.py
+++ b/migrations/versions/62d770006955_drop_old_user_and_team_columns.py
@@ -8,8 +8,8 @@ Create Date: 2020-04-07 04:14:29.626224
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '62d770006955'

--- a/migrations/versions/63c44675b6cd_migrate_to_phonenumber.py
+++ b/migrations/versions/63c44675b6cd_migrate_to_phonenumber.py
@@ -6,14 +6,14 @@ Create Date: 2023-01-17 22:58:23.556730
 
 """
 
-from typing import Optional, Tuple, Union
 import hashlib
+from typing import Optional, Tuple, Union
 
-from alembic import op
-from sqlalchemy.sql import column, table
 import phonenumbers
 import rich.progress
 import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.sql import column, table
 
 # revision identifiers, used by Alembic.
 revision: str = '63c44675b6cd'

--- a/migrations/versions/64f0cfe37976_remove_proposal_feedback_model.py
+++ b/migrations/versions/64f0cfe37976_remove_proposal_feedback_model.py
@@ -8,9 +8,9 @@ Create Date: 2021-04-28 02:37:36.369238
 
 from typing import Optional, Tuple, Union
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '64f0cfe37976'

--- a/migrations/versions/664141d5ec56_add_video_mixin_to_proposal_and_session.py
+++ b/migrations/versions/664141d5ec56_add_video_mixin_to_proposal_and_session.py
@@ -9,8 +9,8 @@ Create Date: 2020-03-16 16:06:28.827051
 revision = '664141d5ec56'
 down_revision = '20c10335b553'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/6835596b1eee_shortlink_model.py
+++ b/migrations/versions/6835596b1eee_shortlink_model.py
@@ -8,8 +8,8 @@ Create Date: 2021-06-13 06:08:28.858610
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '6835596b1eee'

--- a/migrations/versions/69c2ced88981_team_org_uuid.py
+++ b/migrations/versions/69c2ced88981_team_org_uuid.py
@@ -10,11 +10,11 @@ Create Date: 2018-12-07 20:21:02.169857
 revision = '69c2ced88981'
 down_revision = 'b34aa62af7fc'
 
+import progressbar.widgets
+import sqlalchemy as sa
 from alembic import op
 from progressbar import ProgressBar
 from sqlalchemy.sql import column, table
-import progressbar.widgets
-import sqlalchemy as sa
 
 from coaster.utils import buid2uuid, uuid2buid
 

--- a/migrations/versions/6d3599c52873_post_model_field_name_fix.py
+++ b/migrations/versions/6d3599c52873_post_model_field_name_fix.py
@@ -8,8 +8,8 @@ Create Date: 2020-07-23 12:47:40.474840
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '6d3599c52873'

--- a/migrations/versions/6ebbe0cc8e19_change_vote_table_to_use_composite_pkey.py
+++ b/migrations/versions/6ebbe0cc8e19_change_vote_table_to_use_composite_pkey.py
@@ -9,9 +9,9 @@ Create Date: 2020-05-05 00:48:41.032308
 
 from typing import Optional, Tuple, Union
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.schema import CreateSequence, Sequence
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '6ebbe0cc8e19'

--- a/migrations/versions/6f98e24760d_session_speaker.py
+++ b/migrations/versions/6f98e24760d_session_speaker.py
@@ -10,8 +10,8 @@ Create Date: 2013-11-22 17:28:47.751025
 revision = '6f98e24760d'
 down_revision = '58588eba8cb8'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/70ffbc1bcf88_logo_url_banner_url_hasjob_embed.py
+++ b/migrations/versions/70ffbc1bcf88_logo_url_banner_url_hasjob_embed.py
@@ -9,8 +9,8 @@ Create Date: 2018-11-19 16:19:47.976268
 revision = '70ffbc1bcf88'
 down_revision = 'b553db89a76e'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 from coaster.sqlalchemy import JsonDict
 

--- a/migrations/versions/71ea1c409bd7_add_project_update_numbers.py
+++ b/migrations/versions/71ea1c409bd7_add_project_update_numbers.py
@@ -8,8 +8,8 @@ Create Date: 2020-07-27 00:08:46.972049
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '71ea1c409bd7'

--- a/migrations/versions/71f961809275_add_checkin_team_to_proposal_space.py
+++ b/migrations/versions/71f961809275_add_checkin_team_to_proposal_space.py
@@ -10,8 +10,8 @@ Create Date: 2018-04-20 00:57:52.673419
 revision = '71f961809275'
 down_revision = '90cc904ece17'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/71fcac85957c_populate_membership_models.py
+++ b/migrations/versions/71fcac85957c_populate_membership_models.py
@@ -9,9 +9,9 @@ Create Date: 2020-04-21 02:01:52.012077
 from typing import Optional, Tuple, Union
 from uuid import uuid4
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql import column, table
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '71fcac85957c'

--- a/migrations/versions/74e1fbb4a948_notification_constraint_on_document_and_.py
+++ b/migrations/versions/74e1fbb4a948_notification_constraint_on_document_and_.py
@@ -8,8 +8,8 @@ Create Date: 2020-08-29 17:59:31.485184
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '74e1fbb4a948'

--- a/migrations/versions/752dee4ae101_remove_unused_proposal_data.py
+++ b/migrations/versions/752dee4ae101_remove_unused_proposal_data.py
@@ -10,8 +10,8 @@ Create Date: 2019-06-06 15:23:00.280127
 revision = '752dee4ae101'
 down_revision = '3afa589814a9'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 from coaster.sqlalchemy import JsonDict
 

--- a/migrations/versions/79719ee38228_moderator_report_models.py
+++ b/migrations/versions/79719ee38228_moderator_report_models.py
@@ -8,8 +8,8 @@ Create Date: 2020-06-09 15:42:27.791372
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '79719ee38228'

--- a/migrations/versions/7aa9eb80aab4_add_sysadmin_flag.py
+++ b/migrations/versions/7aa9eb80aab4_add_sysadmin_flag.py
@@ -8,8 +8,8 @@ Create Date: 2023-03-08 22:10:27.937483
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = '7aa9eb80aab4'

--- a/migrations/versions/7cd383925de_subspaces.py
+++ b/migrations/versions/7cd383925de_subspaces.py
@@ -10,8 +10,8 @@ Create Date: 2015-01-18 23:16:09.790396
 revision = '7cd383925de'
 down_revision = '21a7dfe8ab4d'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/7d5b77aada1e_add_geoname_models.py
+++ b/migrations/versions/7d5b77aada1e_add_geoname_models.py
@@ -8,9 +8,9 @@ Create Date: 2021-06-19 17:05:32.356693
 
 from typing import Optional, Tuple, Union
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '7d5b77aada1e'

--- a/migrations/versions/7ee3c83f713f_remove_team_fkeys.py
+++ b/migrations/versions/7ee3c83f713f_remove_team_fkeys.py
@@ -8,8 +8,8 @@ Create Date: 2020-04-28 02:24:31.889951
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '7ee3c83f713f'

--- a/migrations/versions/7f6f417dad02_add_user_locale.py
+++ b/migrations/versions/7f6f417dad02_add_user_locale.py
@@ -8,9 +8,9 @@ Create Date: 2020-08-17 07:22:09.637346
 
 from typing import Optional, Tuple, Union
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy_utils import LocaleType
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '7f6f417dad02'

--- a/migrations/versions/7f8114c73092_add_rsvp_uuid.py
+++ b/migrations/versions/7f8114c73092_add_rsvp_uuid.py
@@ -9,11 +9,11 @@ Create Date: 2020-08-18 22:45:58.557775
 from typing import Optional, Tuple, Union
 from uuid import uuid4
 
+import progressbar.widgets
+import sqlalchemy as sa
 from alembic import op
 from progressbar import ProgressBar
 from sqlalchemy.sql import column, table
-import progressbar.widgets
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '7f8114c73092'

--- a/migrations/versions/80b09cfb38c6_profile_website_field.py
+++ b/migrations/versions/80b09cfb38c6_profile_website_field.py
@@ -8,8 +8,8 @@ Create Date: 2020-08-06 15:18:01.978252
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 from coaster.sqlalchemy import UrlType
 

--- a/migrations/versions/82303877b746_update_proposalmembership_structure.py
+++ b/migrations/versions/82303877b746_update_proposalmembership_structure.py
@@ -8,8 +8,8 @@ Create Date: 2021-04-29 02:47:39.590061
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '82303877b746'

--- a/migrations/versions/832a4481cda9_tagline_for_profile.py
+++ b/migrations/versions/832a4481cda9_tagline_for_profile.py
@@ -8,8 +8,8 @@ Create Date: 2022-07-14 13:34:38.590945
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = '832a4481cda9'

--- a/migrations/versions/851473d61beb_rename_post_to_update.py
+++ b/migrations/versions/851473d61beb_rename_post_to_update.py
@@ -8,8 +8,8 @@ Create Date: 2020-08-08 07:31:11.811599
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '851473d61beb'

--- a/migrations/versions/8829241430b6_add_membership_models.py
+++ b/migrations/versions/8829241430b6_add_membership_models.py
@@ -8,8 +8,8 @@ Create Date: 2020-04-21 01:40:41.323838
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '8829241430b6'

--- a/migrations/versions/887db555cca9_adding_uuid_to_commentset.py
+++ b/migrations/versions/887db555cca9_adding_uuid_to_commentset.py
@@ -9,11 +9,11 @@ Create Date: 2020-05-08 19:16:15.324555
 from typing import Optional, Tuple, Union
 from uuid import uuid4
 
+import progressbar.widgets
+import sqlalchemy as sa
 from alembic import op
 from progressbar import ProgressBar
 from sqlalchemy.sql import column, table
-import progressbar.widgets
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '887db555cca9'

--- a/migrations/versions/896137ace892_remove_voteset_and_vote.py
+++ b/migrations/versions/896137ace892_remove_voteset_and_vote.py
@@ -8,9 +8,9 @@ Create Date: 2021-06-15 03:26:20.618000
 
 from typing import Optional, Tuple, Union
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '896137ace892'

--- a/migrations/versions/8b46a8a8ca17_rename_user_status_to_user_state.py
+++ b/migrations/versions/8b46a8a8ca17_rename_user_status_to_user_state.py
@@ -8,8 +8,8 @@ Create Date: 2020-11-05 11:01:13.504106
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '8b46a8a8ca17'

--- a/migrations/versions/90cc904ece17_add_badge_template_to_event.py
+++ b/migrations/versions/90cc904ece17_add_badge_template_to_event.py
@@ -10,8 +10,8 @@ Create Date: 2018-04-17 14:35:52.263777
 revision = '90cc904ece17'
 down_revision = 'cf775ffe502e'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/931be3605dc4_notification_models.py
+++ b/migrations/versions/931be3605dc4_notification_models.py
@@ -8,8 +8,8 @@ Create Date: 2020-08-18 11:58:05.088406
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '931be3605dc4'

--- a/migrations/versions/9333436765cd_add_emailaddress.py
+++ b/migrations/versions/9333436765cd_add_emailaddress.py
@@ -8,8 +8,8 @@ Create Date: 2020-06-11 07:31:23.089071
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '9333436765cd'

--- a/migrations/versions/94ce3a9b7a3a_draft_model.py
+++ b/migrations/versions/94ce3a9b7a3a_draft_model.py
@@ -9,8 +9,8 @@ Create Date: 2019-02-06 20:48:34.700795
 revision = '94ce3a9b7a3a'
 down_revision = 'a9cb0e1c52ed'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 from coaster.sqlalchemy.columns import JsonDict
 

--- a/migrations/versions/99e5e7b54104_drop_user_avatar_field.py
+++ b/migrations/versions/99e5e7b54104_drop_user_avatar_field.py
@@ -8,8 +8,8 @@ Create Date: 2020-08-07 12:10:20.004784
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '99e5e7b54104'

--- a/migrations/versions/99e99507a595_add_commentset_state.py
+++ b/migrations/versions/99e99507a595_add_commentset_state.py
@@ -8,8 +8,8 @@ Create Date: 2021-08-15 22:43:02.921034
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = '99e99507a595'

--- a/migrations/versions/9a0d8fa7da29_project_location.py
+++ b/migrations/versions/9a0d8fa7da29_project_location.py
@@ -9,8 +9,8 @@ Create Date: 2018-11-28 10:48:57.245376
 revision = '9a0d8fa7da29'
 down_revision = 'eec2fad0f3e9'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 from coaster.sqlalchemy import JsonDict
 

--- a/migrations/versions/9aa60ff2a0ea_migrate_to_urltype.py
+++ b/migrations/versions/9aa60ff2a0ea_migrate_to_urltype.py
@@ -10,8 +10,8 @@ Create Date: 2019-02-21 08:48:06.335465
 revision = '9aa60ff2a0ea'
 down_revision = '38394aa411d0'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 from coaster.sqlalchemy import UrlType
 

--- a/migrations/versions/9ad724b3e8cc_remove_userphoneclaim.py
+++ b/migrations/versions/9ad724b3e8cc_remove_userphoneclaim.py
@@ -8,9 +8,9 @@ Create Date: 2022-07-08 11:01:32.223788
 
 from typing import Optional, Tuple, Union
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '9ad724b3e8cc'

--- a/migrations/versions/a116118d086b_add_frozen_title.py
+++ b/migrations/versions/a116118d086b_add_frozen_title.py
@@ -8,8 +8,8 @@ Create Date: 2022-07-13 20:59:11.442605
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = 'a116118d086b'

--- a/migrations/versions/a1ab7bd78649_post_model.py
+++ b/migrations/versions/a1ab7bd78649_post_model.py
@@ -9,9 +9,9 @@ Create Date: 2020-07-03 10:57:39.988762
 from textwrap import dedent
 from typing import Optional, Tuple, Union
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy_utils import TSVectorType
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'a1ab7bd78649'

--- a/migrations/versions/a2115fab4c4_proposal_fields_are_now_optional.py
+++ b/migrations/versions/a2115fab4c4_proposal_fields_are_now_optional.py
@@ -10,8 +10,8 @@ Create Date: 2015-01-16 01:34:45.460775
 revision = 'a2115fab4c4'
 down_revision = '39af75387b10'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/a23e88f06478_add_commentset_fields.py
+++ b/migrations/versions/a23e88f06478_add_commentset_fields.py
@@ -7,9 +7,9 @@ Create Date: 2021-03-22 02:54:30.416806
 
 from typing import Optional, Tuple, Union
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql import column, table
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'a23e88f06478'

--- a/migrations/versions/a42398081979_comment_moderator_report_resolved_at.py
+++ b/migrations/versions/a42398081979_comment_moderator_report_resolved_at.py
@@ -8,8 +8,8 @@ Create Date: 2020-09-11 12:13:15.019538
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'a42398081979'

--- a/migrations/versions/a5dbb3f843e4_add_start_end_check_constraints.py
+++ b/migrations/versions/a5dbb3f843e4_add_start_end_check_constraints.py
@@ -8,9 +8,9 @@ Create Date: 2021-04-27 17:38:26.162336
 
 from typing import Optional, Tuple, Union
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql import column
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'a5dbb3f843e4'

--- a/migrations/versions/a9cb0e1c52ed_uuid_fields_venue_room.py
+++ b/migrations/versions/a9cb0e1c52ed_uuid_fields_venue_room.py
@@ -12,9 +12,9 @@ down_revision = 'e417a13e136d'
 
 from uuid import uuid4
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql import column, table
-import sqlalchemy as sa
 
 venue_room = table('venue_room', column('id', sa.Integer()), column('uuid', sa.Uuid()))
 

--- a/migrations/versions/abfda6e2f41d_rename_to_comment_in_reply_to.py
+++ b/migrations/versions/abfda6e2f41d_rename_to_comment_in_reply_to.py
@@ -8,8 +8,8 @@ Create Date: 2020-09-15 17:13:15.240427
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'abfda6e2f41d'

--- a/migrations/versions/ad5013552ec6_simplify_proposal_fields.py
+++ b/migrations/versions/ad5013552ec6_simplify_proposal_fields.py
@@ -9,11 +9,11 @@ Create Date: 2020-12-08 13:58:56.331436
 from textwrap import dedent
 from typing import Optional, Tuple, Union
 
+import progressbar.widgets
+import sqlalchemy as sa
 from alembic import op
 from progressbar import ProgressBar
 from sqlalchemy.sql import column, table
-import progressbar.widgets
-import sqlalchemy as sa
 
 from coaster.utils import markdown
 

--- a/migrations/versions/ae075a249493_migrate_email_addresses.py
+++ b/migrations/versions/ae075a249493_migrate_email_addresses.py
@@ -6,16 +6,16 @@ Create Date: 2020-06-11 08:01:40.108228
 
 """
 
-from typing import Optional, Tuple, Union
 import hashlib
+from typing import Optional, Tuple, Union
 
+import idna
+import progressbar.widgets
+import sqlalchemy as sa
 from alembic import op
 from progressbar import ProgressBar
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.sql import column, table
-import idna
-import progressbar.widgets
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'ae075a249493'

--- a/migrations/versions/ae68621248af_primary_venue.py
+++ b/migrations/versions/ae68621248af_primary_venue.py
@@ -10,8 +10,8 @@ Create Date: 2018-11-23 01:52:58.790889
 revision = 'ae68621248af'
 down_revision = '2441cb4f44d4'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/aebd5a9e5af1_project_timestamps.py
+++ b/migrations/versions/aebd5a9e5af1_project_timestamps.py
@@ -8,11 +8,11 @@ Create Date: 2021-04-27 00:52:53.622787
 
 from typing import Optional, Tuple, Union
 
+import progressbar.widgets
+import sqlalchemy as sa
 from alembic import op
 from progressbar import ProgressBar
 from sqlalchemy.sql import column, table
-import progressbar.widgets
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'aebd5a9e5af1'

--- a/migrations/versions/b34aa62af7fc_uuid_columns_for_project_profile_user_team.py
+++ b/migrations/versions/b34aa62af7fc_uuid_columns_for_project_profile_user_team.py
@@ -12,11 +12,11 @@ down_revision = '19a1f7f2a365'
 
 from uuid import uuid4
 
+import progressbar.widgets
+import sqlalchemy as sa
 from alembic import op
 from progressbar import ProgressBar
 from sqlalchemy.sql import column, table
-import progressbar.widgets
-import sqlalchemy as sa
 
 from coaster.utils import buid2uuid, uuid2buid
 

--- a/migrations/versions/b553db89a76e_fix_column_settings.py
+++ b/migrations/versions/b553db89a76e_fix_column_settings.py
@@ -10,8 +10,8 @@ Create Date: 2018-11-13 22:34:43.992341
 revision = 'b553db89a76e'
 down_revision = 'ccfad4d5e383'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/b61a489d34a4_contactexchange_notes_and_metadata.py
+++ b/migrations/versions/b61a489d34a4_contactexchange_notes_and_metadata.py
@@ -10,9 +10,9 @@ Create Date: 2019-06-22 10:28:13.775099
 revision = 'b61a489d34a4'
 down_revision = '1829e53eba75'
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql import column, table
-import sqlalchemy as sa
 
 contact_exchange = table(
     'contact_exchange',

--- a/migrations/versions/b6d0edac3e20_profile_banner_image_url.py
+++ b/migrations/versions/b6d0edac3e20_profile_banner_image_url.py
@@ -8,8 +8,8 @@ Create Date: 2020-06-19 12:30:25.891325
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 from coaster.sqlalchemy import UrlType
 

--- a/migrations/versions/b7165507d80c_track_oauth2_refresh_token_and_expiry.py
+++ b/migrations/versions/b7165507d80c_track_oauth2_refresh_token_and_expiry.py
@@ -8,8 +8,8 @@ Create Date: 2022-03-15 15:38:33.306920
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'b7165507d80c'

--- a/migrations/versions/b8a87e6a24f1_versionid_is_now_revisionid_and_in_more_.py
+++ b/migrations/versions/b8a87e6a24f1_versionid_is_now_revisionid_and_in_more_.py
@@ -8,8 +8,8 @@ Create Date: 2022-12-22 12:13:06.124550
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = 'b8a87e6a24f1'

--- a/migrations/versions/bd465803af3a_add_sponsormembership.py
+++ b/migrations/versions/bd465803af3a_add_sponsormembership.py
@@ -8,8 +8,8 @@ Create Date: 2021-04-22 05:02:07.027690
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'bd465803af3a'

--- a/migrations/versions/c11dc931b903_removed_date_date_upto_from_project.py
+++ b/migrations/versions/c11dc931b903_removed_date_date_upto_from_project.py
@@ -10,9 +10,9 @@ Create Date: 2019-06-08 10:58:13.772112
 revision = 'c11dc931b903'
 down_revision = '56ba15eff9ad'
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql import column, table
-import sqlalchemy as sa
 
 project = table(
     'project',

--- a/migrations/versions/c3069d33419a_comment_uuid_field.py
+++ b/migrations/versions/c3069d33419a_comment_uuid_field.py
@@ -11,11 +11,11 @@ down_revision = '69c2ced88981'
 
 from uuid import uuid4
 
+import progressbar.widgets
+import sqlalchemy as sa
 from alembic import op
 from progressbar import ProgressBar
 from sqlalchemy.sql import column, table
-import progressbar.widgets
-import sqlalchemy as sa
 
 comment = table('comment', column('id', sa.Integer()), column('uuid', sa.Uuid()))
 

--- a/migrations/versions/c3483d25178c_remove_obsolete_proposal_fields.py
+++ b/migrations/versions/c3483d25178c_remove_obsolete_proposal_fields.py
@@ -7,8 +7,8 @@ Create Date: 2021-04-05 20:36:55.734125
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'c3483d25178c'

--- a/migrations/versions/c38fa391613f_contact_exchange_model_change.py
+++ b/migrations/versions/c38fa391613f_contact_exchange_model_change.py
@@ -10,8 +10,8 @@ Create Date: 2019-05-20 14:41:42.347664
 revision = 'c38fa391613f'
 down_revision = '4b7fe9b25c6c'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/c47007758ee6_add_email_address_active_at.py
+++ b/migrations/versions/c47007758ee6_add_email_address_active_at.py
@@ -8,9 +8,9 @@ Create Date: 2020-08-20 21:47:43.356619
 
 from typing import Optional, Tuple, Union
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy import column, table
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'c47007758ee6'

--- a/migrations/versions/ca578c1b82e8_populate_usersession_geonameid_from_ip_.py
+++ b/migrations/versions/ca578c1b82e8_populate_usersession_geonameid_from_ip_.py
@@ -9,11 +9,11 @@ Create Date: 2021-04-28 18:02:29.867574
 from types import SimpleNamespace
 from typing import Optional, Tuple, Union
 
+import progressbar.widgets
+import sqlalchemy as sa
 from alembic import op
 from progressbar import ProgressBar
 from sqlalchemy.sql import column, table
-import progressbar.widgets
-import sqlalchemy as sa
 
 try:
     import geoip2.database as geoip2_database

--- a/migrations/versions/cad24ab35cc2_limit_session_duration_to_24h.py
+++ b/migrations/versions/cad24ab35cc2_limit_session_duration_to_24h.py
@@ -8,9 +8,9 @@ Create Date: 2021-06-09 02:50:38.875251
 
 from typing import Optional, Tuple, Union
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql import column
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'cad24ab35cc2'

--- a/migrations/versions/ccfad4d5e383_rename_proposalspace_to_project.py
+++ b/migrations/versions/ccfad4d5e383_rename_proposalspace_to_project.py
@@ -10,8 +10,8 @@ Create Date: 2018-11-13 13:40:54.744756
 revision = 'ccfad4d5e383'
 down_revision = '488077138ee4'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # (old, new)
 renamed_tables = [

--- a/migrations/versions/cd8d073d7557_sync_db_with_models.py
+++ b/migrations/versions/cd8d073d7557_sync_db_with_models.py
@@ -10,8 +10,8 @@ Create Date: 2018-11-07 14:50:09.572953
 revision = 'cd8d073d7557'
 down_revision = '71f961809275'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/d0097ec29880_fix_membership_granted_by.py
+++ b/migrations/versions/d0097ec29880_fix_membership_granted_by.py
@@ -8,8 +8,8 @@ Create Date: 2021-04-22 05:20:50.774828
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'd0097ec29880'

--- a/migrations/versions/d0a6fab28b7f_add_label_to_project_crew_membership.py
+++ b/migrations/versions/d0a6fab28b7f_add_label_to_project_crew_membership.py
@@ -8,8 +8,8 @@ Create Date: 2023-03-15 01:37:55.947574
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = 'd0a6fab28b7f'

--- a/migrations/versions/d50c3d8e3f33_drop_old_user_and_team_tables.py
+++ b/migrations/versions/d50c3d8e3f33_drop_old_user_and_team_tables.py
@@ -9,9 +9,9 @@ Create Date: 2020-04-07 05:17:03.917173
 
 from typing import Optional, Tuple, Union
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'd50c3d8e3f33'

--- a/migrations/versions/d576f55f9eba_proposal_instructions.py
+++ b/migrations/versions/d576f55f9eba_proposal_instructions.py
@@ -10,8 +10,8 @@ Create Date: 2017-10-31 13:03:06.146288
 revision = 'd576f55f9eba'
 down_revision = '570f4ea99cda'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/d5d6aba41475_remove_proposal_speaker_id.py
+++ b/migrations/versions/d5d6aba41475_remove_proposal_speaker_id.py
@@ -8,8 +8,8 @@ Create Date: 2021-05-11 05:50:32.990176
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'd5d6aba41475'

--- a/migrations/versions/d6b1904bea0e_add_session_featured_field.py
+++ b/migrations/versions/d6b1904bea0e_add_session_featured_field.py
@@ -9,8 +9,8 @@ Create Date: 2018-11-20 17:22:11.582473
 revision = 'd6b1904bea0e'
 down_revision = '70ffbc1bcf88'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/daeb6753652a_add_profile_protected_and_verified_flags.py
+++ b/migrations/versions/daeb6753652a_add_profile_protected_and_verified_flags.py
@@ -8,8 +8,8 @@ Create Date: 2020-11-06 02:57:05.891627
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'daeb6753652a'

--- a/migrations/versions/dcd0870c24cc_remove_password_reset_request_model.py
+++ b/migrations/versions/dcd0870c24cc_remove_password_reset_request_model.py
@@ -8,9 +8,9 @@ Create Date: 2020-08-02 02:02:43.959488
 
 from typing import Optional, Tuple, Union
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'dcd0870c24cc'

--- a/migrations/versions/e111dd05e62b_remove_proposalredirect_model.py
+++ b/migrations/versions/e111dd05e62b_remove_proposalredirect_model.py
@@ -8,9 +8,9 @@ Create Date: 2021-05-07 02:58:36.527380
 
 from typing import Optional, Tuple, Union
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'e111dd05e62b'

--- a/migrations/versions/e2b28adfa135_add_proposal_suuid_redirect.py
+++ b/migrations/versions/e2b28adfa135_add_proposal_suuid_redirect.py
@@ -8,11 +8,11 @@ Create Date: 2020-04-20 03:31:29.101725
 
 from typing import Optional, Tuple, Union
 
+import progressbar.widgets
+import sqlalchemy as sa
 from alembic import op
 from progressbar import ProgressBar
 from sqlalchemy.sql import column, table
-import progressbar.widgets
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'e2b28adfa135'

--- a/migrations/versions/e2be4ab896d3_migrate_old_labels.py
+++ b/migrations/versions/e2be4ab896d3_migrate_old_labels.py
@@ -10,9 +10,9 @@ Create Date: 2019-04-22 12:50:31.062089
 revision = 'e2be4ab896d3'
 down_revision = '0b25df40d307'
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql import column, table
-import sqlalchemy as sa
 
 proposal = table(
     'proposal',

--- a/migrations/versions/e3b3ccbca3b9_move_participant_to_emailaddressmixin.py
+++ b/migrations/versions/e3b3ccbca3b9_move_participant_to_emailaddressmixin.py
@@ -7,16 +7,16 @@ Create Date: 2020-06-17 02:13:45.493791
 
 """
 
-from typing import Optional, Tuple, Union
 import hashlib
+from typing import Optional, Tuple, Union
 
+import idna
+import progressbar.widgets
+import sqlalchemy as sa
 from alembic import op
 from progressbar import ProgressBar
 from pyisemail import is_email
 from sqlalchemy.sql import column, table
-import idna
-import progressbar.widgets
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'e3b3ccbca3b9'

--- a/migrations/versions/e3bf172763bc_use_timezone_type.py
+++ b/migrations/versions/e3bf172763bc_use_timezone_type.py
@@ -10,9 +10,9 @@ Create Date: 2019-02-20 16:25:30.611549
 revision = 'e3bf172763bc'
 down_revision = '94ce3a9b7a3a'
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy_utils import TimezoneType
-import sqlalchemy as sa
 
 
 def upgrade() -> None:

--- a/migrations/versions/e417a13e136d_venue_venueroom_sequence.py
+++ b/migrations/versions/e417a13e136d_venue_venueroom_sequence.py
@@ -9,9 +9,9 @@ Create Date: 2019-02-07 09:58:40.632722
 revision = 'e417a13e136d'
 down_revision = 'c3069d33419a'
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql import column, table
-import sqlalchemy as sa
 
 project = table('project', column('id', sa.Integer()))
 

--- a/migrations/versions/e4f17fe2cce8_record_usersession_login_service.py
+++ b/migrations/versions/e4f17fe2cce8_record_usersession_login_service.py
@@ -8,8 +8,8 @@ Create Date: 2020-07-19 05:04:51.004750
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'e4f17fe2cce8'

--- a/migrations/versions/e8665a81606d_merge_account_name_into_profile.py
+++ b/migrations/versions/e8665a81606d_merge_account_name_into_profile.py
@@ -10,11 +10,11 @@ Create Date: 2020-04-15 02:24:49.259869
 from textwrap import dedent
 from typing import Optional, Tuple, Union
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.sql import column, table
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'e8665a81606d'

--- a/migrations/versions/e9cf265bdde6_remove_profile_legacy_flag.py
+++ b/migrations/versions/e9cf265bdde6_remove_profile_legacy_flag.py
@@ -8,8 +8,8 @@ Create Date: 2021-05-07 02:44:35.530119
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'e9cf265bdde6'

--- a/migrations/versions/ea1ea3b0ff95_rename_post_constraints_to_update_.py
+++ b/migrations/versions/ea1ea3b0ff95_rename_post_constraints_to_update_.py
@@ -9,8 +9,8 @@ Create Date: 2020-08-08 08:40:19.751509
 from textwrap import dedent
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'ea1ea3b0ff95'

--- a/migrations/versions/ea20c403b240_featured_project_flag.py
+++ b/migrations/versions/ea20c403b240_featured_project_flag.py
@@ -10,8 +10,8 @@ Create Date: 2019-06-05 12:38:15.928874
 revision = 'ea20c403b240'
 down_revision = 'c38fa391613f'
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 
 def upgrade() -> None:

--- a/migrations/versions/eec2fad0f3e9_venue_uuid_field.py
+++ b/migrations/versions/eec2fad0f3e9_venue_uuid_field.py
@@ -11,11 +11,11 @@ down_revision = 'ae68621248af'
 
 from uuid import uuid4
 
+import progressbar.widgets
+import sqlalchemy as sa
 from alembic import op
 from progressbar import ProgressBar
 from sqlalchemy.sql import column, table
-import progressbar.widgets
-import sqlalchemy as sa
 
 venue = table('venue', column('id', sa.Integer()), column('uuid', sa.Uuid()))
 

--- a/migrations/versions/f346a7cc783a_use_underscores_in_account_names.py
+++ b/migrations/versions/f346a7cc783a_use_underscores_in_account_names.py
@@ -8,8 +8,8 @@ Create Date: 2023-03-27 22:16:42.701748
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = 'f346a7cc783a'

--- a/migrations/versions/f58bd7c54f9b_clientcredential_needs_variable_length_.py
+++ b/migrations/versions/f58bd7c54f9b_clientcredential_needs_variable_length_.py
@@ -8,8 +8,8 @@ Create Date: 2020-06-04 05:06:51.336248
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'f58bd7c54f9b'

--- a/migrations/versions/f8204bcd438_move_content_into_description.py
+++ b/migrations/versions/f8204bcd438_move_content_into_description.py
@@ -10,9 +10,9 @@ Create Date: 2014-12-03 00:57:54.098592
 revision = 'f8204bcd438'
 down_revision = '55b1ef63bee'
 
+import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.sql import column, table
-import sqlalchemy as sa
 
 from coaster.gfm import markdown
 from coaster.sqlalchemy import JsonDict

--- a/migrations/versions/f9c44ecb5999_rename_ticket_event_models.py
+++ b/migrations/versions/f9c44ecb5999_rename_ticket_event_models.py
@@ -8,8 +8,8 @@ Create Date: 2020-09-10 02:13:29.641181
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'f9c44ecb5999'

--- a/migrations/versions/fa05ebecbc0f_populate_proposalmembership.py
+++ b/migrations/versions/fa05ebecbc0f_populate_proposalmembership.py
@@ -9,11 +9,11 @@ Create Date: 2021-04-30 04:07:47.387372
 from typing import Optional, Tuple, Union
 from uuid import uuid4
 
+import progressbar.widgets
+import sqlalchemy as sa
 from alembic import op
 from progressbar import ProgressBar
 from sqlalchemy.sql import column, table
-import progressbar.widgets
-import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = 'fa05ebecbc0f'

--- a/migrations/versions/fb8eb6e5b70a_record_usersession_geonameid_and_asn.py
+++ b/migrations/versions/fb8eb6e5b70a_record_usersession_geonameid_and_asn.py
@@ -8,8 +8,8 @@ Create Date: 2021-04-28 03:24:28.554095
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = 'fb8eb6e5b70a'

--- a/migrations/versions/fb90ab2af4c2_add_phonenumber.py
+++ b/migrations/versions/fb90ab2af4c2_add_phonenumber.py
@@ -8,8 +8,8 @@ Create Date: 2023-01-17 22:52:13.062751
 
 from typing import Optional, Tuple, Union
 
-from alembic import op
 import sqlalchemy as sa
+from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = 'fb90ab2af4c2'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1759,9 +1759,9 @@
       "integrity": "sha512-Tbsj02wXCbqGmzdnXNk0SOF19ChhRU70BsroIi4Pm6Ehp56in6vch94mfbdQ17DozxkL3BAVjbZ4Qc1a0HFRAg=="
     },
     "node_modules/@codemirror/autocomplete": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.7.1.tgz",
-      "integrity": "sha512-hSxf9S0uB+GV+gBsjY1FZNo53e1FFdzPceRfCfD1gWOnV6o21GfB5J5Wg9G/4h76XZMPrF0A6OCK/Rz5+V1egg==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.8.0.tgz",
+      "integrity": "sha512-nTimZYnTYaZ5skAt+zlk8BD41GvjpWgtDni2K+BritA7Ed9A0aJWwo1ohTvwUEfHfhIVtcFSLEddVPkegw8C/Q==",
       "dependencies": {
         "@codemirror/language": "^6.0.0",
         "@codemirror/state": "^6.0.0",
@@ -1870,9 +1870,9 @@
       "integrity": "sha512-RupHSZ8+OjNT38zU9fKH2sv+Dnlr8Eb8sl4NOnnqz95mCFTZUaiRP8Xv5MeeaG0px2b8Bnfe7YGwCV3nsBhbuw=="
     },
     "node_modules/@codemirror/view": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.13.0.tgz",
-      "integrity": "sha512-oXTfJzHJ5Tl7f6T8ZO0HKf981zubxgKohjddLobbntbNZHlOZGMRL+pPZGtclDWFaFJWtGBYRGyNdjQ6Xsx5yA==",
+      "version": "6.13.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.13.2.tgz",
+      "integrity": "sha512-XA/jUuu1H+eTja49654QkrQwx2CuDMdjciHcdqyasfTVo4HRlvj87rD/Qmm4HfnhwX8234FQSSA8HxEzxihX/Q==",
       "dependencies": {
         "@codemirror/state": "^6.1.4",
         "style-mod": "^4.0.0",
@@ -2529,9 +2529,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.0.tgz",
-      "integrity": "sha512-cumHmIAf6On83X7yP+LrsEyUOf/YlociZelmpRYaGFydoaPdxdt80MAbu6vWerQT2COCp2nPvHdsbD7tHn/YlQ=="
+      "version": "20.3.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
+      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg=="
     },
     "node_modules/@types/resolve": {
       "version": "1.17.1",
@@ -3000,12 +3000,12 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/aria-query": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.1.3.tgz",
-      "integrity": "sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.2.1.tgz",
+      "integrity": "sha512-7uFg4b+lETFgdaJyETnILsXgnnzVnkHcgRbwbPwevm5x/LmUlt3MjczMRe1zg824iBgXZNRPTBftNYyRSKLp2g==",
       "dev": true,
       "dependencies": {
-        "deep-equal": "^2.0.5"
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/array-buffer-byte-length": {
@@ -3217,12 +3217,12 @@
       }
     },
     "node_modules/axobject-query": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.1.1.tgz",
-      "integrity": "sha512-goKlv8DZrK9hUh975fnHzhNIO4jUnFCfv/dszV5VwUGDFjI6vQ2VwoyjYjYNEbBE8AH87TduWP5uyDR1D+Iteg==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.2.1.tgz",
+      "integrity": "sha512-jsyHu61e6N4Vbz/v18DHwWYKK0bSWLqn47eeDSKPB7m8tqMHF9YJ+mhIk2lVteyZrY8tnSj/jHOv4YiTCuCJgg==",
       "dev": true,
       "dependencies": {
-        "deep-equal": "^2.0.5"
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/babel-eslint": {
@@ -3389,9 +3389,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.21.7",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.7.tgz",
-      "integrity": "sha512-BauCXrQ7I2ftSqd2mvKHGo85XR0u7Ru3C/Hxsy/0TkfCtjrmAbPdzLGasmoiBxplpDXlPvdjX9u7srIMfgasNA==",
+      "version": "4.21.9",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.9.tgz",
+      "integrity": "sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==",
       "funding": [
         {
           "type": "opencollective",
@@ -3407,8 +3407,8 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001489",
-        "electron-to-chromium": "^1.4.411",
+        "caniuse-lite": "^1.0.30001503",
+        "electron-to-chromium": "^1.4.431",
         "node-releases": "^2.0.12",
         "update-browserslist-db": "^1.0.11"
       },
@@ -3500,9 +3500,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001500",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001500.tgz",
-      "integrity": "sha512-wSpY0RQnEwFwVZ063ggl3M4ALRP9OSknL0enldDEydIGzuShbtuWwaedB/RfkxsGF3P0kf1Tnv/nTtJEbjzc4Q==",
+      "version": "1.0.30001505",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001505.tgz",
+      "integrity": "sha512-jaAOR5zVtxHfL0NjZyflVTtXm3D3J9P15zSJ7HmQF8dSKGA6tqzQq+0ZI3xkjyQj46I4/M0K2GbMpcAFOcbr3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -3890,9 +3890,9 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
     "node_modules/copy-webpack-plugin/node_modules/schema-utils": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.1.0.tgz",
-      "integrity": "sha512-Jw+GZVbP5IggB2WAn6UHI02LBwGmsIeYN/lNbSMZyDziQ7jmtAUrqKqDja+W89YHVs+KL/3IkIMltAklqB1vAw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.2.0.tgz",
+      "integrity": "sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==",
       "dependencies": {
         "@types/json-schema": "^7.0.9",
         "ajv": "^8.9.0",
@@ -4023,9 +4023,9 @@
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
-      "version": "14.18.50",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.50.tgz",
-      "integrity": "sha512-DdJP83r2Zp5x32la3jEzjIlB85+2gMPUHP1xFL2xFORzbJ94sNwh4b6ZBaF6EN/7BTII6mba3yakqfLEnt5eZg==",
+      "version": "14.18.51",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.51.tgz",
+      "integrity": "sha512-P9bsdGFPpVtofEKlhWMVS2qqx1A/rt9QBfihWlklfHHpUpjtYse5AzFz6j4DWrARLYh6gRnw9+5+DJcrq3KvBA==",
       "dev": true
     },
     "node_modules/cypress/node_modules/ansi-styles": {
@@ -4111,9 +4111,9 @@
       }
     },
     "node_modules/cypress/node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -4665,35 +4665,6 @@
         }
       }
     },
-    "node_modules/deep-equal": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-2.2.1.tgz",
-      "integrity": "sha512-lKdkdV6EOGoVn65XaOsPdH4rMxTZOnmFyuIkMjM1i5HHCbfjC97dawgTAy0deYNfuqUqW+Q5VrVaQYtUpSd6yQ==",
-      "dev": true,
-      "dependencies": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.2",
-        "es-get-iterator": "^1.1.3",
-        "get-intrinsic": "^1.2.0",
-        "is-arguments": "^1.1.1",
-        "is-array-buffer": "^3.0.2",
-        "is-date-object": "^1.0.5",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "isarray": "^2.0.5",
-        "object-is": "^1.1.5",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.0",
-        "side-channel": "^1.0.4",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.9"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -4784,6 +4755,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -4843,9 +4823,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.427",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.427.tgz",
-      "integrity": "sha512-HK3r9l+Jm8dYAm1ctXEWIC+hV60zfcjS9UA5BDlYvnI5S7PU/yytjpvSrTNrSSRRkuu3tDyZhdkwIczh+0DWaw=="
+      "version": "1.4.435",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.435.tgz",
+      "integrity": "sha512-B0CBWVFhvoQCW/XtjRzgrmqcgVWg6RXOEM/dK59+wFV93BFGR6AeNKc4OyhM+T3IhJaOOG8o/V+33Y2mwJWtzw=="
     },
     "node_modules/elkjs": {
       "version": "0.8.2",
@@ -4900,9 +4880,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.14.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.14.1.tgz",
-      "integrity": "sha512-Vklwq2vDKtl0y/vtwjSesgJ5MYS7Etuk5txS8VdKL4AOS1aUlD96zqIfsOSLQsdv3xgMRbtkWM8eG9XDfKUPow==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.15.0.tgz",
+      "integrity": "sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -4923,9 +4903,9 @@
       }
     },
     "node_modules/envinfo": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.8.1.tgz",
-      "integrity": "sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.9.0.tgz",
+      "integrity": "sha512-RODB4txU+xImYDemN5DqaKC0CHk05XSVkOX4pq0hK26Qx+1LChkuOyUDlGEjYb3ACr0n9qBhFjg37hQuJvpkRQ==",
       "dev": true,
       "bin": {
         "envinfo": "dist/cli.js"
@@ -4977,26 +4957,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/es-get-iterator": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.3.tgz",
-      "integrity": "sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
-        "has-symbols": "^1.0.3",
-        "is-arguments": "^1.1.1",
-        "is-map": "^2.0.2",
-        "is-set": "^2.0.2",
-        "is-string": "^1.0.7",
-        "isarray": "^2.0.5",
-        "stop-iteration-iterator": "^1.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5469,9 +5429,9 @@
       }
     },
     "node_modules/eslint-webpack-plugin/node_modules/schema-utils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.2.0.tgz",
-      "integrity": "sha512-0zTyLGyDJYd/MBxG1AhJkKa6fpEBds4OQO2ut0w7OYG+ZGhGea09lijvzsqegYSik88zc7cUtIlnnO+/BvD6gQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
       "dependencies": {
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
@@ -5602,9 +5562,9 @@
       }
     },
     "node_modules/eslint/node_modules/semver": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-      "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+      "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -5929,9 +5889,9 @@
       }
     },
     "node_modules/file-loader/node_modules/schema-utils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.2.0.tgz",
-      "integrity": "sha512-0zTyLGyDJYd/MBxG1AhJkKa6fpEBds4OQO2ut0w7OYG+ZGhGea09lijvzsqegYSik88zc7cUtIlnnO+/BvD6gQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.8",
@@ -6350,9 +6310,9 @@
       }
     },
     "node_modules/globby": {
-      "version": "13.1.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-13.1.4.tgz",
-      "integrity": "sha512-iui/IiiW+QrJ1X1hKH5qwlMQyv34wJAYwH1vrf8b9kBA4sNiif3gKsMHa+BrdnOpEudWjpotfa7LrTzB1ERS/g==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-13.2.0.tgz",
+      "integrity": "sha512-jWsQfayf13NvqKUIL3Ta+CIqMnvlaIDFveWE/dpOZ9+3AMEJozsxDvKA02zync9UuvOM8rOXzsD5GqKP4OnWPQ==",
       "dependencies": {
         "dir-glob": "^3.0.1",
         "fast-glob": "^3.2.11",
@@ -6695,22 +6655,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/is-arguments": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.1.1.tgz",
-      "integrity": "sha512-8Q7EARjzEnKpt/PCD7e1cgUS0a6X8u5tdSiMqXhojOdoV9TsMsiO+9VLC5vAmO8N7/GmXn7yjR8qnA6bVAEzfA==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-array-buffer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
@@ -6863,15 +6807,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -7001,15 +6936,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-set": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-shared-array-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
@@ -7101,15 +7027,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-weakmap": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
-      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/is-weakref": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -7122,24 +7039,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-weakset": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
-      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -8948,22 +8851,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/object-is": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.5.tgz",
-      "integrity": "sha512-3cyDsyHgtmi7I7DfSSI2LDp6SK2lwvtbg0p0R1e0RvTqF5ceGx+K2dfSjm1bKDMVCFEDAQvy+o8c6a7VujOddw==",
-      "dev": true,
-      "dependencies": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
@@ -9545,11 +9432,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/readable-stream/node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
-    },
     "node_modules/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
@@ -9963,9 +9845,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
-      "version": "1.63.3",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.63.3.tgz",
-      "integrity": "sha512-ySdXN+DVpfwq49jG1+hmtDslYqpS7SkOR5GpF6o2bmb1RL/xS+wvPmegMvMywyfsmAV6p7TgwXYGrCZIFFbAHg==",
+      "version": "1.63.4",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.63.4.tgz",
+      "integrity": "sha512-Sx/+weUmK+oiIlI+9sdD0wZHsqpbgQg8wSwSnGBjwb5GwqFhYNwwnI+UWZtLjKvKyFlKkatRK235qQ3mokyPoQ==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -10215,18 +10097,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/stop-iteration-iterator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.0.0.tgz",
-      "integrity": "sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==",
-      "dev": true,
-      "dependencies": {
-        "internal-slot": "^1.0.4"
-      },
-      "engines": {
-        "node": ">= 0.4"
       }
     },
     "node_modules/string_decoder": {
@@ -10574,9 +10444,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.17.7",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.17.7.tgz",
-      "integrity": "sha512-/bi0Zm2C6VAexlGgLlVxA0P2lru/sdLyfCVaRMfKVo9nWxbmz7f/sD8VPybPeSUJaJcwmCJis9pBIhcVcG1QcQ==",
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.18.1.tgz",
+      "integrity": "sha512-j1n0Ao919h/Ai5r43VAnfV/7azUYW43GPxK7qSATzrsERfW7+y2QW9Cp9ufnRF5CQUWbnLSo7UJokSWCqg4tsQ==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",
@@ -10624,9 +10494,9 @@
       }
     },
     "node_modules/terser-webpack-plugin/node_modules/schema-utils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.2.0.tgz",
-      "integrity": "sha512-0zTyLGyDJYd/MBxG1AhJkKa6fpEBds4OQO2ut0w7OYG+ZGhGea09lijvzsqegYSik88zc7cUtIlnnO+/BvD6gQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
       "dependencies": {
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
@@ -10641,9 +10511,9 @@
       }
     },
     "node_modules/terser/node_modules/acorn": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
+      "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -11573,9 +11443,9 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/webpack": {
-      "version": "5.86.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.86.0.tgz",
-      "integrity": "sha512-3BOvworZ8SO/D4GVP+GoRC3fVeg5MO4vzmq8TJJEkdmopxyazGDxN8ClqN12uzrZW9Tv8EED8v5VSb6Sqyi0pg==",
+      "version": "5.87.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.87.0.tgz",
+      "integrity": "sha512-GOu1tNbQ7p1bDEoFRs2YPcfyGs8xq52yyPBZ3m2VGnXGtV9MxjrkABHm4V9Ia280OefsSLzvbVoXcfLxjKY/Iw==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -11586,7 +11456,7 @@
         "acorn-import-assertions": "^1.9.0",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.14.1",
+        "enhanced-resolve": "^5.15.0",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -11596,7 +11466,7 @@
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
-        "schema-utils": "^3.1.2",
+        "schema-utils": "^3.2.0",
         "tapable": "^2.1.1",
         "terser-webpack-plugin": "^5.3.7",
         "watchpack": "^2.4.0",
@@ -11723,9 +11593,9 @@
       }
     },
     "node_modules/webpack/node_modules/acorn": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "version": "8.9.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.9.0.tgz",
+      "integrity": "sha512-jaVNAFBHNLXspO543WnNNPZFRtavh3skAkITqD0/2aeMkKZTN+254PyhwxFYrk3vQ1xfY+2wbesJMs/JC8/PwQ==",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -11742,9 +11612,9 @@
       }
     },
     "node_modules/webpack/node_modules/schema-utils": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.2.0.tgz",
-      "integrity": "sha512-0zTyLGyDJYd/MBxG1AhJkKa6fpEBds4OQO2ut0w7OYG+ZGhGea09lijvzsqegYSik88zc7cUtIlnnO+/BvD6gQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
+      "integrity": "sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==",
       "dependencies": {
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
@@ -11792,21 +11662,6 @@
         "is-number-object": "^1.0.4",
         "is-string": "^1.0.5",
         "is-symbol": "^1.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/which-collection": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
-      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-      "dev": true,
-      "dependencies": {
-        "is-map": "^2.0.1",
-        "is-set": "^2.0.1",
-        "is-weakmap": "^2.0.1",
-        "is-weakset": "^2.0.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,26 +213,26 @@ unfixable = []
 
 # Exclude a variety of commonly ignored directories.
 exclude = [
-    ".bzr",
-    ".direnv",
-    ".eggs",
-    ".git",
-    ".hg",
-    ".mypy_cache",
-    ".nox",
-    ".pants.d",
-    ".pytype",
-    ".ruff_cache",
-    ".svn",
-    ".tox",
-    ".venv",
-    "__pypackages__",
-    "_build",
-    "buck-out",
-    "build",
-    "dist",
-    "node_modules",
-    "venv",
+  ".bzr",
+  ".direnv",
+  ".eggs",
+  ".git",
+  ".hg",
+  ".mypy_cache",
+  ".nox",
+  ".pants.d",
+  ".pytype",
+  ".ruff_cache",
+  ".svn",
+  ".tox",
+  ".venv",
+  "__pypackages__",
+  "_build",
+  "buck-out",
+  "build",
+  "dist",
+  "node_modules",
+  "venv",
 ]
 
 # Same as Black.
@@ -255,7 +255,9 @@ extra-standard-library = ['typing_extensions']
 split-on-trailing-comma = false
 relative-imports-order = 'furthest-to-closest'
 known-first-party = ['baseframe', 'coaster', 'flask_lastuser']
-section-order = ['future', 'standard-library', 'third-party', 'first-party', 'repo', 'local-folder']
+section-order = [
+  'future', 'standard-library', 'third-party', 'first-party', 'repo', 'local-folder'
+]
 
 [tool.ruff.isort.sections]
 repo = ['funnel']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,15 +70,16 @@ image_alt = true
 tabindex_no_positive = true
 
 [tool.isort]
+# Some isort functionality is replicated in ruff, which should have matching config
 profile = 'black'
 multi_line_output = 3
 include_trailing_comma = true
 line_length = 88
 order_by_type = true
 use_parentheses = true
-from_first = true
-# add_imports = 'from __future__ import annotations'
-known_future_library = ['__future__', 'six']
+combine_as_imports = true
+split_on_trailing_comma = false
+extra_standard_library = ['typing_extensions']
 known_repo = ['funnel']
 known_first_party = ['baseframe', 'coaster', 'flask_lastuser']
 default_section = 'THIRDPARTY'
@@ -173,7 +174,8 @@ disable = [
   'too-many-lines',  # We have large files that include all related functionality
   'too-many-public-methods',  # Models and views have many public methods
   'unused-argument',  # Arguments required for spec compatibility aren't always used
-  'wrong-import-position',  # Let black and isort handle this
+  'wrong-import-order',  # Let isort and ruff handle this
+  'wrong-import-position',  # Let black, isort and ruff handle this
 
   # Temporarily disabled pending audit and fixes
   'missing-class-docstring',
@@ -245,3 +247,15 @@ target-version = "py37"
 [tool.ruff.mccabe]
 # Unlike Flake8, default to a complexity level of 10.
 max-complexity = 10
+
+[tool.ruff.isort]
+# These config options should match isort config above under [tool.isort]
+combine-as-imports = true
+extra-standard-library = ['typing_extensions']
+split-on-trailing-comma = false
+relative-imports-order = 'furthest-to-closest'
+known-first-party = ['baseframe', 'coaster', 'flask_lastuser']
+section-order = ['future', 'standard-library', 'third-party', 'first-party', 'repo', 'local-folder']
+
+[tool.ruff.isort.sections]
+repo = ['funnel']

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -64,9 +64,9 @@ blinker==1.6.2
     #   -r requirements/base.in
     #   baseframe
     #   coaster
-boto3==1.26.151
+boto3==1.26.156
     # via -r requirements/base.in
-botocore==1.29.151
+botocore==1.29.156
     # via
     #   boto3
     #   s3transfer
@@ -115,11 +115,11 @@ dnspython==2.3.0
     #   baseframe
     #   mxsniff
     #   pyisemail
-emoji==2.5.0
+emoji==2.5.1
     # via baseframe
 exceptiongroup==1.1.1
     # via anyio
-filelock==3.12.1
+filelock==3.12.2
     # via tldextract
 flask==2.2.5
     # via
@@ -163,7 +163,7 @@ flask-redis==0.4.0
     # via -r requirements/base.in
 flask-rq2==18.3
     # via -r requirements/base.in
-flask-sqlalchemy==3.0.3
+flask-sqlalchemy==3.0.4
     # via
     #   -r requirements/base.in
     #   coaster
@@ -225,7 +225,7 @@ idna==3.4
     #   requests
     #   tldextract
     #   yarl
-importlib-metadata==6.6.0
+importlib-metadata==6.7.0
     # via
     #   flask
     #   markdown
@@ -309,7 +309,7 @@ packaging==23.1
     # via marshmallow
 passlib==1.7.4
     # via -r requirements/base.in
-phonenumbers==8.13.13
+phonenumbers==8.13.14
     # via -r requirements/base.in
 premailer==3.10.0
     # via -r requirements/base.in
@@ -343,7 +343,7 @@ pyjwt==2.7.0
     # via twilio
 pymdown-extensions==10.0.1
     # via coaster
-pyparsing==3.0.9
+pyparsing==3.1.0
     # via httplib2
 pypng==0.20220715.0
     # via qrcode
@@ -413,7 +413,7 @@ requests-file==1.5.1
     # via tldextract
 requests-oauthlib==1.3.1
     # via tweepy
-rich==13.4.1
+rich==13.4.2
     # via -r requirements/base.in
 rq==1.15.0
     # via
@@ -471,7 +471,7 @@ sqlalchemy-utils==0.41.1
     #   coaster
 statsd==4.0.1
     # via baseframe
-tinydb==4.7.1
+tinydb==4.8.0
     # via tuspy
 tldextract==3.4.4
     # via
@@ -481,11 +481,11 @@ toml==0.10.2
     # via -r requirements/base.in
 tqdm==4.65.0
     # via nltk
-tuspy==1.0.0
+tuspy==1.0.1
     # via pyvimeo
 tweepy==4.14.0
     # via -r requirements/base.in
-twilio==8.2.2
+twilio==8.3.0
     # via -r requirements/base.in
 typing-extensions==4.6.3
     # via
@@ -528,7 +528,7 @@ werkzeug==2.2.3
     #   baseframe
     #   coaster
     #   flask
-whitenoise==6.4.0
+whitenoise==6.5.0
     # via -r requirements/base.in
 wtforms==3.0.1
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -51,7 +51,7 @@ flake8-bugbear==23.6.5
     # via -r requirements/dev.in
 flake8-builtins==2.1.0
     # via -r requirements/dev.in
-flake8-comprehensions==3.12.0
+flake8-comprehensions==3.13.0
     # via -r requirements/dev.in
 flake8-docstrings==1.7.0
     # via -r requirements/dev.in
@@ -90,7 +90,7 @@ mccabe==0.7.0
     # via
     #   flake8
     #   pylint
-mypy==1.3.0
+mypy==1.4.0
     # via -r requirements/dev.in
 mypy-json-report==1.0.4
     # via -r requirements/dev.in
@@ -106,14 +106,14 @@ pip-compile-multi==2.6.3
     # via -r requirements/dev.in
 pip-tools==6.13.0
     # via pip-compile-multi
-platformdirs==3.5.3
+platformdirs==3.6.0
     # via
     #   black
     #   pylint
     #   virtualenv
 po2json==0.2.2
     # via -r requirements/dev.in
-pre-commit==3.3.2
+pre-commit==3.3.3
     # via -r requirements/dev.in
 pycodestyle==2.10.0
     # via
@@ -127,7 +127,7 @@ pylint==2.17.4
     # via -r requirements/dev.in
 pyproject-hooks==1.0.0
     # via build
-pyupgrade==3.6.0
+pyupgrade==3.7.0
     # via -r requirements/dev.in
 reformat-gherkin==3.0.1
     # via -r requirements/dev.in
@@ -161,7 +161,7 @@ types-requests==2.31.0.1
     # via -r requirements/dev.in
 types-urllib3==1.26.25.13
     # via types-requests
-virtualenv==20.23.0
+virtualenv==20.23.1
     # via pre-commit
 wcwidth==0.2.6
     # via reformat-gherkin

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -31,7 +31,7 @@ iniconfig==2.0.0
     # via pytest
 outcome==1.2.0
     # via trio
-parse==1.19.0
+parse==1.19.1
     # via
     #   parse-type
     #   pytest-bdd
@@ -66,7 +66,7 @@ pytest-cov==4.1.0
     # via -r requirements/test.in
 pytest-dotenv==0.5.2
     # via -r requirements/test.in
-pytest-env==0.8.1
+pytest-env==0.8.2
     # via -r requirements/test.in
 pytest-html==3.2.0
     # via pytest-selenium

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,24 +3,24 @@
 
 from __future__ import annotations
 
+import re
+import typing as t
+import warnings
 from contextlib import ExitStack
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from difflib import unified_diff
 from types import MethodType, ModuleType, SimpleNamespace
 from unittest.mock import patch
-import re
-import typing as t
-import warnings
 
-from flask import session
-from flask_sqlalchemy import SQLAlchemy
-from flask_sqlalchemy.session import Session as FsaSession
-from sqlalchemy.orm import Session as DatabaseSessionClass
 import flask_wtf.csrf
 import pytest
 import sqlalchemy as sa
 import typeguard
+from flask import session
+from flask_sqlalchemy import SQLAlchemy
+from flask_sqlalchemy.session import Session as FsaSession
+from sqlalchemy.orm import Session as DatabaseSessionClass
 
 if t.TYPE_CHECKING:
     from flask import Flask
@@ -349,8 +349,8 @@ def colorize_code(rich_console: Console) -> t.Callable[[str, t.Optional[str]], s
 @pytest.fixture(scope='session')
 def print_stack(pytestconfig, colorama, colorize_code) -> t.Callable[[int, int], None]:
     """Print a stack trace up to an outbound call from within this repository."""
-    from inspect import stack as inspect_stack
     import os.path
+    from inspect import stack as inspect_stack
 
     boundary_path = str(pytestconfig.rootpath)
     if not boundary_path.endswith('/'):

--- a/tests/e2e/account/register_test.py
+++ b/tests/e2e/account/register_test.py
@@ -2,12 +2,12 @@
 
 import time
 
+import pytest
 from pytest_bdd import given, parsers, scenarios, then, when
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as ec
 from selenium.webdriver.support.wait import WebDriverWait
-import pytest
 
 scenarios('account/register.feature')
 pytestmark = pytest.mark.usefixtures('live_server')

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,8 +1,8 @@
 """Feature test configuration."""
 # pylint: disable=redefined-outer-name
 
-from pytest_socket import enable_socket
 import pytest
+from pytest_socket import enable_socket
 
 
 @pytest.fixture()

--- a/tests/integration/views/comment_moderation_test.py
+++ b/tests/integration/views/comment_moderation_test.py
@@ -1,9 +1,9 @@
 """Test comment moderation views."""
 # pylint: disable=too-many-locals
 
+import pytest
 from flask import url_for
 from werkzeug.datastructures import MultiDict
-import pytest
 
 from funnel import models
 

--- a/tests/integration/views/login_test.py
+++ b/tests/integration/views/login_test.py
@@ -6,9 +6,9 @@ from smtplib import SMTPRecipientsRefused
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
 from flask import redirect, request, session
 from werkzeug.datastructures import MultiDict
-import pytest
 
 from coaster.auth import current_auth
 from coaster.utils import utcnow

--- a/tests/unit/cli/periodic_stats_test.py
+++ b/tests/unit/cli/periodic_stats_test.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 
 from typing import Dict, List, Optional, Union
 
-from respx import MockRouter
 import httpx
 import pytest
+from respx import MockRouter
 
 from funnel.cli.periodic import stats as cli_stats
 

--- a/tests/unit/forms/label_forms_test.py
+++ b/tests/unit/forms/label_forms_test.py
@@ -1,7 +1,7 @@
 """Test Label forms."""
 
-from werkzeug.datastructures import MultiDict
 import pytest
+from werkzeug.datastructures import MultiDict
 
 from funnel import forms
 

--- a/tests/unit/forms/project_forms_test.py
+++ b/tests/unit/forms/project_forms_test.py
@@ -1,8 +1,8 @@
 """Tests for Project forms."""
 
-from werkzeug.datastructures import MultiDict
 import pytest
 import requests_mock
+from werkzeug.datastructures import MultiDict
 
 from funnel import forms
 

--- a/tests/unit/models/auth_client_ScopeMixin_test.py
+++ b/tests/unit/models/auth_client_ScopeMixin_test.py
@@ -1,8 +1,8 @@
 """Tests for the ScopeMixin model mixin."""
 # pylint: disable=protected-access
 
-from sqlalchemy.exc import IntegrityError
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from funnel import models
 

--- a/tests/unit/models/email_address_test.py
+++ b/tests/unit/models/email_address_test.py
@@ -5,9 +5,9 @@
 from types import SimpleNamespace
 from typing import Generator
 
-from sqlalchemy.exc import IntegrityError
 import pytest
 import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
 
 from funnel import models
 

--- a/tests/unit/models/helpers_test.py
+++ b/tests/unit/models/helpers_test.py
@@ -3,13 +3,13 @@
 
 from types import SimpleNamespace
 
-from flask_babel import lazy_gettext
-from sqlalchemy.exc import StatementError
 import pytest
 import sqlalchemy as sa
+from flask_babel import lazy_gettext
+from sqlalchemy.exc import StatementError
 
-from funnel import models
 import funnel.models.helpers as mhelpers
+from funnel import models
 
 
 def test_valid_name() -> None:

--- a/tests/unit/models/notification_test.py
+++ b/tests/unit/models/notification_test.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Dict, List, Set
 
-from sqlalchemy.exc import IntegrityError
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from funnel import models
 

--- a/tests/unit/models/phone_number_test.py
+++ b/tests/unit/models/phone_number_test.py
@@ -5,10 +5,10 @@ from contextlib import nullcontext as does_not_raise
 from types import SimpleNamespace
 from typing import Generator
 
-from sqlalchemy.exc import IntegrityError
 import phonenumbers
 import pytest
 import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
 
 from funnel import models
 

--- a/tests/unit/models/profile_name_test.py
+++ b/tests/unit/models/profile_name_test.py
@@ -1,7 +1,7 @@
 """Tests for Account (nee Profile) name."""
 
-from sqlalchemy.exc import IntegrityError
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from funnel import models
 

--- a/tests/unit/models/profile_test.py
+++ b/tests/unit/models/profile_test.py
@@ -1,8 +1,8 @@
 """Tests for Account (nee Profile) model."""
 
+import pytest
 from furl import furl
 from sqlalchemy.exc import StatementError
-import pytest
 
 from coaster.sqlalchemy import StateTransitionError
 

--- a/tests/unit/models/project_crew_membership_test.py
+++ b/tests/unit/models/project_crew_membership_test.py
@@ -1,7 +1,7 @@
 """Tests for ProjectCrewMembership membership model."""
 
-from sqlalchemy.exc import IntegrityError
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from funnel import models
 

--- a/tests/unit/models/session_test.py
+++ b/tests/unit/models/session_test.py
@@ -5,10 +5,10 @@ from datetime import datetime, timedelta
 from types import SimpleNamespace
 from typing import Dict, List, Optional
 
-from pytz import utc
-from sqlalchemy.exc import IntegrityError
 import pytest
 import sqlalchemy as sa
+from pytz import utc
+from sqlalchemy.exc import IntegrityError
 
 from funnel import models
 

--- a/tests/unit/models/shortlink_test.py
+++ b/tests/unit/models/shortlink_test.py
@@ -10,8 +10,8 @@
 from typing import Any
 from unittest.mock import patch
 
-from furl import furl
 import pytest
+from furl import furl
 
 from funnel import models
 

--- a/tests/unit/models/site_membership_test.py
+++ b/tests/unit/models/site_membership_test.py
@@ -1,7 +1,7 @@
 """Tests for SiteMembership model."""
 
-from sqlalchemy.exc import IntegrityError
 import pytest
+from sqlalchemy.exc import IntegrityError
 
 from funnel import models
 

--- a/tests/unit/transports/aws_ses/ses_notices_test.py
+++ b/tests/unit/transports/aws_ses/ses_notices_test.py
@@ -1,11 +1,11 @@
 """Test for processing AWS SES notices received via AWS SNS."""
 
-from typing import cast
 import json
 import os
+from typing import cast
 
-from flask import Response
 import pytest
+from flask import Response
 
 # Data Directory which contains JSON Files
 DATA_DIR = os.path.join(os.path.dirname(__file__), 'data')

--- a/tests/unit/transports/sms_send_test.py
+++ b/tests/unit/transports/sms_send_test.py
@@ -2,9 +2,9 @@
 
 from unittest.mock import patch
 
-from flask import Response
 import pytest
 import requests
+from flask import Response
 
 from funnel.transports import TransportConnectionError, TransportRecipientError
 from funnel.transports.sms import (
@@ -36,6 +36,7 @@ MESSAGE = OneLineTemplate(
 
 @pytest.mark.enable_socket()
 @pytest.mark.requires_config('app', 'twilio')
+@pytest.mark.use_fixtures('app_context')
 def test_twilio_success() -> None:
     """Test if message sending is a success."""
     sid = send(TWILIO_CLEAN_TARGET, MESSAGE, callback=False)
@@ -44,7 +45,8 @@ def test_twilio_success() -> None:
 
 @pytest.mark.enable_socket()
 @pytest.mark.requires_config('app', 'twilio')
-def test_twilio_callback(client) -> None:
+@pytest.mark.use_fixtures('app_context')
+def test_twilio_callback() -> None:
     """Test if message sending is a success when a callback is requested."""
     sid = send(TWILIO_CLEAN_TARGET, MESSAGE, callback=True)
     assert sid
@@ -52,6 +54,7 @@ def test_twilio_callback(client) -> None:
 
 @pytest.mark.enable_socket()
 @pytest.mark.requires_config('app', 'twilio')
+@pytest.mark.use_fixtures('app_context')
 def test_twilio_failures() -> None:
     """Test if message sending is a failure."""
     # Invalid Target
@@ -89,7 +92,8 @@ def test_exotel_nonce(client) -> None:
 
 
 @pytest.mark.requires_config('app', 'exotel')
-def test_exotel_send_error(client) -> None:
+@pytest.mark.use_fixtures('app_context')
+def test_exotel_send_error() -> None:
     """Only tests if url_for works and usually fails otherwise, which is OK."""
     # Check False Path via monkey patching the requests object
     with patch.object(requests, 'post') as mock_method:

--- a/tests/unit/transports/sms_send_test.py
+++ b/tests/unit/transports/sms_send_test.py
@@ -36,7 +36,7 @@ MESSAGE = OneLineTemplate(
 
 @pytest.mark.enable_socket()
 @pytest.mark.requires_config('app', 'twilio')
-@pytest.mark.use_fixtures('app_context')
+@pytest.mark.usefixtures('app_context')
 def test_twilio_success() -> None:
     """Test if message sending is a success."""
     sid = send(TWILIO_CLEAN_TARGET, MESSAGE, callback=False)
@@ -45,7 +45,7 @@ def test_twilio_success() -> None:
 
 @pytest.mark.enable_socket()
 @pytest.mark.requires_config('app', 'twilio')
-@pytest.mark.use_fixtures('app_context')
+@pytest.mark.usefixtures('app_context')
 def test_twilio_callback() -> None:
     """Test if message sending is a success when a callback is requested."""
     sid = send(TWILIO_CLEAN_TARGET, MESSAGE, callback=True)
@@ -54,7 +54,7 @@ def test_twilio_callback() -> None:
 
 @pytest.mark.enable_socket()
 @pytest.mark.requires_config('app', 'twilio')
-@pytest.mark.use_fixtures('app_context')
+@pytest.mark.usefixtures('app_context')
 def test_twilio_failures() -> None:
     """Test if message sending is a failure."""
     # Invalid Target
@@ -92,7 +92,7 @@ def test_exotel_nonce(client) -> None:
 
 
 @pytest.mark.requires_config('app', 'exotel')
-@pytest.mark.use_fixtures('app_context')
+@pytest.mark.usefixtures('app_context')
 def test_exotel_send_error() -> None:
     """Only tests if url_for works and usually fails otherwise, which is OK."""
     # Check False Path via monkey patching the requests object

--- a/tests/unit/transports/sms_template_test.py
+++ b/tests/unit/transports/sms_template_test.py
@@ -3,8 +3,8 @@
 
 from types import SimpleNamespace
 
-from flask import Flask
 import pytest
+from flask import Flask
 
 from funnel.transports import sms
 

--- a/tests/unit/utils/markdown/conftest.py
+++ b/tests/unit/utils/markdown/conftest.py
@@ -5,9 +5,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
+import tomlkit
 from bs4 import BeautifulSoup
 from markupsafe import Markup
-import tomlkit
 
 from funnel.utils.markdown import MarkdownConfig
 

--- a/tests/unit/utils/markdown/markdown_test.py
+++ b/tests/unit/utils/markdown/markdown_test.py
@@ -2,8 +2,8 @@
 
 import warnings
 
-from markupsafe import Markup
 import pytest
+from markupsafe import Markup
 
 from funnel.utils.markdown import MarkdownConfig
 

--- a/tests/unit/utils/misc_test.py
+++ b/tests/unit/utils/misc_test.py
@@ -1,7 +1,7 @@
 """Tests for base utilities."""
 
-from werkzeug.exceptions import BadRequest
 import pytest
+from werkzeug.exceptions import BadRequest
 
 from funnel import utils
 

--- a/tests/unit/views/api_shortlink_test.py
+++ b/tests/unit/views/api_shortlink_test.py
@@ -1,9 +1,9 @@
 """Test shortlink API views."""
 # pylint: disable=redefined-outer-name
 
+import pytest
 from flask import url_for
 from furl import furl
-import pytest
 
 from funnel import models
 

--- a/tests/unit/views/api_support_test.py
+++ b/tests/unit/views/api_support_test.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 
 import secrets
 
+import pytest
 from flask import Flask, url_for
 from flask.testing import FlaskClient
-import pytest
 
 from funnel import models
 

--- a/tests/unit/views/helpers_test.py
+++ b/tests/unit/views/helpers_test.py
@@ -7,10 +7,10 @@ from typing import Any
 from unittest.mock import patch
 from urllib.parse import urlsplit
 
+import pytest
 from flask import Flask, request
 from furl import furl
 from werkzeug.routing import BuildError
-import pytest
 
 import funnel.views.helpers as vhelpers
 

--- a/tests/unit/views/login_session_test.py
+++ b/tests/unit/views/login_session_test.py
@@ -1,7 +1,7 @@
 """Test login session helpers."""
 
-from flask import session
 import pytest
+from flask import session
 
 from funnel.views.login_session import save_session_next_url
 

--- a/tests/unit/views/notification_test.py
+++ b/tests/unit/views/notification_test.py
@@ -3,8 +3,8 @@
 
 from urllib.parse import urlsplit
 
-from flask import url_for
 import pytest
+from flask import url_for
 
 from funnel import models
 

--- a/tests/unit/views/search_test.py
+++ b/tests/unit/views/search_test.py
@@ -9,8 +9,8 @@ corpus of searchable data in fixtures.
 
 from typing import cast
 
-from flask import url_for
 import pytest
+from flask import url_for
 
 from funnel.models import Query
 from funnel.views.search import (

--- a/tests/unit/views/session_temp_vars_test.py
+++ b/tests/unit/views/session_temp_vars_test.py
@@ -1,8 +1,8 @@
 """Test handling of temporary variables in cookie session."""
 # pylint: disable=redefined-outer-name
 
-from datetime import timedelta
 import time
+from datetime import timedelta
 
 import pytest
 

--- a/tests/unit/views/sitemap_test.py
+++ b/tests/unit/views/sitemap_test.py
@@ -2,10 +2,10 @@
 
 from datetime import datetime, timedelta
 
+import pytest
 from dateutil.relativedelta import relativedelta
 from pytz import utc
 from werkzeug.exceptions import NotFound
-import pytest
 
 from coaster.utils import utcnow
 

--- a/tests/unit/views/video_test.py
+++ b/tests/unit/views/video_test.py
@@ -1,11 +1,11 @@
 """Test embedded video view helpers."""
 
-from datetime import datetime
 import logging
+from datetime import datetime
 
-from pytz import utc
 import pytest
 import requests
+from pytz import utc
 
 from funnel import models
 


### PR DESCRIPTION
Decorators are now typed using ParamSpec, removing the need for a type cast.

In the process, ruff and isort were found to be in conflict with each other as ruff replicates isort's functionality but didn't have the same config. Isort had a non-default value for `from_first`. Reverting to the default has caused imports to be reordered in a large number of files.