### PR TITLE
Send Updates to participants across the account

### DIFF
--- a/funnel/forms/update.py
+++ b/funnel/forms/update.py
@@ -27,5 +27,5 @@ class UpdateForm(forms.Form):
         __("Pin this update above other updates"), default=False
     )
     is_restricted = forms.BooleanField(
-        __("Limit visibility to participants only"), default=False
+        __("Limit access to current participants only"), default=False
     )

--- a/funnel/models/notification_types.py
+++ b/funnel/models/notification_types.py
@@ -114,7 +114,7 @@ class NewUpdateNotification(DocumentHasProject, Notification, type='update_new')
     )
 
     document_model = Update
-    roles = ['project_crew', 'project_participant']
+    roles = ['project_crew', 'project_participant', 'account_participant']
     exclude_actor = False  # Send to everyone including the actor
 
 

--- a/funnel/models/project.py
+++ b/funnel/models/project.py
@@ -91,7 +91,7 @@ class Project(UuidMixin, BaseScopedNameMixin, Model):
         grants_via={
             None: {
                 'admin': 'profile_admin',
-                'account_participant': 'account_participant',
+                'follower': 'account_participant',
             }
         },
         # `profile` only appears in the 'primary' dataset. It must not be included in
@@ -773,7 +773,9 @@ class __Profile:
             ),
             viewonly=True,
         ),
-        grants_via={None: {'participant': {'account_participant'}}},
+        # This grant of follower from Project participant is interim until Account gets
+        # it's own follower membership model
+        grants_via={None: {'participant': {'follower'}}},
     )
     draft_projects: DynamicMapped[Project] = relationship(
         Project,

--- a/funnel/models/update.py
+++ b/funnel/models/update.py
@@ -98,6 +98,18 @@ class Update(UuidMixin, BaseScopedIdNameMixin, TimestampMixin, Model):
     )
     parent: Mapped[Project] = sa.orm.synonym('project')
 
+    _project_when_unrestricted: Mapped[Project] = with_roles(
+        relationship(
+            Project,
+            viewonly=True,
+            uselist=False,
+            primaryjoin=sa.and_(
+                project_id == Project.id, _visibility_state == VISIBILITY_STATE.PUBLIC
+            ),
+        ),
+        grants_via={None: {'account_participant': 'account_participant'}},
+    )
+
     body, body_text, body_html = MarkdownCompositeDocument.create(
         'body', nullable=False
     )

--- a/funnel/models/update.py
+++ b/funnel/models/update.py
@@ -98,6 +98,13 @@ class Update(UuidMixin, BaseScopedIdNameMixin, TimestampMixin, Model):
     )
     parent: Mapped[Project] = sa.orm.synonym('project')
 
+    # Relationship to project that exists only when the Update is not restricted, for
+    # the purpose of inheriting the account_participant role. We do this because
+    # RoleMixin does not have a mechanism for conditional grant of roles. A relationship
+    # marked as `grants_via` will always grant the role unconditionally, so the only
+    # control at the moment is to make the relationship itself conditional. The affected
+    # mechanism is not `roles_for` but `actors_with`, which is currently not meant to be
+    # redefined in a subclass
     _project_when_unrestricted: Mapped[Project] = with_roles(
         relationship(
             Project,

--- a/funnel/views/notifications/update_notification.py
+++ b/funnel/views/notifications/update_notification.py
@@ -19,7 +19,10 @@ class RenderNewUpdateNotification(RenderNotification):
     update: Update
     aliases = {'document': 'update'}
     emoji_prefix = "📰 "
-    reason = __("You are receiving this because you have registered for this project")
+    reason = __(
+        "You are receiving this because you have registered for this or related"
+        " projects"
+    )
 
     @property
     def actor(self):


### PR DESCRIPTION
However, restricted updates remain restricted to the current project's participants