### PR TITLE
Grant ticket_participant role

### DIFF
--- a/funnel/models/sync_ticket.py
+++ b/funnel/models/sync_ticket.py
@@ -591,7 +591,9 @@ class __Project:
         relationship(
             TicketParticipant, lazy='dynamic', cascade='all', back_populates='project'
         ),
-        grants_via={'user': {'participant'}},
+        grants_via={
+            'user': {'participant', 'project_participant', 'ticket_participant'}
+        },
     )
 
 


### PR DESCRIPTION
The `ticket_participant` role can be used to identify project participants who have tickets.