### PR TITLE
Roles without remapping in VenueRoom (resolves #1893)

### DIFF
--- a/funnel/models/project_membership.py
+++ b/funnel/models/project_membership.py
@@ -12,7 +12,7 @@ from .helpers import reopen
 from .membership_mixin import ImmutableUserMembershipMixin
 from .project import Project
 
-__all__ = ['ProjectMembership', 'project_child_role_map']
+__all__ = ['ProjectMembership', 'project_child_role_map', 'project_child_role_set']
 
 #: Roles in a project and their remapped names in objects attached to a project
 project_child_role_map: dict[str, str] = {
@@ -23,6 +23,9 @@ project_child_role_map: dict[str, str] = {
     'participant': 'project_participant',
     'reader': 'reader',
 }
+
+#: A model that is indirectly under a project needs the role names without remapping
+project_child_role_set: set[str] = set(project_child_role_map.values())
 
 #: ProjectMembership maps project's `account_admin` role to membership's `editor`
 #: role in addition to the recurring role grant map

--- a/funnel/models/venue.py
+++ b/funnel/models/venue.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import itertools
-
 from sqlalchemy.ext.orderinglist import ordering_list
 
 from coaster.sqlalchemy import add_primary_relationship, with_roles
@@ -19,7 +17,7 @@ from . import (
 )
 from .helpers import MarkdownCompositeBasic, reopen
 from .project import Project
-from .project_membership import project_child_role_map
+from .project_membership import project_child_role_map, project_child_role_set
 
 __all__ = ['Venue', 'VenueRoom']
 
@@ -113,7 +111,7 @@ class VenueRoom(UuidMixin, BaseScopedNameMixin, Model):
     venue: Mapped[Venue] = with_roles(
         relationship(Venue, back_populates='rooms'),
         # Since Venue already remaps Project roles, we just want the remapped role names
-        grants_via={None: set(itertools.chain(*project_child_role_map.values()))},
+        grants_via={None: project_child_role_set},
     )
     parent: Mapped[Venue] = sa.orm.synonym('venue')
     description, description_text, description_html = MarkdownCompositeBasic.create(


### PR DESCRIPTION
Using `itertools.chain` was causing role strings to be broken down into individual characters, which was incorrect. We've moved the set definition to sit alongside the mapping so that an error of this sort will be less likely in a future refactor.