### PR TITLE
Make MarkdownString comprehensive and fix escaping in Mustache renderers

### DIFF
--- a/funnel/utils/markdown/__init__.py
+++ b/funnel/utils/markdown/__init__.py
@@ -2,3 +2,4 @@
 # flake8: noqa
 
 from .base import *
+from .escape import *

--- a/funnel/utils/markdown/base.py
+++ b/funnel/utils/markdown/base.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from dataclasses import dataclass
 from typing import (
     Any,
@@ -15,7 +14,7 @@ from typing import (
     Union,
     overload,
 )
-from typing_extensions import Literal
+from typing_extensions import Literal, Self
 
 from markdown_it import MarkdownIt
 from markupsafe import Markup
@@ -38,72 +37,7 @@ from .mdit_plugins import (  # toc_plugin,
 )
 from .tabs import render_tab
 
-__all__ = ['MarkdownPlugin', 'MarkdownConfig', 'MarkdownString', 'markdown_escape']
-
-# --- Markdown escaper and string ------------------------------------------------------
-
-#: Based on the ASCII punctuation list in the CommonMark spec at
-#: https://spec.commonmark.org/0.30/#backslash-escapes
-markdown_escape_re = re.compile(r"""([\[\\\]{|}\(\)`~!@#$%^&*=+;:'"<>/,.?_-])""")
-
-
-def markdown_escape(text: str) -> MarkdownString:
-    """
-    Escape all Markdown formatting characters and strip whitespace at ends.
-
-    As per the CommonMark spec, all ASCII punctuation can be escaped with a backslash
-    and compliant parsers will then render the punctuation mark as a literal character.
-    However, escaping any other character will cause the backslash to be rendered. This
-    escaper therefore targets only ASCII punctuation characters listed in the spec.
-
-    Edge whitespace is significant in Markdown and must be stripped when escaping:
-
-    * Four spaces at the start will initiate a code block
-    * Two spaces at the end will cause a line-break in non-GFM Markdown
-
-    Replacing these spaces with &nbsp; is not suitable because non-breaking spaces
-    affect HTML rendering, specifically the CSS ``white-space: normal`` sequence
-    collapsing behaviour.
-
-    :returns: Escaped text as an instance of :class:`MarkdownString`, to avoid
-        double-escaping
-    """
-    if hasattr(text, '__markdown__'):
-        return MarkdownString(text.__markdown__())
-    return MarkdownString(markdown_escape_re.sub(r'\\\1', text).strip())
-
-
-class MarkdownString(str):
-    """Markdown string, implements a __markdown__ method."""
-
-    __slots__ = ()
-
-    def __new__(
-        cls, base: Any = '', encoding: Optional[str] = None, errors: str = 'strict'
-    ) -> MarkdownString:
-        if hasattr(base, '__markdown__'):
-            base = base.__markdown__()
-
-        if encoding is None:
-            return super().__new__(cls, base)
-
-        return super().__new__(cls, base, encoding, errors)
-
-    def __markdown__(self) -> MarkdownString:
-        """Return a markdown source string."""
-        return self
-
-    @classmethod
-    def escape(cls, text: str) -> MarkdownString:
-        """Escape a string."""
-        rv = markdown_escape(text)
-
-        if rv.__class__ is not cls:
-            return cls(rv)
-
-        return rv
-
-    # TODO: Implement other methods supported by markupsafe
+__all__ = ['MarkdownPlugin', 'MarkdownConfig']
 
 
 # --- Markdown dataclasses -------------------------------------------------------------
@@ -118,17 +52,19 @@ class MarkdownPlugin:
     #: Registry of instances
     registry: ClassVar[Dict[str, MarkdownPlugin]] = {}
 
-    #: Optional name for this config, for adding to the registry
-    name: str
+    #: Optional name for this config
+    name: Optional[str]
     func: Callable
     config: Optional[Dict[str, Any]] = None
 
-    def __post_init__(self) -> None:
-        # If this plugin+configuration has a name, add it to the registry
-        if self.name is not None:
-            if self.name in self.registry:
-                raise NameError(f"Plugin {self.name} has already been registered")
-            self.registry[self.name] = self
+    @classmethod
+    def register(cls, name: str, *args, **kwargs) -> Self:
+        """Create a new instance and add it to the registry."""
+        if name in cls.registry:
+            raise NameError(f"MarkdownPlugin {name} has already been registered")
+        obj = cls(name, *args, **kwargs)
+        cls.registry[name] = obj
+        return obj
 
 
 @dataclass
@@ -171,11 +107,14 @@ class MarkdownConfig:
         except KeyError as exc:
             raise TypeError(f"Unknown Markdown plugin {exc.args[0]}") from None
 
-        # If this plugin+configuration has a name, add it to the registry
-        if self.name is not None:
-            if self.name in self.registry:
-                raise NameError(f"Config {self.name} has already been registered")
-            self.registry[self.name] = self
+    @classmethod
+    def register(cls, name: str, *args, **kwargs) -> Self:
+        """Create a new instance and add it to the registry."""
+        if name in cls.registry:
+            raise NameError(f"MarkdownConfig {name} has already been registered")
+        obj = cls(name, *args, **kwargs)
+        cls.registry[name] = obj
+        return obj
 
     @overload
     def render(self, text: None) -> None:
@@ -219,10 +158,10 @@ class MarkdownConfig:
 # --- Markdown plugins -----------------------------------------------------------------
 
 
-MarkdownPlugin('abbr', abbr_plugin)
-MarkdownPlugin('deflists', deflist.deflist_plugin)
-MarkdownPlugin('footnote', footnote.footnote_plugin)
-MarkdownPlugin(
+MarkdownPlugin.register('abbr', abbr_plugin)
+MarkdownPlugin.register('deflists', deflist.deflist_plugin)
+MarkdownPlugin.register('footnote', footnote.footnote_plugin)
+MarkdownPlugin.register(
     'heading_anchors',
     anchors.anchors_plugin,
     {
@@ -234,43 +173,45 @@ MarkdownPlugin(
         'permalinkSpace': False,
     },
 )
-MarkdownPlugin(
+# The heading_anchors_fix plugin modifies the token stream output of heading_anchors
+# plugin to make the heading a permalink instead of a separate permalink. It eliminates
+# the extra character and strips any links inside the heading that may have been
+# introduced by the author.
+MarkdownPlugin.register('heading_anchors_fix', heading_anchors_fix_plugin)
+
+MarkdownPlugin.register(
     'tasklists',
     tasklists.tasklists_plugin,
     {'enabled': True, 'label': True, 'label_after': False},
 )
-MarkdownPlugin('ins', ins_plugin)
-MarkdownPlugin('del', del_plugin)
-MarkdownPlugin('sub', sub_plugin)
-MarkdownPlugin('sup', sup_plugin)
-MarkdownPlugin('mark', mark_plugin)
+MarkdownPlugin.register('ins', ins_plugin)
+MarkdownPlugin.register('del', del_plugin)
+MarkdownPlugin.register('sub', sub_plugin)
+MarkdownPlugin.register('sup', sup_plugin)
+MarkdownPlugin.register('mark', mark_plugin)
 
-MarkdownPlugin(
+MarkdownPlugin.register(
     'tab_container',
     container.container_plugin,
     {'name': 'tab', 'marker': ':', 'render': render_tab},
 )
-MarkdownPlugin('markmap', embeds_plugin, {'name': 'markmap'})
-MarkdownPlugin('vega-lite', embeds_plugin, {'name': 'vega-lite'})
-MarkdownPlugin('mermaid', embeds_plugin, {'name': 'mermaid'})
-MarkdownPlugin('block_code_ext', block_code_extend_plugin)
-MarkdownPlugin('footnote_ext', footnote_extend_plugin)
-# The heading_anchors_fix plugin modifies the token stream output of heading_anchors plugin to
-# make the heading a permalink instead of a separate permalink. It eliminates the extra
-# character and strips any links inside the heading that may have been introduced by the
-# author.
-MarkdownPlugin('heading_anchors_fix', heading_anchors_fix_plugin)
-# MarkdownPlugin('toc', toc_plugin)
+MarkdownPlugin.register('markmap', embeds_plugin, {'name': 'markmap'})
+MarkdownPlugin.register('vega_lite', embeds_plugin, {'name': 'vega-lite'})
+MarkdownPlugin.register('mermaid', embeds_plugin, {'name': 'mermaid'})
+MarkdownPlugin.register('block_code_ext', block_code_extend_plugin)
+MarkdownPlugin.register('footnote_ext', footnote_extend_plugin)
+# The TOC plugin isn't yet working
+# MarkdownPlugin.register('toc', toc_plugin)
 
 # --- Markdown configurations ----------------------------------------------------------
 
-MarkdownConfig(
+markdown_basic = MarkdownConfig.register(
     name='basic',
     options_update={'html': False, 'breaks': True},
     plugins=['block_code_ext'],
 )
 
-MarkdownConfig(
+markdown_document = MarkdownConfig.register(
     name='document',
     preset='gfm-like',
     options_update={
@@ -295,11 +236,25 @@ MarkdownConfig(
         'sup',
         'mark',
         'markmap',
-        'vega-lite',
+        'vega_lite',
         'mermaid',
         # 'toc',
     ],
     enable_rules={'smartquotes'},
+)
+
+markdown_mailer = MarkdownConfig.register(
+    name='mailer',
+    preset='gfm-like',
+    options_update={
+        'html': True,
+        'linkify': True,
+        'typographer': True,
+        'breaks': True,
+    },
+    plugins=markdown_document.plugins,
+    enable_rules={'smartquotes'},
+    linkify_fuzzy_email=True,
 )
 
 #: This profile is meant for inline fields (like Title) and allows for only inline
@@ -310,7 +265,7 @@ MarkdownConfig(
 #: Unicode characters for bold/italic/sub/sup, but found this unsuitable as these
 #: character ranges are not comprehensive. Instead, plaintext use will include the
 #: Markdown formatting characters as-is.
-MarkdownConfig(
+markdown_inline = MarkdownConfig.register(
     name='inline',
     preset='zero',
     options_update={'html': False, 'breaks': False, 'typographer': True},

--- a/funnel/utils/markdown/escape.py
+++ b/funnel/utils/markdown/escape.py
@@ -1,0 +1,308 @@
+"""Markdown escaper."""
+
+from __future__ import annotations
+
+import re
+import string
+import sys
+from functools import wraps
+from typing import (
+    Any,
+    Callable,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Tuple,
+    TypeVar,
+    Union,
+)
+from typing_extensions import Concatenate, ParamSpec, Protocol, Self, SupportsIndex
+
+__all__ = ['HasMarkdown', 'MarkdownString', 'markdown_escape']
+
+
+_P = ParamSpec('_P')
+_ListOrDict = TypeVar('_ListOrDict', list, dict)
+
+
+class HasMarkdown(Protocol):
+    """Protocol for a class implementing :meth:`__markdown__`."""
+
+    def __markdown__(self) -> str:
+        """Return a Markdown string."""
+
+
+#: Based on the ASCII punctuation list in the CommonMark spec at
+#: https://spec.commonmark.org/0.30/#backslash-escapes
+markdown_escape_re = re.compile(r"""([\[\\\]{|}\(\)`~!@#$%^&*=+;:'"<>/,.?_-])""")
+#: Unescape regex has a `\` prefix and the same characters
+markdown_unescape_re = re.compile(r"""\\([\[\\\]{|}\(\)`~!@#$%^&*=+;:'"<>/,.?_-])""")
+
+
+class _MarkdownEscapeFormatter(string.Formatter):
+    __slots__ = ('escape',)
+
+    def __init__(self, escape: Callable[[Any], MarkdownString]) -> None:
+        self.escape = escape
+        super().__init__()
+
+    def format_field(self, value: Any, format_spec: str) -> str:
+        if hasattr(value, '__markdown_format__'):
+            rv = value.__markdown_format__(format_spec)
+        elif hasattr(value, '__markdown__'):
+            if format_spec:
+                raise ValueError(
+                    f"Format specifier {format_spec} given, but {type(value)} does not"
+                    " define __markdown_format__. A class that defines __markdown__"
+                    " must define __markdown_format__ to work with format specifiers."
+                )
+            rv = value.__markdown__()
+        else:
+            # We need to make sure the format spec is str here as
+            # otherwise the wrong callback methods are invoked.
+            rv = string.Formatter.format_field(self, value, str(format_spec))
+        return str(self.escape(rv))
+
+
+class _MarkdownEscapeHelper:
+    """Helper for :meth:`MarkdownString.__mod__`."""
+
+    __slots__ = ('obj', 'escape')
+
+    def __init__(self, obj: Any, escape: Callable[[Any], MarkdownString]) -> None:
+        self.obj = obj
+        self.escape = escape
+
+    def __getitem__(self, item: Any) -> Self:
+        return self.__class__(self.obj[item], self.escape)
+
+    def __str__(self) -> str:
+        return str(self.escape(self.obj))
+
+    def __repr__(self) -> str:
+        return str(self.escape(repr(self.obj)))
+
+    def __int__(self) -> int:
+        return int(self.obj)
+
+    def __float__(self) -> float:
+        return float(self.obj)
+
+
+def _escape_argspec(
+    obj: _ListOrDict, iterable: Iterable[Any], escape: Callable[[Any], MarkdownString]
+) -> _ListOrDict:
+    """Escape all arguments."""
+    for key, value in iterable:
+        if isinstance(value, str) or hasattr(value, '__markdown__'):
+            obj[key] = escape(value)
+
+    return obj
+
+
+def _simple_escaping_wrapper(
+    func: Callable[Concatenate[str, _P], str]
+) -> Callable[Concatenate[MarkdownString, _P], MarkdownString]:
+    @wraps(func)
+    def wrapped(
+        self: MarkdownString, *args: _P.args, **kwargs: _P.kwargs
+    ) -> MarkdownString:
+        arg_list = _escape_argspec(list(args), enumerate(args), self.escape)
+        _escape_argspec(kwargs, kwargs.items(), self.escape)
+        return self.__class__(func(self, *arg_list, **kwargs))
+
+    return wrapped
+
+
+class MarkdownString(str):
+    """Markdown string, implements a __markdown__ method."""
+
+    __slots__ = ()
+
+    def __new__(
+        cls, base: Any = '', encoding: Optional[str] = None, errors: str = 'strict'
+    ) -> MarkdownString:
+        if hasattr(base, '__markdown__'):
+            base = base.__markdown__()
+
+        if encoding is None:
+            return super().__new__(cls, base)
+
+        return super().__new__(cls, base, encoding, errors)
+
+    def __markdown__(self) -> Self:
+        """Return a markdown embed-compatible string."""
+        return self
+
+    def __markdown_format__(self, format_spec: str) -> Self:
+        if format_spec:
+            # MarkdownString cannot support format_spec because any manipulation may
+            # remove an escape char, causing downstream damage with unwanted formatting
+            raise ValueError("Unsupported format specification for MarkdownString.")
+
+        return self
+
+    def unescape(self) -> str:
+        """Unescape the string."""
+        return markdown_unescape_re.sub(r'\1', str(self))
+
+    @classmethod
+    def escape(cls, text: Union[str, HasMarkdown], silent: bool = True) -> Self:
+        """Escape a string, for internal use only. Use :func:`markdown_escape`."""
+        if silent and text is None:
+            return cls('')  # type: ignore[unreachable]
+        if hasattr(text, '__markdown__'):
+            return cls(text.__markdown__())
+        return cls(markdown_escape_re.sub(r'\\\1', text))
+
+    # These additional methods are borrowed from the implementation in markupsafe
+
+    def __add__(self, other: Union[str, HasMarkdown]) -> Self:
+        if isinstance(other, str) or hasattr(other, '__markdown__'):
+            return self.__class__(super().__add__(self.escape(other)))
+
+        return NotImplemented
+
+    def __radd__(self, other: Union[str, HasMarkdown]) -> Self:
+        if isinstance(other, str) or hasattr(other, '__markdown__'):
+            return self.escape(other).__add__(self)
+
+        return NotImplemented
+
+    def __mul__(self, num: SupportsIndex) -> Self:
+        if isinstance(num, int):
+            return self.__class__(super().__mul__(num))
+
+        return NotImplemented
+
+    __rmul__ = __mul__
+
+    def __mod__(self, arg: Any) -> Self:
+        """Apply legacy `str % arg(s)` formatting."""
+        if isinstance(arg, tuple):
+            # a tuple of arguments, each wrapped
+            arg = tuple(_MarkdownEscapeHelper(x, self.escape) for x in arg)
+        elif hasattr(type(arg), '__getitem__') and not isinstance(arg, str):
+            # a mapping of arguments, wrapped
+            arg = _MarkdownEscapeHelper(arg, self.escape)
+        else:
+            # a single argument, wrapped with the helper and a tuple
+            arg = (_MarkdownEscapeHelper(arg, self.escape),)
+
+        return self.__class__(super().__mod__(arg))
+
+    def __repr__(self) -> str:
+        return f'{self.__class__.__name__}({super().__repr__()})'
+
+    def join(self, iterable: Iterable[Union[str, HasMarkdown]]) -> Self:
+        return self.__class__(super().join(map(self.escape, iterable)))
+
+    join.__doc__ = str.join.__doc__
+
+    def split(  # type: ignore[override]
+        self, sep: Optional[str] = None, maxsplit: SupportsIndex = -1
+    ) -> List[Self]:
+        return [self.__class__(v) for v in super().split(sep, maxsplit)]
+
+    split.__doc__ = str.split.__doc__
+
+    def rsplit(  # type: ignore[override]
+        self, sep: Optional[str] = None, maxsplit: SupportsIndex = -1
+    ) -> List[Self]:
+        return [self.__class__(v) for v in super().rsplit(sep, maxsplit)]
+
+    rsplit.__doc__ = str.rsplit.__doc__
+
+    def splitlines(  # type: ignore[override]
+        self, keepends: bool = False
+    ) -> List[Self]:
+        return [self.__class__(v) for v in super().splitlines(keepends)]
+
+    splitlines.__doc__ = str.splitlines.__doc__
+
+    __getitem__ = _simple_escaping_wrapper(str.__getitem__)  # type: ignore[assignment]
+    capitalize = _simple_escaping_wrapper(str.capitalize)  # type: ignore[assignment]
+    title = _simple_escaping_wrapper(str.title)  # type: ignore[assignment]
+    lower = _simple_escaping_wrapper(str.lower)  # type: ignore[assignment]
+    upper = _simple_escaping_wrapper(str.upper)  # type: ignore[assignment]
+    replace = _simple_escaping_wrapper(str.replace)  # type: ignore[assignment]
+    ljust = _simple_escaping_wrapper(str.ljust)  # type: ignore[assignment]
+    rjust = _simple_escaping_wrapper(str.rjust)  # type: ignore[assignment]
+    lstrip = _simple_escaping_wrapper(str.lstrip)  # type: ignore[assignment]
+    rstrip = _simple_escaping_wrapper(str.rstrip)  # type: ignore[assignment]
+    center = _simple_escaping_wrapper(str.center)  # type: ignore[assignment]
+    strip = _simple_escaping_wrapper(str.strip)  # type: ignore[assignment]
+    translate = _simple_escaping_wrapper(str.translate)  # type: ignore[assignment]
+    expandtabs = _simple_escaping_wrapper(str.expandtabs)  # type: ignore[assignment]
+    swapcase = _simple_escaping_wrapper(str.swapcase)  # type: ignore[assignment]
+    zfill = _simple_escaping_wrapper(str.zfill)  # type: ignore[assignment]
+    casefold = _simple_escaping_wrapper(str.casefold)  # type: ignore[assignment]
+
+    if sys.version_info >= (3, 9):
+        removeprefix = _simple_escaping_wrapper(  # type: ignore[assignment]
+            str.removeprefix
+        )
+        removesuffix = _simple_escaping_wrapper(  # type: ignore[assignment]
+            str.removesuffix
+        )
+
+    def partition(self, sep: str) -> Tuple[Self, Self, Self]:
+        left, sep, right = super().partition(self.escape(sep))
+        cls = self.__class__
+        return cls(left), cls(sep), cls(right)
+
+    partition.__doc__ = str.partition.__doc__
+
+    def rpartition(self, sep: str) -> Tuple[Self, Self, Self]:
+        left, sep, right = super().rpartition(self.escape(sep))
+        cls = self.__class__
+        return cls(left), cls(sep), cls(right)
+
+    rpartition.__doc__ = str.rpartition.__doc__
+
+    def format(self, *args: Any, **kwargs: Any) -> Self:  # noqa: A003
+        formatter = _MarkdownEscapeFormatter(self.escape)
+        return self.__class__(formatter.vformat(self, args, kwargs))
+
+    format.__doc__ = str.format.__doc__
+
+    # pylint: disable=redefined-builtin
+    def format_map(
+        self, map: Mapping[str, Any]  # type: ignore[override]  # noqa: A002
+    ) -> Self:
+        formatter = _MarkdownEscapeFormatter(self.escape)
+        return self.__class__(formatter.vformat(self, (), map))
+
+    format_map.__doc__ = str.format_map.__doc__
+
+
+def markdown_escape(text: str) -> MarkdownString:
+    """
+    Escape all Markdown formatting characters and strip whitespace at ends.
+
+    As per the CommonMark spec, all ASCII punctuation can be escaped with a backslash
+    and compliant parsers will then render the punctuation mark as a literal character.
+    However, escaping any other character will cause the backslash to be rendered. This
+    escaper therefore targets only ASCII punctuation characters listed in the spec.
+
+    Edge whitespace is significant in Markdown:
+
+    * Four spaces at the start will initiate a code block
+    * Two spaces at the end will cause a line-break in non-GFM Markdown
+
+    The space and tab characters cannot be escaped, and replacing spaces with &nbsp; is
+    not suitable because non-breaking spaces affect HTML rendering, specifically the
+    CSS ``white-space: normal`` sequence collapsing behaviour. Since there is no way to
+    predict adjacent whitespace when this escaped variable is placed in a Markdown
+    document, it is safest to strip all edge whitespace.
+
+    ..note::
+        This function strips edge whitespace and calls :meth:`MarkdownString.escape`,
+        and should be preferred over calling :meth:`MarkdownString.escape` directly.
+        That classmethod is internal to :class:`MarkdownString`.
+
+    :returns: Escaped text as an instance of :class:`MarkdownString`, to avoid
+        double-escaping
+    """
+    return MarkdownString.escape(text.strip())

--- a/funnel/utils/markdown/escape.py
+++ b/funnel/utils/markdown/escape.py
@@ -41,6 +41,8 @@ markdown_unescape_re = re.compile(r"""\\([\[\\\]{|}\(\)`~!@#$%^&*=+;:'"<>/,.?_-]
 
 
 class _MarkdownEscapeFormatter(string.Formatter):
+    """Support class for :meth:`MarkdownString.format`."""
+
     __slots__ = ('escape',)
 
     def __init__(self, escape: Callable[[Any], MarkdownString]) -> None:

--- a/funnel/utils/mustache.py
+++ b/funnel/utils/mustache.py
@@ -3,36 +3,81 @@
 import functools
 import types
 from copy import copy
-from typing import Callable
+from typing import Callable, Optional, Type, TypeVar
+from typing_extensions import ParamSpec
 
 from chevron import render
-from markupsafe import escape as html_escape
+from markupsafe import Markup, escape as html_escape
 
-from .markdown import markdown_escape
+from .markdown import MarkdownString, markdown_escape
 
 __all__ = ['mustache_html', 'mustache_md']
 
 
+_P = ParamSpec('_P')
+_T = TypeVar('_T', bound=str)
+
+
 def _render_with_escape(
-    name: str, escapefunc: Callable[[str], str]
-) -> Callable[..., str]:
-    """Make a copy of Chevron's render function with a replacement HTML escaper."""
-    _globals = copy(render.__globals__)
-    _globals['_html_escape'] = escapefunc
+    name: str,
+    renderer: Callable[_P, str],
+    escapefunc: Callable[[str], str],
+    recast: Type[_T],
+    doc: Optional[str] = None,
+) -> Callable[_P, _T]:
+    """
+    Make a copy of Chevron's render function with a replacement HTML escaper.
+
+    Chevron does not allow the HTML escaper to be customized, so we construct a new
+    function using the same code, replacing the escaper in the globals. We also recast
+    Chevron's output to a custom sub-type of str like :class:`~markupsafe.Markup` or
+    :class:`~funnel.utils.markdown.escape.MarkdownString`.
+
+    :param name: Name of the new function (readable as `func.__name__`)
+    :param renderer: Must be :func:`chevron.render` and must be explicitly passed for
+        mypy to recognise the function's parameters
+    :param escapefunc: Replacement escape function
+    :param recast: str subtype to recast Chevron's output to
+    :param doc: Optional replacement docstring
+    """
+    _globals = copy(renderer.__globals__)
+    # Chevron tries `output += _html_escape(thing)`, which given Markup or
+    # MarkdownString will call `thing.__radd__(output)`, which will then escape the
+    # existing output. We must therefore recast the escaped string as a plain `str`
+    _globals['_html_escape'] = lambda text: str(escapefunc(text))
 
     new_render = types.FunctionType(
-        render.__code__,
+        renderer.__code__,
         _globals,
         name=name,
-        argdefs=render.__defaults__,
-        closure=render.__closure__,
+        argdefs=renderer.__defaults__,
+        closure=renderer.__closure__,
     )
-    new_render = functools.update_wrapper(new_render, render)
+    new_render = functools.update_wrapper(new_render, renderer)
     new_render.__module__ = __name__
-    new_render.__kwdefaults__ = copy(render.__kwdefaults__)
-    return new_render
+    new_render.__kwdefaults__ = copy(renderer.__kwdefaults__)
+    new_render.__doc__ = renderer.__doc__
+
+    @functools.wraps(renderer)
+    def render_and_recast(*args: _P.args, **kwargs: _P.kwargs) -> _T:
+        # pylint: disable=not-callable
+        return recast(new_render(*args, **kwargs))
+
+    render_and_recast.__doc__ = doc if doc else renderer.__doc__
+    return render_and_recast
 
 
-mustache_html = _render_with_escape('mustache_html', html_escape)
-mustache_md = _render_with_escape('mustache_md', markdown_escape)
-# TODO: Add mustache_mdhtml for use with Markdown with HTML tags enabled
+mustache_html = _render_with_escape(
+    'mustache_html',
+    render,
+    html_escape,
+    Markup,
+    doc="Render a Mustache template in a HTML context.",
+)
+mustache_md = _render_with_escape(
+    'mustache_md',
+    render,
+    markdown_escape,
+    MarkdownString,
+    doc="Render a Mustache template in a Markdown context.",
+)

--- a/tests/unit/utils/markdown/data/vega-lite.toml
+++ b/tests/unit/utils/markdown/data/vega-lite.toml
@@ -354,9 +354,9 @@ markdown = """
 [config]
 profiles = [ "basic", "document",]
 
-[config.custom_profiles.vega-lite]
+[config.custom_profiles.vega_lite]
 preset = "default"
-plugins = [ "vega-lite",]
+plugins = [ "vega_lite",]
 
 [expected_output]
 basic = """<h1>vega-lite tests</h1>

--- a/tests/unit/utils/markdown_escape_test.py
+++ b/tests/unit/utils/markdown_escape_test.py
@@ -1,0 +1,15 @@
+"""Tests for MarkdownString and markdown_escape."""
+
+from funnel.utils import MarkdownString, markdown_escape
+
+
+def test_markdown_escape() -> None:
+    """Test that markdown_escape escapes Markdown punctuation (partial test)."""
+    assert isinstance(markdown_escape(''), MarkdownString)
+    assert markdown_escape('No escape') == 'No escape'
+    assert (
+        markdown_escape('This _has_ Markdown markup') == r'This \_has\_ Markdown markup'
+    )
+    mixed = 'This <em>has</em> **mixed** markup'
+    assert markdown_escape(mixed) == r'This \<em\>has\<\/em\> \*\*mixed\*\* markup'
+    assert markdown_escape(mixed).unescape() == mixed

--- a/tests/unit/utils/mustache_test.py
+++ b/tests/unit/utils/mustache_test.py
@@ -1,11 +1,12 @@
+"""Tests for Mustache templates on Markdown documents."""
+# pylint: disable=not-callable
 # mypy: disable-error-code=index
-"""Tests for the mustache template escaper."""
 
 from typing import Dict, Tuple
 
 import pytest
 
-from funnel.utils.markdown.base import MarkdownConfig
+from funnel.utils.markdown import MarkdownConfig
 from funnel.utils.mustache import mustache_md
 
 test_data = {
@@ -28,6 +29,7 @@ test_data = {
 
 #: Dict of {test_name: (template, output)}
 templates_and_output: Dict[str, Tuple[str, str]] = {}
+#: Dict of {test_name: (template, config_name, output)}
 config_template_output: Dict[str, Tuple[str, str, str]] = {}
 
 templates_and_output['basic'] = (
@@ -86,9 +88,8 @@ templates_and_output['escaped-sequence'] = (
     templates_and_output.values(),
     ids=templates_and_output.keys(),
 )
-def test_mustache_md(template, expected_output):
-    output = mustache_md(template, test_data)  # pylint: disable=not-callable
-    assert expected_output == output
+def test_mustache_md(template: str, expected_output: str) -> None:
+    assert mustache_md(template, test_data) == expected_output
 
 
 config_template_output['basic-basic'] = (
@@ -174,7 +175,8 @@ config_template_output['escaped-sequence-document'] = (
     config_template_output.values(),
     ids=config_template_output.keys(),
 )
-def test_mustache_md_markdown(template, config, expected_output):
-    assert expected_output == MarkdownConfig.registry[config].render(
-        mustache_md(template, test_data)  # pylint: disable=not-callable
+def test_mustache_md_markdown(template: str, config: str, expected_output: str) -> None:
+    assert (
+        MarkdownConfig.registry[config].render(mustache_md(template, test_data))
+        == expected_output
     )


### PR DESCRIPTION
Also use an explicit `register` classmethod in MarkdownPlugin and MarkdownConfig.