### PR TITLE
Reduce z-index of overlay of card

### DIFF
--- a/funnel/assets/sass/components/_card.scss
+++ b/funnel/assets/sass/components/_card.scss
@@ -431,7 +431,7 @@
 .card__image-wrapper--default:after {
   content: '';
   position: absolute;
-  z-index: 2;
+  z-index: 1;
   top: 0;
   left: 0;
   background-color: $mui-primary-color;


### PR DESCRIPTION
Overlay had a higher z-index than anchor and clicking on the blank banner of the card was not working