### PR TITLE
Use OTP verification for new email address, deprecating UserEmailClaim

### DIFF
--- a/.testenv
+++ b/.testenv
@@ -35,6 +35,7 @@ FLASK_LASTUSER_COOKIE_DOMAIN='.funnel.test:3002'
 FLASK_SITE_TITLE='Test Hasgeek'
 FLASK_SITE_SUPPORT_EMAIL=test-support-email
 FLASK_SITE_SUPPORT_PHONE=test-support-phone
+FLASK_MAIL_DEFAULT_SENDER="Funnel <no-reply@funnel.test>"
 DB_HOST=localhost
 FLASK_SQLALCHEMY_DATABASE_URI='postgresql+psycopg://${DB_HOST}/funnel_testing'
 FLASK_SQLALCHEMY_BINDS__geoname='postgresql+psycopg://${DB_HOST}/geoname_testing'

--- a/funnel/__init__.py
+++ b/funnel/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os.path
 from datetime import timedelta
+from email.utils import parseaddr
 
 import geoip2.database
 from flask import Flask
@@ -115,6 +116,10 @@ app.config.pop('ASSET_BASE_PATH', None)
 
 # Install common extensions on all apps
 for each_app in all_apps:
+    # If MAIL_DEFAULT_SENDER is in the form "Name <email>", extract email
+    each_app.config['MAIL_DEFAULT_SENDER_ADDR'] = parseaddr(
+        app.config['MAIL_DEFAULT_SENDER']
+    )[1]
     proxies.init_app(each_app)
     manifest.init_app(each_app)
     db.init_app(each_app)

--- a/funnel/forms/account.py
+++ b/funnel/forms/account.py
@@ -6,7 +6,9 @@ from hashlib import sha1
 from typing import Dict, Iterable, Optional
 
 import requests
+from flask import url_for
 from flask_babel import ngettext
+from markupsafe import Markup
 
 from baseframe import _, __, forms
 from coaster.utils import sorted_timezones
@@ -18,7 +20,6 @@ from ..models import (
     Anchor,
     Profile,
     User,
-    UserEmailClaim,
     check_password_strength,
     getuser,
 )
@@ -497,17 +498,24 @@ class UsernameAvailableForm(forms.Form):
         raise_username_error(reason)
 
 
-def validate_emailclaim(form: forms.Form, field: forms.Field) -> None:
-    """Validate if an email address is already pending verification."""
-    existing = UserEmailClaim.get_for(user=form.edit_user, email=field.data)
-    if existing is not None:
-        raise forms.validators.StopValidation(
-            _("This email address is pending verification")
-        )
+class EnableNotificationsDescriptionMixin:
+    """Mixin to add a link in the description for enabling notifications."""
+
+    enable_notifications: forms.Field
+
+    def set_queries(self) -> None:
+        """Change the description to include a link."""
+        self.enable_notifications.description = Markup(
+            _(
+                "Unsubscribe anytime, and control what notifications are sent from the"
+                ' <a href="{url}" target="_blank">Notifications tab under account'
+                ' settings</a>'
+            )
+        ).format(url=url_for('notification_preferences'))
 
 
 @User.forms('email_add')
-class NewEmailAddressForm(forms.RecaptchaForm):
+class NewEmailAddressForm(EnableNotificationsDescriptionMixin, forms.RecaptchaForm):
     """Form to add a new email address to a user account."""
 
     __expects__ = ('edit_user',)
@@ -517,7 +525,6 @@ class NewEmailAddressForm(forms.RecaptchaForm):
         __("Email address"),
         validators=[
             forms.validators.DataRequired(),
-            validate_emailclaim,
             EmailAddressAvailable(purpose='claim'),
         ],
         filters=strip_filters,
@@ -526,6 +533,15 @@ class NewEmailAddressForm(forms.RecaptchaForm):
             'autocapitalize': 'off',
             'autocomplete': 'email',
         },
+    )
+
+    enable_notifications = forms.BooleanField(
+        __("Send notifications by email"),
+        description=__(
+            "Unsubscribe anytime, and control what notifications are sent from the"
+            " Notifications tab under account settings"
+        ),
+        default=True,
     )
 
 
@@ -546,7 +562,7 @@ class EmailPrimaryForm(forms.Form):
 
 
 @User.forms('phone_add')
-class NewPhoneForm(forms.RecaptchaForm):
+class NewPhoneForm(EnableNotificationsDescriptionMixin, forms.RecaptchaForm):
     """Form to add a new mobile number (SMS-capable) to a user account."""
 
     __expects__ = ('edit_user',)

--- a/funnel/forms/helpers.py
+++ b/funnel/forms/helpers.py
@@ -15,6 +15,7 @@ from ..models import (
     EmailAddress,
     PhoneNumber,
     Profile,
+    User,
     UserEmailClaim,
     canonical_phone_number,
     parse_phone_number,
@@ -67,23 +68,25 @@ class EmailAddressAvailable:
         self.purpose = purpose
 
     def __call__(self, form: forms.Form, field: forms.Field) -> None:
-        # Get actor (from existing obj, or current_auth.actor)
-        actor = None
-        if hasattr(form, 'edit_obj'):
-            obj = form.edit_obj
-            if obj and hasattr(obj, '__email_for__'):
-                actor = getattr(obj, obj.__email_for__)
+        # Get actor (from form, or current_auth.actor)
+        actor: Optional[User] = None
+        if hasattr(form, 'edit_user'):
+            actor = form.edit_user
         if actor is None:
             actor = current_auth.actor
 
         # Call validator
-        is_valid = EmailAddress.validate_for(
+        has_error = EmailAddress.validate_for(
             actor, field.data, check_dns=True, new=self.purpose != 'use'
         )
 
         # Interpret code
-        if not is_valid:
+        if has_error == 'taken':
             if actor is not None:
+                if self.purpose == 'claim':
+                    # Allow a claim on an existing ownership -- if verified, it will
+                    # lead to account merger
+                    return
                 raise forms.validators.StopValidation(
                     _("This email address is linked to another account")
                 )
@@ -93,11 +96,11 @@ class EmailAddressAvailable:
                     " logging in or resetting your password"
                 )
             )
-        if is_valid in ('invalid', 'nullmx'):
+        if has_error in ('invalid', 'nullmx'):
             raise forms.validators.StopValidation(
                 _("This does not appear to be a valid email address")
             )
-        if is_valid == 'nomx':
+        if has_error == 'nomx':
             raise forms.validators.StopValidation(
                 _(
                     "The domain name of this email address is missing a DNS MX record."
@@ -105,11 +108,11 @@ class EmailAddressAvailable:
                     " spam. Please ask your tech person to add MX to DNS"
                 )
             )
-        if is_valid == 'not_new':
+        if has_error == 'not_new':
             raise forms.validators.StopValidation(
                 _("You have already registered this email address")
             )
-        if is_valid == 'soft_fail':
+        if has_error == 'soft_fail':
             # XXX: In the absence of support for warnings in WTForms, we can only use
             # flash messages to communicate
             flash(
@@ -120,21 +123,21 @@ class EmailAddressAvailable:
                 'warning',
             )
             return
-        if is_valid == 'hard_fail':
+        if has_error == 'hard_fail':
             raise forms.validators.StopValidation(
                 _(
                     "This email address is no longer valid. If you believe this to be"
                     " incorrect, email {support} asking for the address to be activated"
                 ).format(support=app.config['SITE_SUPPORT_EMAIL'])
             )
-        if is_valid == 'blocked':
+        if has_error == 'blocked':
             raise forms.validators.StopValidation(
                 _("This email address has been blocked from use")
             )
-        if is_valid is not True:
-            app.logger.error("Unknown email address validation code: %r", is_valid)
+        if has_error is not None:
+            app.logger.error("Unknown email address validation code: %r", has_error)
 
-        if is_valid and self.purpose == 'register':
+        if has_error is None and self.purpose == 'register':
             # One last check: is there an existing claim? If so, stop the user from
             # making a dupe account
             if UserEmailClaim.all(email=field.data).notempty():
@@ -161,11 +164,9 @@ class PhoneNumberAvailable:
 
     def __call__(self, form: forms.Form, field: forms.Field) -> None:
         # Get actor (from existing obj, or current_auth.actor)
-        actor = None
-        if hasattr(form, 'edit_obj'):
-            obj = form.edit_obj
-            if obj and hasattr(obj, '__phone_for__'):
-                actor = getattr(obj, obj.__phone_for__)
+        actor: Optional[User] = None
+        if hasattr(form, 'edit_user'):
+            actor = form.edit_user
         if actor is None:
             actor = current_auth.actor
 
@@ -178,14 +179,21 @@ class PhoneNumberAvailable:
             raise forms.validators.StopValidation(
                 _("This does not appear to be a valid phone number")
             )
+
+        # Save the parsed number back to the form field
+        field.data = canonical_phone_number(parsed_number)
         # Call validator
-        is_valid = PhoneNumber.validate_for(
+        has_error = PhoneNumber.validate_for(
             actor, parsed_number, new=self.purpose != 'use'
         )
 
         # Interpret code
-        if not is_valid:
+        if has_error == 'taken':
             if actor is not None:
+                if self.purpose == 'claim':
+                    # Allow a claim on an existing ownership -- if verified, it will
+                    # lead to account merger.
+                    return
                 raise forms.validators.StopValidation(
                     _("This phone number is linked to another account")
                 )
@@ -195,23 +203,22 @@ class PhoneNumberAvailable:
                     " logging in or resetting your password"
                 )
             )
-        if is_valid == 'invalid':
+        if has_error == 'invalid':
             raise forms.validators.StopValidation(
                 _("This does not appear to be a valid phone number")
             )
-        if is_valid == 'not_new':
+        if has_error == 'not_new':
             raise forms.validators.StopValidation(
                 _("You have already registered this phone number")
             )
-        if is_valid == 'blocked':
+        if has_error == 'blocked':
             raise forms.validators.StopValidation(
                 _("This phone number has been blocked from use")
             )
-        if is_valid is not True:
+        if has_error is not None:
             app.logger.error(  # type: ignore[unreachable]
-                "Unknown phone number validation code: %r", is_valid
+                "Unknown phone number validation code: %r", has_error
             )
-        field.data = canonical_phone_number(parsed_number)
 
 
 def image_url_validator() -> forms.validators.ValidUrl:

--- a/funnel/forms/login.py
+++ b/funnel/forms/login.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Optional, Union
 
-from baseframe import __, forms
+from baseframe import _, __, forms
 
 from ..models import (
     PASSWORD_MAX_LENGTH,
@@ -30,6 +30,7 @@ __all__ = [
     'LogoutForm',
     'RegisterWithOtp',
     'OtpForm',
+    'EmailOtpForm',
     'RegisterOtpForm',
 ]
 
@@ -291,6 +292,14 @@ class OtpForm(forms.Form):
         """Confirm OTP is as expected."""
         if field.data != self.valid_otp:
             raise forms.validators.StopValidation(MSG_INCORRECT_OTP)
+
+
+class EmailOtpForm(OtpForm):
+    """Verify an OTP sent to email."""
+
+    def set_queries(self) -> None:
+        super().set_queries()
+        self.otp.description = _("One-time password sent to your email address")
 
 
 class RegisterOtpForm(forms.Form):

--- a/funnel/models/email_address.py
+++ b/funnel/models/email_address.py
@@ -379,7 +379,7 @@ class EmailAddress(BaseMixin, Model):
         )
 
     def is_available_for(self, owner: Optional[User]) -> bool:
-        """Return True if this EmailAddress is available for the given owner."""
+        """Return True if this EmailAddress is available for the proposed owner."""
         for backref_name in self.__exclusive_backrefs__:
             for related_obj in getattr(self, backref_name):
                 curr_owner = getattr(related_obj, related_obj.__email_for__)
@@ -615,9 +615,10 @@ class EmailAddress(BaseMixin, Model):
         ],
     ]:
         """
-        Validate whether the email address is available to the given owner.
+        Validate whether the email address is available to the proposed owner.
 
-        Returns None if available without issues, or a string value indicating the concern:
+        Returns None if available without issues, or a string value indicating the
+        concern:
 
         1. 'taken': Email address has another owner
         2. 'nomx': Email address is available, but has no MX records

--- a/funnel/models/phone_number.py
+++ b/funnel/models/phone_number.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import hashlib
-from typing import Any, Optional, Set, Type, Union, overload
+from typing import TYPE_CHECKING, Any, Optional, Set, Type, Union, overload
 from typing_extensions import Literal
 
 import base58
@@ -435,7 +435,7 @@ class PhoneNumber(BaseMixin, Model):
             for related_obj in getattr(self, backref_name)
         )
 
-    def is_available_for(self, owner: PhoneNumberMixin) -> bool:
+    def is_available_for(self, owner: Optional[User]) -> bool:
         """Return True if this PhoneNumber is available for the given owner."""
         for backref_name in self.__exclusive_backrefs__:
             for related_obj in getattr(self, backref_name):
@@ -637,7 +637,7 @@ class PhoneNumber(BaseMixin, Model):
     @classmethod
     def add_for(
         cls,
-        owner: Optional[PhoneNumberMixin],
+        owner: Optional[User],
         phone: Union[str, phonenumbers.PhoneNumber],
     ) -> PhoneNumber:
         """
@@ -665,19 +665,20 @@ class PhoneNumber(BaseMixin, Model):
     @classmethod
     def validate_for(
         cls,
-        owner: Optional[PhoneNumberMixin],
+        owner: Optional[User],
         phone: Union[str, phonenumbers.PhoneNumber],
         new: bool = False,
-    ) -> Union[bool, Literal['invalid', 'not_new', 'blocked']]:
+    ) -> Optional[Literal['taken', 'invalid', 'not_new', 'blocked']]:
         """
         Validate whether the phone number is available to the given owner.
 
         Returns False if the number is blocked or in use by another owner, True if
         available without issues, or a string value indicating the concern:
 
-        1. 'not_new': Phone number is already attached to owner (if `new` is True)
-        2. 'invalid': Invalid syntax and therefore unusable
-        3. 'blocked': Phone number has been blocked from use
+        1. 'taken': Phone number has another owner
+        2. 'not_new': Phone number is already attached to owner (if `new` is True)
+        3. 'invalid': Invalid syntax and therefore unusable
+        4. 'blocked': Phone number has been blocked from use
 
         :param owner: Proposed owner of this phone number (may be None)
         :param phone: Phone number to validate
@@ -689,20 +690,20 @@ class PhoneNumber(BaseMixin, Model):
             return 'invalid'
         existing = cls.get(phone)
         if existing is None:
-            return True
+            return None
         # There's an existing? Is it blocked?
         if existing.is_blocked:
             return 'blocked'
         # Is the existing phone mumber available for this owner?
         if not existing.is_available_for(owner):
             # Not available, so return False
-            return False
+            return 'taken'
         # Caller is asking to confirm this is not already belonging to this owner
         if new and existing.is_exclusive():
             # It's in an exclusive relationship, and we're already determined it's
             # available to this owner, so it must be exclusive to them
             return 'not_new'
-        return True
+        return None
 
 
 @declarative_mixin
@@ -890,3 +891,7 @@ def _phone_number_mixin_configure_events(
 ) -> None:
     event.listen(cls.phone_number, 'set', _phone_number_mixin_set_validator)
     event.listen(cls, 'before_delete', _send_refcount_event_before_delete)
+
+
+if TYPE_CHECKING:
+    from .user import User

--- a/funnel/models/phone_number.py
+++ b/funnel/models/phone_number.py
@@ -436,7 +436,7 @@ class PhoneNumber(BaseMixin, Model):
         )
 
     def is_available_for(self, owner: Optional[User]) -> bool:
-        """Return True if this PhoneNumber is available for the given owner."""
+        """Return True if this PhoneNumber is available for the proposed owner."""
         for backref_name in self.__exclusive_backrefs__:
             for related_obj in getattr(self, backref_name):
                 curr_owner = getattr(related_obj, related_obj.__phone_for__)
@@ -670,10 +670,10 @@ class PhoneNumber(BaseMixin, Model):
         new: bool = False,
     ) -> Optional[Literal['taken', 'invalid', 'not_new', 'blocked']]:
         """
-        Validate whether the phone number is available to the given owner.
+        Validate whether the phone number is available to the proposed owner.
 
-        Returns False if the number is blocked or in use by another owner, True if
-        available without issues, or a string value indicating the concern:
+        Returns None if available without issues, or a string value indicating the
+        concern:
 
         1. 'taken': Phone number has another owner
         2. 'not_new': Phone number is already attached to owner (if `new` is True)

--- a/funnel/models/user.py
+++ b/funnel/models/user.py
@@ -1567,6 +1567,7 @@ class UserEmailClaim(EmailAddressMixin, BaseMixin, Model):
 
     # Tell mypy that these are not optional
     email_address: Mapped[EmailAddress]  # type: ignore[assignment]
+    email: str
 
     user_id = sa.orm.mapped_column(sa.Integer, sa.ForeignKey('user.id'), nullable=False)
     user: Mapped[User] = relationship(

--- a/funnel/templates/account.html.jinja2
+++ b/funnel/templates/account.html.jinja2
@@ -177,7 +177,7 @@
                   {% for useremail in current_auth.user.emailclaims %}
                     <li>
                       <input type="radio" disabled="disabled" class="margin-right"/>
-                      <span class="form-inline-label">{{ useremail }} <em><a href="{{ url_for('verify_email', email_hash=useremail.transport_hash) }}">{% trans %}(pending verification){% endtrans %}</a></em></span>
+                      <span class="form-inline-label">{{ useremail }} <em><a href="{{ url_for('verify_email_legacy', email_hash=useremail.transport_hash) }}">{% trans %}(pending verification){% endtrans %}</a></em></span>
                       <a href="{{ url_for('remove_email', email_hash=useremail.transport_hash) }}"
                          aria-label="{% trans %}Remove{% endtrans %}"
                          class="mui--pull-right">{{ faicon(icon='trash-alt', icon_size='subhead', baseline=false, css_class="mui--align-middle") }}</a>

--- a/funnel/templates/account_merge.html.jinja2
+++ b/funnel/templates/account_merge.html.jinja2
@@ -4,26 +4,34 @@
 
 {% macro accountinfo(user) %}
   <ul class="list--aligned mui--text-subhead">
-    <li><span class="text-bold">{% trans %}Name:{% endtrans %}</span> {{ user.fullname }}</li>
-    <li><span class="text-bold">{% trans %}Username:{% endtrans %}</span> {% if user.username %}{{ user.username }}{% else %}{% trans %}(none){% endtrans %}{% endif %}</li>
-    <li>
-      <ul>
-        {%- for useremail in user.emails %}
-          <li><span class="text-bold">{% trans %}Email addresses:{% endtrans %}</span> {{ useremail.email }}</li>
-        {%- else %}
-          <li><span class="text-bold">{% trans %}Email addresses:{% endtrans %}</span> <em>{% trans %}(none){% endtrans %}</em></li>
-        {%- endfor %}
-      </ul>
-    </li>
-    <li><span class="text-bold">{% trans %}Connected accounts:{% endtrans %}</span>
-      <ul>
-        {%- for extid in user.externalids %}
-          <li><span class="text-bold">{{ login_registry[extid.service].title }}:</span> {{ extid.username }}</li>
-        {%- else %}
-          <li><em>(none)</em></li>
-        {%- endfor %}
-      </ul>
-    </li>
+    <li><span class="text-bold">{% trans %}Name:{% endtrans %}</span> {{ user.pickername }}</li>
+    {%- if user.emails %}
+      <li><span class="text-bold">{% trans %}Email addresses:{% endtrans %}</span>
+        <ul>
+          {%- for useremail in user.emails %}
+            <li>{{ useremail.email }}</li>
+          {%- endfor %}
+        </ul>
+      </li>
+    {%- endif %}
+    {%- if user.phones %}
+      <li><span class="text-bold">{% trans %}Phone numbers:{% endtrans %}</span>
+        <ul>
+          {%- for userphone in user.phones %}
+            <li>{{ userphone.formatted }}</li>
+          {%- endfor %}
+        </ul>
+      </li>
+    {%- endif %}
+    {%- if user.externalids %}
+      <li><span class="text-bold">{% trans %}Connected accounts:{% endtrans %}</span>
+        <ul>
+          {%- for extid in user.externalids %}
+            <li><span class="text-bold">{% if extid.service in login_registry %}{{ login_registry[extid.service].title }}{% else %}{{ extid.service|capitalize }}{% endif %}:</span> {{ extid.username }}</li>
+          {%- endfor %}
+        </ul>
+      </li>
+    {%- endif %}
   </ul>
 {% endmacro %}
 

--- a/funnel/templates/email_add_otp.html.jinja2
+++ b/funnel/templates/email_add_otp.html.jinja2
@@ -1,0 +1,12 @@
+{% extends "notifications/layout_email.html.jinja2" %}
+{% block content -%}
+
+  <p>{% trans %}Hello {{ fullname }},{% endtrans %}</p>
+
+  <p>{% trans %}This OTP to verify your email address is valid for 15 minutes.{% endtrans %}</p>
+
+  <p><big>{% trans %}OTP:{% endtrans %} <strong>{{ otp }}</strong></big></p>
+
+  <p>{% trans %}If you did not ask for this, you may safely ignore this email.{% endtrans %}</p>
+
+{%- endblock %}

--- a/funnel/transports/sms/send.py
+++ b/funnel/transports/sms/send.py
@@ -246,7 +246,14 @@ sender_registry = [
 ]
 
 #: Available senders as per config
-senders_by_prefix: List[Tuple[str, Callable[[str, SmsTemplate, bool], str]]] = []
+senders_by_prefix: List[
+    Tuple[
+        str,
+        Callable[
+            [Union[str, phonenumbers.PhoneNumber, PhoneNumber], SmsTemplate, bool], str
+        ],
+    ]
+] = []
 
 
 def init() -> bool:

--- a/funnel/transports/sms/send.py
+++ b/funnel/transports/sms/send.py
@@ -120,8 +120,12 @@ def send_via_exotel(
         'Body': str(message),
         'DltEntityId': message.registered_entityid,
     }
-    if message.registered_templateid:
-        payload['DltTemplateId'] = message.registered_templateid
+    if not message.registered_templateid:
+        app.logger.warning(
+            "Dropping SMS message with unknown template id: %s", str(message)
+        )
+        return ''
+    payload['DltTemplateId'] = message.registered_templateid
     if callback:
         payload['StatusCallback'] = url_for(
             'process_exotel_event',

--- a/funnel/views/account.py
+++ b/funnel/views/account.py
@@ -8,7 +8,16 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 import geoip2.errors
 import user_agents
-from flask import abort, current_app, flash, redirect, render_template, request, url_for
+from flask import (
+    abort,
+    current_app,
+    flash,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
 from markupsafe import Markup, escape
 
 from baseframe import _, forms
@@ -21,6 +30,7 @@ from .. import app
 from ..forms import (
     AccountDeleteForm,
     AccountForm,
+    EmailOtpForm,
     EmailPrimaryForm,
     LogoutForm,
     NewEmailAddressForm,
@@ -98,7 +108,7 @@ def user_locale(obj: User) -> str:
 def user_timezone(obj: User) -> str:
     """Human-friendly identifier for user's timezone, defaulting to timezone name."""
     return timezone_identifiers.get(
-        str(obj.timezone) if obj.timezone else None, obj.timezone
+        str(obj.timezone) if obj.timezone else '', obj.timezone
     )
 
 
@@ -353,9 +363,9 @@ class AccountView(ClassView):
         )
 
     # FIXME: Don't modify db on GET. Autosubmit via JS and process on POST
-    @route('confirm/<email_hash>/<secret>', endpoint='confirm_email')
-    def confirm_email(self, email_hash: str, secret: str) -> ReturnView:
-        """Confirm an email address using a verification link."""
+    @route('confirm/<email_hash>/<secret>', endpoint='confirm_email_legacy')
+    def confirm_email_legacy(self, email_hash: str, secret: str) -> ReturnView:
+        """Confirm an email address using a legacy verification link."""
         try:
             emailclaim = UserEmailClaim.get_by(
                 verification_code=secret, email_hash=email_hash
@@ -475,27 +485,67 @@ class AccountView(ClassView):
 
     @route('email/new', methods=['GET', 'POST'], endpoint='add_email')
     def add_email(self) -> ReturnView:
-        """Add a new email address using a confirmation link (legacy, pre-OTP)."""
+        """Add a new email address using an OTP."""
         form = NewEmailAddressForm(edit_user=current_auth.user)
         if form.validate_on_submit():
-            useremail = UserEmailClaim.get_for(
-                user=current_auth.user, email=form.email.data
+            otp_session = OtpSession.make(
+                'add-email', user=current_auth.user, anchor=None, email=form.email.data
             )
-            if useremail is None:
-                useremail = UserEmailClaim(
-                    user=current_auth.user, email=form.email.data
+            if otp_session.send():
+                current_auth.user.main_notification_preferences.by_email = (
+                    form.enable_notifications.data
                 )
-                db.session.add(useremail)
-            send_email_verify_link(useremail)
-            db.session.commit()
-            flash(_("We sent you an email to confirm your address"), 'success')
-            user_data_changed.send(current_auth.user, changes=['email-claim'])
-            return render_redirect(url_for('account'))
+                return render_redirect(url_for('verify_email'))
         return render_form(
             form=form,
             title=_("Add an email address"),
             formid='email_add',
-            submit=_("Add email"),
+            submit=_("Verify email"),
+            ajax=False,
+            template='account_formlayout.html.jinja2',
+        )
+
+    @route('email/verify', methods=['GET', 'POST'], endpoint='verify_email')
+    def verify_email(self) -> ReturnView:
+        """Verify an email address with an OTP."""
+        try:
+            otp_session = OtpSession.retrieve('add-email')
+        except OtpTimeoutError:
+            flash(_("This OTP has expired"), category='error')
+            return render_redirect(url_for('add_email'))
+
+        form = EmailOtpForm(valid_otp=otp_session.otp)
+        if form.is_submitted():
+            # Allow 5 guesses per 60 seconds
+            validate_rate_limit('account_email-otp', otp_session.token, 5, 60)
+        if form.validate_on_submit():
+            OtpSession.delete()
+            if TYPE_CHECKING:
+                assert otp_session.email is not None  # nosec B101
+            existing = UserEmail.get(otp_session.email)
+            if existing is None:
+                # This email address is available to claim. If there are no other email
+                # addresses in this account, this will be a primary
+                primary = not current_auth.user.emails
+                useremail = UserEmail(user=current_auth.user, email=otp_session.email)
+                useremail.primary = primary
+                db.session.add(useremail)
+                useremail.email_address.mark_active()
+                db.session.commit()
+                flash(_("Your email address has been verified"), 'success')
+                user_data_changed.send(current_auth.user, changes=['email'])
+                return render_redirect(
+                    get_next_url(session=True, default=url_for('account'))
+                )
+            # Already linked to another account, but we have verified the ownership, so
+            # proceed to merge account flow here
+            session['merge_buid'] = existing.user.buid
+            return render_redirect(url_for('account_merge'), 303)
+        return render_form(
+            form=form,
+            title=_("Verify email address"),
+            formid='email_verify',
+            submit=_("Verify"),
             ajax=False,
             template='account_formlayout.html.jinja2',
         )
@@ -606,9 +656,9 @@ class AccountView(ClassView):
     @route(
         'email/<email_hash>/verify',
         methods=['GET', 'POST'],
-        endpoint='verify_email',
+        endpoint='verify_email_legacy',
     )
-    def verify_email(self, email_hash: str) -> ReturnView:
+    def verify_email_legacy(self, email_hash: str) -> ReturnView:
         """
         Allow user to resend an email verification link if original is lost.
 
@@ -691,9 +741,11 @@ class AccountView(ClassView):
         if form.validate_on_submit():
             OtpSession.delete()
             if TYPE_CHECKING:
-                assert otp_session.phone is not None  # nosec
-            if UserPhone.get(otp_session.phone) is None:
-                # If there are no existing phone numbers, this will be a primary
+                assert otp_session.phone is not None  # nosec B101
+            existing = UserPhone.get(otp_session.phone)
+            if existing is None:
+                # This phone number is available to claim. If there are no other
+                # phone numbers in this account, this will be a primary
                 primary = not current_auth.user.phones
                 userphone = UserPhone(user=current_auth.user, phone=otp_session.phone)
                 userphone.primary = primary
@@ -705,11 +757,10 @@ class AccountView(ClassView):
                 return render_redirect(
                     get_next_url(session=True, default=url_for('account'))
                 )
-            flash(
-                _("This phone number has already been claimed by another user"),
-                'danger',
-            )
-            return render_redirect(url_for('add_phone'))
+            # Already linked to another user, but we have verified the ownership, so
+            # proceed to merge account flow here
+            session['merge_buid'] = existing.user.buid
+            return render_redirect(url_for('account_merge'), 303)
         return render_form(
             form=form,
             title=_("Verify phone number"),

--- a/funnel/views/email.py
+++ b/funnel/views/email.py
@@ -14,7 +14,7 @@ def send_email_verify_link(useremail: UserEmail) -> str:
     """Mail a verification link to the user."""
     subject = _("Verify your email address")
     url = url_for(
-        'confirm_email',
+        'confirm_email_legacy',
         _external=True,
         email_hash=useremail.email_address.email_hash,
         secret=useremail.verification_code,

--- a/funnel/views/notification.py
+++ b/funnel/views/notification.py
@@ -520,7 +520,7 @@ def dispatch_transport_email(
         to=[(user_notification.user.fullname, str(address))],
         content=content,
         attachments=attachments,
-        from_email=(view.email_from(), app.config['MAIL_DEFAULT_SENDER']),
+        from_email=(view.email_from(), app.config['MAIL_DEFAULT_SENDER_ADDR']),
         headers={
             'List-Id': formataddr(
                 (

--- a/funnel/views/notification.py
+++ b/funnel/views/notification.py
@@ -518,7 +518,7 @@ def dispatch_transport_email(
         to=[(user_notification.user.fullname, str(address))],
         content=content,
         attachments=attachments,
-        from_email=(view.email_from(), 'no-reply@' + app.config['DEFAULT_DOMAIN']),
+        from_email=(view.email_from(), app.config['MAIL_DEFAULT_SENDER']),
         headers={
             'List-Id': formataddr(
                 (

--- a/funnel/views/otp.py
+++ b/funnel/views/otp.py
@@ -306,7 +306,10 @@ class OtpSession(Generic[OptionalUserType]):
 
     def mark_transport_active(self) -> None:
         """Mark email and/or phone as active based on user activity."""
-        # FIXME: Potential future scenario where email AND phone are sent an OTP
+        if self.phone and self.email:
+            # FIXME: Potential future scenario where email AND phone are sent an OTP.
+            # We don't know which is active and it's not safe to assume, so do nothing
+            return
         if self.phone:
             try:
                 phone_number = PhoneNumber.get(self.phone)

--- a/funnel/views/schedule.py
+++ b/funnel/views/schedule.py
@@ -179,7 +179,7 @@ def session_ical(session: Session, rsvp: Optional[Rsvp] = None) -> Event:
 
     event = Event()
     event.add('summary', session.title)
-    organizer = vCalAddress(f'MAILTO:{current_app.config["MAIL_DEFAULT_SENDER"]}')
+    organizer = vCalAddress(f'MAILTO:{current_app.config["MAIL_DEFAULT_SENDER_ADDR"]}')
     organizer.params['cn'] = vText(session.project.profile.title)
     event['organizer'] = organizer
     if rsvp:

--- a/funnel/views/schedule.py
+++ b/funnel/views/schedule.py
@@ -179,7 +179,7 @@ def session_ical(session: Session, rsvp: Optional[Rsvp] = None) -> Event:
 
     event = Event()
     event.add('summary', session.title)
-    organizer = vCalAddress(f'MAILTO:no-reply@{current_app.config["DEFAULT_DOMAIN"]}')
+    organizer = vCalAddress(f'MAILTO:{current_app.config["MAIL_DEFAULT_SENDER"]}')
     organizer.params['cn'] = vText(session.project.profile.title)
     event['organizer'] = organizer
     if rsvp:

--- a/sample.env
+++ b/sample.env
@@ -101,7 +101,7 @@ FLASK_MAIL_USE_SSL=false
 FLASK_MAIL_USERNAME=null
 FLASK_MAIL_PASSWORD=null
 # Default "From:" address in email
-FLASK_MAIL_DEFAULT_SENDER=sender@example.com
+FLASK_MAIL_DEFAULT_SENDER="Hasgeek <sender@example.com>"
 
 # --- AWS SNS configuration
 # AWS SES events (required only if app is configured to send email via SES)

--- a/tests/integration/views/account_add_test.py
+++ b/tests/integration/views/account_add_test.py
@@ -6,6 +6,8 @@ from unittest.mock import patch
 import pytest
 from werkzeug.datastructures import MultiDict
 
+from coaster.utils import newpin
+
 from funnel import models
 
 PATCH_EMAIL_VALIDATOR = (
@@ -30,6 +32,14 @@ def userphone_rincewind(user_rincewind: models.User) -> models.UserPhone:
     return user_rincewind.add_phone(TEST_NEW_PHONE)
 
 
+def get_wrong_otp(reference: str) -> str:
+    """Return a random value that does not match the reference value."""
+    result = reference
+    while result == reference:
+        result = newpin(len(reference))
+    return result
+
+
 def test_add_email_wrong_otp(
     client, csrf_token, login, user_rincewind: models.User
 ) -> None:
@@ -48,7 +58,9 @@ def test_add_email_wrong_otp(
 
         rv2 = client.post(
             rv1.location,
-            data=MultiDict({'csrf_token': csrf_token, 'otp': caught_otp[::-1]}),
+            data=MultiDict(
+                {'csrf_token': csrf_token, 'otp': get_wrong_otp(caught_otp)}
+            ),
         )
         assert 'OTP is incorrect' in rv2.data.decode()
 
@@ -121,7 +133,7 @@ def test_add_phone_wrong_otp(
 
     rv2 = client.post(
         rv1.location,
-        data=MultiDict({'csrf_token': csrf_token, 'otp': caught_otp[::-1]}),
+        data=MultiDict({'csrf_token': csrf_token, 'otp': get_wrong_otp(caught_otp)}),
     )
     assert 'OTP is incorrect' in rv2.data.decode()
 

--- a/tests/integration/views/account_add_test.py
+++ b/tests/integration/views/account_add_test.py
@@ -1,0 +1,174 @@
+"""Tests to add a new phone number or email address."""
+# pylint: disable=redefined-outer-name
+
+from unittest.mock import patch
+
+import pytest
+from werkzeug.datastructures import MultiDict
+
+from funnel import models
+
+PATCH_EMAIL_VALIDATOR = (
+    'funnel.models.email_address.EmailAddress.is_valid_email_address'
+)
+PATCH_SMS_OTP_SEND = 'funnel.views.otp.OtpSessionForNewPhone.send_sms'
+PATCH_EMAIL_OTP_SEND = 'funnel.views.otp.OtpSessionForNewEmail.send_email'
+
+TEST_NEW_EMAIL = 'rincewind@example.com'
+TEST_NEW_PHONE = '+918123456789'
+
+
+@pytest.fixture()
+def useremail_rincewind(user_rincewind: models.User) -> models.UserEmail:
+    """Email address for user fixture."""
+    return user_rincewind.add_email(TEST_NEW_EMAIL)
+
+
+@pytest.fixture()
+def userphone_rincewind(user_rincewind: models.User) -> models.UserPhone:
+    """Phone number for user fixture."""
+    return user_rincewind.add_phone(TEST_NEW_PHONE)
+
+
+def test_add_email_wrong_otp(
+    client, csrf_token, login, user_rincewind: models.User
+) -> None:
+    """Add a new email address with an OTP and confirm an incorrect OTP is rejected."""
+    login.as_(user_rincewind)
+
+    with patch(PATCH_EMAIL_VALIDATOR, return_value=True):
+        with patch(PATCH_EMAIL_OTP_SEND, autospec=True, return_value=True) as mock:
+            rv1 = client.post(
+                '/account/email/new',
+                data=MultiDict({'csrf_token': csrf_token, 'email': TEST_NEW_EMAIL}),
+            )
+            assert rv1.status_code == 303
+            otp_session = mock.call_args[0][0]  # First call, first argument (self)
+            caught_otp = otp_session.otp
+
+        rv2 = client.post(
+            rv1.location,
+            data=MultiDict({'csrf_token': csrf_token, 'otp': caught_otp[::-1]}),
+        )
+        assert 'OTP is incorrect' in rv2.data.decode()
+
+
+def test_add_email(client, csrf_token, login, user_rincewind: models.User) -> None:
+    """Add a new email address with an OTP."""
+    login.as_(user_rincewind)
+    assert user_rincewind.emails == []
+
+    with patch(PATCH_EMAIL_VALIDATOR, return_value=True):
+        with patch(PATCH_EMAIL_OTP_SEND, autospec=True, return_value=True) as mock:
+            rv1 = client.post(
+                '/account/email/new',
+                data=MultiDict({'csrf_token': csrf_token, 'email': TEST_NEW_EMAIL}),
+            )
+            assert rv1.status_code == 303
+            otp_session = mock.call_args[0][0]  # First call, first argument (self)
+            caught_otp = otp_session.otp
+
+        rv2 = client.post(
+            rv1.location, data=MultiDict({'csrf_token': csrf_token, 'otp': caught_otp})
+        )
+        assert rv2.status_code == 303
+
+    assert str(user_rincewind.email) == TEST_NEW_EMAIL
+
+
+def test_merge_with_email_otp(
+    client, csrf_token, login, useremail_rincewind, user_mort
+) -> None:
+    """Providing a valid OTP for another user's email address causes a merge prompt."""
+    login.as_(user_mort)
+    assert user_mort.emails == []
+    with patch(PATCH_EMAIL_VALIDATOR, return_value=True):
+        with patch(PATCH_EMAIL_OTP_SEND, autospec=True, return_value=True) as mock:
+            rv1 = client.post(
+                '/account/email/new',
+                data=MultiDict({'csrf_token': csrf_token, 'email': TEST_NEW_EMAIL}),
+            )
+            assert rv1.status_code == 303
+            otp_session = mock.call_args[0][0]  # First call, first argument (self)
+            caught_otp = otp_session.otp
+
+        rv2 = client.post(
+            rv1.location, data=MultiDict({'csrf_token': csrf_token, 'otp': caught_otp})
+        )
+        assert rv2.status_code == 303
+        assert user_mort.emails == []
+        assert rv2.location == '/account/merge'
+        with client.session_transaction() as session:
+            assert session['merge_buid'] == useremail_rincewind.user.buid
+
+
+def test_add_phone_wrong_otp(
+    client, csrf_token, login, user_rincewind: models.User
+) -> None:
+    """Add a new phone number with an OTP and confirm an incorrect OTP is rejected."""
+    login.as_(user_rincewind)
+
+    assert user_rincewind.phones == []
+
+    with patch(PATCH_SMS_OTP_SEND, autospec=True, return_value=True) as mock:
+        rv1 = client.post(
+            '/account/phone/new',
+            data=MultiDict({'csrf_token': csrf_token, 'phone': TEST_NEW_PHONE}),
+        )
+        assert rv1.status_code == 303
+        otp_session = mock.call_args[0][0]  # First call, first argument (self)
+        caught_otp = otp_session.otp
+
+    rv2 = client.post(
+        rv1.location,
+        data=MultiDict({'csrf_token': csrf_token, 'otp': caught_otp[::-1]}),
+    )
+    assert 'OTP is incorrect' in rv2.data.decode()
+
+
+def test_add_phone(client, csrf_token, login, user_rincewind: models.User) -> None:
+    """Add a new phone number with an OTP."""
+    login.as_(user_rincewind)
+    assert user_rincewind.phones == []
+
+    with patch(PATCH_SMS_OTP_SEND, autospec=True, return_value=True) as mock:
+        rv1 = client.post(
+            '/account/phone/new',
+            data=MultiDict({'csrf_token': csrf_token, 'phone': TEST_NEW_PHONE}),
+        )
+        assert rv1.status_code == 303
+        otp_session = mock.call_args[0][0]  # First call, first argument (self)
+        caught_otp = otp_session.otp
+
+    rv2 = client.post(
+        rv1.location, data=MultiDict({'csrf_token': csrf_token, 'otp': caught_otp})
+    )
+    assert rv2.status_code == 303
+
+    assert str(user_rincewind.phone) == TEST_NEW_PHONE
+
+
+def test_merge_with_phone_otp(
+    client, csrf_token, login, userphone_rincewind, user_mort
+) -> None:
+    """Providing a valid OTP for another user's phone number causes a merge prompt."""
+    login.as_(user_mort)
+    assert user_mort.phones == []
+    with patch(PATCH_SMS_OTP_SEND, autospec=True, return_value=True) as mock:
+        rv1 = client.post(
+            '/account/phone/new',
+            data=MultiDict({'csrf_token': csrf_token, 'phone': TEST_NEW_PHONE}),
+        )
+        assert rv1.status_code == 303
+        assert rv1.location == '/account/phone/verify'
+        otp_session = mock.call_args[0][0]  # First call, first argument (self)
+        caught_otp = otp_session.otp
+
+    rv2 = client.post(
+        rv1.location, data=MultiDict({'csrf_token': csrf_token, 'otp': caught_otp})
+    )
+    assert rv2.status_code == 303
+    assert user_mort.phones == []
+    assert rv2.location == '/account/merge'
+    with client.session_transaction() as session:
+        assert session['merge_buid'] == userphone_rincewind.user.buid

--- a/tests/integration/views/login_test.py
+++ b/tests/integration/views/login_test.py
@@ -24,7 +24,7 @@ pytestmark = pytest.mark.filterwarnings(
 
 # User fixture's details
 RINCEWIND_USERNAME = 'rincewind'
-RINCEWIND_PHONE = '+917676332020'
+RINCEWIND_PHONE = '+918123456789'
 RINCEWIND_EMAIL = 'rincewind@example.com'
 LOGIN_USERNAMES = [RINCEWIND_USERNAME, RINCEWIND_EMAIL, RINCEWIND_PHONE]
 

--- a/tests/unit/models/phone_number_test.py
+++ b/tests/unit/models/phone_number_test.py
@@ -710,25 +710,28 @@ def test_phone_number_validate_for(phone_models, db_session) -> None:
     db_session.add_all([user1, user2])
 
     # A new phone number is available to all
-    assert models.PhoneNumber.validate_for(user1, EXAMPLE_NUMBER_IN) is True
-    assert models.PhoneNumber.validate_for(user2, EXAMPLE_NUMBER_IN) is True
-    assert models.PhoneNumber.validate_for(anon_user, EXAMPLE_NUMBER_IN) is True
+    assert models.PhoneNumber.validate_for(user1, EXAMPLE_NUMBER_IN) is None
+    assert models.PhoneNumber.validate_for(user2, EXAMPLE_NUMBER_IN) is None
+    assert models.PhoneNumber.validate_for(anon_user, EXAMPLE_NUMBER_IN) is None
 
     # Once it's assigned to a user, availability changes
     link = phone_models.PhoneLink(phoneuser=user1, phone=EXAMPLE_NUMBER_IN)
     db_session.add(link)
 
-    assert models.PhoneNumber.validate_for(user1, EXAMPLE_NUMBER_IN) is True
-    assert models.PhoneNumber.validate_for(user2, EXAMPLE_NUMBER_IN) is False
-    assert models.PhoneNumber.validate_for(anon_user, EXAMPLE_NUMBER_IN) is False
+    assert models.PhoneNumber.validate_for(user1, EXAMPLE_NUMBER_IN) is None
+    assert models.PhoneNumber.validate_for(user2, EXAMPLE_NUMBER_IN) == 'taken'
+    assert models.PhoneNumber.validate_for(anon_user, EXAMPLE_NUMBER_IN) == 'taken'
 
     # A number in use is not available to claim as new
     assert (
         models.PhoneNumber.validate_for(user1, EXAMPLE_NUMBER_IN, new=True) == 'not_new'
     )
-    assert models.PhoneNumber.validate_for(user2, EXAMPLE_NUMBER_IN, new=True) is False
     assert (
-        models.PhoneNumber.validate_for(anon_user, EXAMPLE_NUMBER_IN, new=True) is False
+        models.PhoneNumber.validate_for(user2, EXAMPLE_NUMBER_IN, new=True) == 'taken'
+    )
+    assert (
+        models.PhoneNumber.validate_for(anon_user, EXAMPLE_NUMBER_IN, new=True)
+        == 'taken'
     )
 
     # A blocked number is available to no one
@@ -754,5 +757,5 @@ def test_phone_number_existing_but_unused_validate_for(
     db_session.add_all([user, phone_number])
     db_session.commit()
 
-    assert models.PhoneNumber.validate_for(user, EXAMPLE_NUMBER_GB, new=True) is True
-    assert models.PhoneNumber.validate_for(user, EXAMPLE_NUMBER_GB) is True
+    assert models.PhoneNumber.validate_for(user, EXAMPLE_NUMBER_GB, new=True) is None
+    assert models.PhoneNumber.validate_for(user, EXAMPLE_NUMBER_GB) is None


### PR DESCRIPTION
Changes:
* Verify a new email address using an OTP, deprecating use of UserEmailClaim
* Allow account merger using an OTP to phone or email address (both with tests)
* Send notifications using `MAIL_DEFAULT_SENDER`, not `DEFAULT_DOMAIN`
* Fix for when `MAIL_DEFAULT_SENDER` includes a display name
* Do not send SMS when the template id is not provided in config
* Simplify notification batch processing so it doesn't need that confusing explanation
* Add typing in notification dispatch methods
* Fix typing in EmailAddress and PhoneNumber classes