### PR TITLE
SMS template for Update should show account (profile) instead of project

### DIFF
--- a/funnel/models/profile.py
+++ b/funnel/models/profile.py
@@ -221,6 +221,7 @@ class Profile(EnumerateMembershipsMixin, UuidMixin, BaseMixin, Model):
                 'uuid_b58',
                 'name',
                 'title',
+                'pickername',
                 'tagline',
                 'description',
                 'website',

--- a/funnel/models/profile.py
+++ b/funnel/models/profile.py
@@ -283,7 +283,7 @@ class Profile(EnumerateMembershipsMixin, UuidMixin, BaseMixin, Model):
         return f'<Profile "{self.name}">'
 
     @property
-    def owner(self) -> Union[User, Organization]:
+    def owner(self) -> Optional[Union[User, Organization]]:
         """Return the user or organization that owns this account."""
         return self.user or self.organization
 

--- a/funnel/views/notifications/mixins.py
+++ b/funnel/views/notifications/mixins.py
@@ -5,7 +5,7 @@ from typing_extensions import Self
 
 import grapheme
 
-from ...models import Project, User
+from ...models import Organization, Profile, Project, User
 
 _T = TypeVar('_T')  # Host type for SetVar
 _I = TypeVar('_I')  # Input type for SetVar's setter
@@ -78,15 +78,16 @@ class TemplateVarMixin:
         return title[:index] + '…'
 
     @SetVar
-    def user(self, user: User) -> str:
-        """Set user's display name, truncated to fit."""
-        pickername = user.pickername
+    def account(self, account: Union[User, Organization, Profile]) -> str:
+        """Set account's display name, truncated to fit."""
+        pickername = account.pickername
         if len(pickername) <= self.var_max_length:
             return pickername
-        fullname = user.fullname
-        if len(fullname) <= self.var_max_length:
-            return fullname
-        index = grapheme.safe_split_index(fullname, self.var_max_length - 1)
-        return fullname[:index] + '…'
+        title = account.title
+        if len(title) <= self.var_max_length:
+            return title
+        index = grapheme.safe_split_index(title, self.var_max_length - 1)
+        return title[:index] + '…'
 
-    actor = user  # This will trigger cloning in SetVar.__set_name__
+    # This will trigger cloning in SetVar.__set_name__
+    actor = user = organization = profile = account

--- a/funnel/views/notifications/update_notification.py
+++ b/funnel/views/notifications/update_notification.py
@@ -20,11 +20,12 @@ class UpdateTemplate(TemplateVarMixin, SmsTemplate):
         'There is an update in {#var#}: {#var#}\n\nhttps://bye.li to stop -Hasgeek'
     )
     template = (
-        "There is an update in {project}: {url}\n\nhttps://bye.li to stop -Hasgeek"
+        "There is an update in {profile}: {url}\n\nhttps://bye.li to stop -Hasgeek"
     )
-    plaintext_template = "There is an update in {project}: {url}"
+    plaintext_template = "There is an update in {profile}: {url}"
 
     url: str
+    profile: str
 
 
 @NewUpdateNotification.renderer
@@ -65,7 +66,7 @@ class RenderNewUpdateNotification(RenderNotification):
 
     def sms(self) -> UpdateTemplate:
         return UpdateTemplate(
-            project=self.update.project,
+            profile=self.update.profile,
             url=shortlink(
                 self.update.url_for(_external=True, **self.tracking_tags('sms')),
                 shorter=True,

--- a/funnel/views/notifications/update_notification.py
+++ b/funnel/views/notifications/update_notification.py
@@ -25,7 +25,6 @@ class UpdateTemplate(TemplateVarMixin, SmsTemplate):
     plaintext_template = "There is an update in {profile}: {url}"
 
     url: str
-    profile: str
 
 
 @NewUpdateNotification.renderer
@@ -66,7 +65,7 @@ class RenderNewUpdateNotification(RenderNotification):
 
     def sms(self) -> UpdateTemplate:
         return UpdateTemplate(
-            profile=self.update.profile,
+            profile=self.update.project.profile,
             url=shortlink(
                 self.update.url_for(_external=True, **self.tracking_tags('sms')),
                 shorter=True,

--- a/tests/unit/views/notification_test.py
+++ b/tests/unit/views/notification_test.py
@@ -146,9 +146,9 @@ def test_template_var_mixin() -> None:
         title='Ankh-Morpork 2010', joined_title='Ankh-Morpork / Ankh-Morpork 2010'
     )
     u1 = SimpleNamespace(
-        pickername='Havelock Vetinari (@vetinari)', fullname='Havelock Vetinari'
+        pickername='Havelock Vetinari (@vetinari)', title='Havelock Vetinari'
     )
-    u2 = SimpleNamespace(pickername='Twoflower', fullname='Twoflower')
+    u2 = SimpleNamespace(pickername='Twoflower', title='Twoflower')
     t1.project = cast(models.Project, p1)
     t1.user = cast(models.User, u2)
     t1.actor = cast(models.User, u1)


### PR DESCRIPTION
Update notifications are now sent to all participants (soon followers) of an account, so the project name will not be familiar. Show account instead.