### PR TITLE
Label.proposals was mistyped as not a list

### DIFF
--- a/funnel/models/label.py
+++ b/funnel/models/label.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Union
+from typing import List, Union
 
 from sqlalchemy.ext.orderinglist import ordering_list
 
@@ -68,10 +68,12 @@ class Label(BaseScopedNameMixin, Model):
         index=True,
         nullable=True,
     )
+    main_label: Mapped[Label] = relationship(
+        remote_side='Label.id', back_populates='options'
+    )
     # See https://docs.sqlalchemy.org/en/13/orm/self_referential.html
-    options = relationship(
-        'Label',
-        backref=sa.orm.backref('main_label', remote_side='Label.id'),
+    options: Mapped[List[Label]] = relationship(
+        back_populates='main_label',
         order_by='Label.seq',
         passive_deletes=True,
         collection_class=ordering_list('seq', count_from=1),
@@ -128,7 +130,7 @@ class Label(BaseScopedNameMixin, Model):
     )
 
     #: Proposals that this label is attached to
-    proposals: Mapped[Proposal] = relationship(
+    proposals: Mapped[List[Proposal]] = relationship(
         Proposal, secondary=proposal_label, back_populates='labels'
     )
 
@@ -399,7 +401,7 @@ class ProposalLabelProxy:
 
 @reopen(Project)
 class __Project:
-    labels = relationship(
+    labels: Mapped[List[Label]] = relationship(
         Label,
         primaryjoin=sa.and_(
             Label.project_id == Project.id,
@@ -409,7 +411,7 @@ class __Project:
         order_by=Label.seq,
         viewonly=True,
     )
-    all_labels = relationship(
+    all_labels: Mapped[List[Label]] = relationship(
         Label,
         collection_class=ordering_list('seq', count_from=1),
         back_populates='project',
@@ -421,7 +423,7 @@ class __Proposal:
     #: For reading and setting labels from the edit form
     formlabels = ProposalLabelProxy()
 
-    labels = with_roles(
+    labels: Mapped[List[Label]] = with_roles(
         relationship(Label, secondary=proposal_label, back_populates='proposals'),
         read={'all'},
     )

--- a/funnel/models/notification.py
+++ b/funnel/models/notification.py
@@ -1371,7 +1371,7 @@ class __User:
     )
 
     # This relationship is wrapped in a property that creates it on first access
-    _main_notification_preferences = relationship(
+    _main_notification_preferences: Mapped[NotificationPreferences] = relationship(
         NotificationPreferences,
         primaryjoin=sa.and_(
             NotificationPreferences.user_id == User.id,

--- a/funnel/models/project_membership.py
+++ b/funnel/models/project_membership.py
@@ -252,7 +252,7 @@ class __User:
 
     # This relationship is only useful to check if the user has ever been a crew member.
     # Most operations will want to use one of the active membership relationships.
-    projects_as_crew_memberships = relationship(
+    projects_as_crew_memberships: DynamicMapped[ProjectCrewMembership] = relationship(
         ProjectCrewMembership,
         lazy='dynamic',
         foreign_keys=[ProjectCrewMembership.user_id],
@@ -260,7 +260,9 @@ class __User:
     )
 
     # This is used to determine if it is safe to purge the subject's database record
-    projects_as_crew_noninvite_memberships = relationship(
+    projects_as_crew_noninvite_memberships: DynamicMapped[
+        ProjectCrewMembership
+    ] = relationship(
         ProjectCrewMembership,
         lazy='dynamic',
         primaryjoin=sa.and_(
@@ -269,7 +271,9 @@ class __User:
         ),
         viewonly=True,
     )
-    projects_as_crew_active_memberships = relationship(
+    projects_as_crew_active_memberships: DynamicMapped[
+        ProjectCrewMembership
+    ] = relationship(
         ProjectCrewMembership,
         lazy='dynamic',
         primaryjoin=sa.and_(
@@ -283,7 +287,9 @@ class __User:
         'projects_as_crew_active_memberships', 'project'
     )
 
-    projects_as_editor_active_memberships = relationship(
+    projects_as_editor_active_memberships: DynamicMapped[
+        ProjectCrewMembership
+    ] = relationship(
         ProjectCrewMembership,
         lazy='dynamic',
         primaryjoin=sa.and_(

--- a/funnel/models/proposal.py
+++ b/funnel/models/proposal.py
@@ -504,7 +504,9 @@ class ProposalSuuidRedirect(BaseMixin, Model):
 
 @reopen(Commentset)
 class __Commentset:
-    proposal = relationship(Proposal, uselist=False, back_populates='commentset')
+    proposal: Mapped[Proposal] = relationship(
+        Proposal, uselist=False, back_populates='commentset'
+    )
 
 
 @reopen(Project)

--- a/funnel/models/session.py
+++ b/funnel/models/session.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections import OrderedDict, defaultdict
 from datetime import datetime, timedelta
-from typing import Any, Dict, Optional, Type
+from typing import Any, Dict, List, Optional, Type
 
 from flask_babel import format_date, get_locale
 from isoweek import Week
@@ -280,7 +280,7 @@ add_search_trigger(Session, 'search_vector')
 
 @reopen(VenueRoom)
 class __VenueRoom:
-    scheduled_sessions = relationship(
+    scheduled_sessions: Mapped[List[Session]] = relationship(
         Session,
         primaryjoin=sa.and_(
             Session.venue_room_id == VenueRoom.id,

--- a/funnel/models/site_membership.py
+++ b/funnel/models/site_membership.py
@@ -115,7 +115,7 @@ class SiteMembership(ImmutableUserMembershipMixin, Model):
 @reopen(User)
 class __User:
     # Singular, as only one can be active
-    active_site_membership = relationship(
+    active_site_membership: Mapped[SiteMembership] = relationship(
         SiteMembership,
         lazy='select',
         primaryjoin=sa.and_(

--- a/funnel/models/user.py
+++ b/funnel/models/user.py
@@ -1391,7 +1391,7 @@ class UserEmail(EmailAddressMixin, BaseMixin, Model):
     __email_for__ = 'user'
 
     # Tell mypy that these are not optional
-    email_address: Mapped[EmailAddress]
+    email_address: Mapped[EmailAddress]  # type: ignore[assignment]
 
     user_id = sa.orm.mapped_column(sa.Integer, sa.ForeignKey('user.id'), nullable=False)
     user: Mapped[User] = relationship(
@@ -1566,7 +1566,7 @@ class UserEmailClaim(EmailAddressMixin, BaseMixin, Model):
     __email_is_exclusive__ = False
 
     # Tell mypy that these are not optional
-    email_address: Mapped[EmailAddress]
+    email_address: Mapped[EmailAddress]  # type: ignore[assignment]
 
     user_id = sa.orm.mapped_column(sa.Integer, sa.ForeignKey('user.id'), nullable=False)
     user: Mapped[User] = relationship(


### PR DESCRIPTION
This may explain the recent bug where assigning a label to one proposal removed it from other proposals. All relationships have been audited and type hints added where necessary.