### PR TITLE
Fix timezone cookie

### DIFF
--- a/funnel/assets/js/app.js
+++ b/funnel/assets/js/app.js
@@ -64,7 +64,7 @@ $(() => {
   }
 
   // Detect timezone for login
-  if ($.cookie('timezone') === null) {
+  if (!$.cookie('timezone')) {
     $.cookie('timezone', jstz.determine().name(), { path: '/' });
   }
 


### PR DESCRIPTION
The timezone cookie was set only  if it is `null` which is not the case on first time load. The empty check is fixed.