### PR TITLE
Hide ticketing widget for a member

### DIFF
--- a/funnel/templates/project_layout.html.jinja2
+++ b/funnel/templates/project_layout.html.jinja2
@@ -396,7 +396,7 @@
       </div>
     </div>
 
-    {% if not project.state.PAST and project.features.tickets() -%}
+    {% if project.features.tickets() -%}
       <div class="tickets-wrapper">
         <div class="tickets-wrapper__modal tickets-wrapper__modal--project-page">
           <div class="mui--hidden-md mui--hidden-lg mui--hidden-xl tickets-wrapper__modal__back mobile-nav-wrapper">

--- a/funnel/views/project.py
+++ b/funnel/views/project.py
@@ -177,6 +177,7 @@ def feature_project_tickets(obj: Project) -> bool:
         and 'item_collection_id' in obj.boxoffice_data
         and obj.boxoffice_data['item_collection_id']
         and not obj.state.PAST
+        and not obj.current_roles.ticket_participant
     )
 
 


### PR DESCRIPTION
Don't show the ticketing widget for a member (user who has a ticket)
Caveat: Works only when tickets have been synced from boxoffice to funnel