### PR TITLE
Allow setting an org's name if previously unset

### DIFF
--- a/funnel/forms/organization.py
+++ b/funnel/forms/organization.py
@@ -61,6 +61,13 @@ class OrganizationForm(forms.Form):
             )
         if reason == 'reserved':
             raise forms.validators.ValidationError(_("This name is reserved"))
+        if (
+            self.edit_obj
+            and self.edit_obj.name
+            and field.data.lower() == self.edit_obj.name.lower()
+        ):
+            # Name has only changed case from previous name. This is a validation pass
+            return
         if reason == 'user':
             if (
                 self.edit_user.username
@@ -82,13 +89,6 @@ class OrganizationForm(forms.Form):
             raise forms.validators.ValidationError(
                 _("This name has been taken by another organization")
             )
-        if (
-            self.edit_obj
-            and self.edit_obj.name
-            and field.data.lower() == self.edit_obj.name.lower()
-        ):
-            # Name has only changed case from previous name. This is a validation pass
-            return
         # We're not supposed to get an unknown reason. Flag error to developers.
         raise ValueError(f"Unknown account name validation failure reason: {reason}")
 

--- a/funnel/forms/organization.py
+++ b/funnel/forms/organization.py
@@ -61,10 +61,6 @@ class OrganizationForm(forms.Form):
             )
         if reason == 'reserved':
             raise forms.validators.ValidationError(_("This name is reserved"))
-        if self.edit_obj and field.data.lower() == self.edit_obj.name.lower():
-            # Name is not reserved or invalid under current rules. It's also not changed
-            # from existing name, or has only changed case. This is a validation pass.
-            return
         if reason == 'user':
             if (
                 self.edit_user.username
@@ -86,6 +82,13 @@ class OrganizationForm(forms.Form):
             raise forms.validators.ValidationError(
                 _("This name has been taken by another organization")
             )
+        if (
+            self.edit_obj
+            and self.edit_obj.name
+            and field.data.lower() == self.edit_obj.name.lower()
+        ):
+            # Name has only changed case from previous name. This is a validation pass
+            return
         # We're not supposed to get an unknown reason. Flag error to developers.
         raise ValueError(f"Unknown account name validation failure reason: {reason}")
 


### PR DESCRIPTION
The old system of separate OrganizationForm and ProfileForm is obsolete with unified Accounts. This is an interim fix pending a refactor of these multiple forms.