### PR TITLE
Disable clean in webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -91,7 +91,6 @@ module.exports = {
     path: path.resolve(__dirname, 'funnel/static/build'),
     publicPath: '/static/build/',
     filename: 'js/[name].[chunkhash].js',
-    clean: true,
   },
   module: {
     rules: [


### PR DESCRIPTION
Cleaning up old files is breaking mid-day deployments as clients keep requesting for old files until cache expiry.