### PR TITLE
New email and phone are now auto-primary

### DIFF
--- a/funnel/models/account.py
+++ b/funnel/models/account.py
@@ -1118,10 +1118,16 @@ class Account(UuidMixin, BaseMixin[int, 'Account'], Model):
     def add_email(
         self,
         email: str,
-        primary: bool = False,
+        primary: bool | None = None,
         private: bool = False,
     ) -> AccountEmail:
-        """Add an email address (assumed to be verified)."""
+        """
+        Add an email address (assumed to be verified).
+
+        :param email: Email address as a string
+        :param primary: Mark this email address as primary (default: auto-assign)
+        :param private: Mark as private (currently unused)
+        """
         accountemail = AccountEmail(account=self, email=email, private=private)
         accountemail = failsafe_add(
             db.session,
@@ -1129,7 +1135,7 @@ class Account(UuidMixin, BaseMixin[int, 'Account'], Model):
             account=self,
             email_address=accountemail.email_address,
         )
-        if primary:
+        if (primary is None and self.primary_email is None) or primary is True:
             self.primary_email = accountemail
         return accountemail
         # FIXME: This should remove competing instances of AccountEmailClaim
@@ -1172,10 +1178,16 @@ class Account(UuidMixin, BaseMixin[int, 'Account'], Model):
     def add_phone(
         self,
         phone: str,
-        primary: bool = False,
+        primary: bool | None = None,
         private: bool = False,
     ) -> AccountPhone:
-        """Add a phone number (assumed to be verified)."""
+        """
+        Add a phone number (assumed to be verified).
+
+        :param phone: Phone number as a string
+        :param primary: Mark this phone number as primary (default: auto-assign)
+        :param private: Mark as private (currently unused)
+        """
         accountphone = AccountPhone(account=self, phone=phone, private=private)
         accountphone = failsafe_add(
             db.session,
@@ -1183,7 +1195,7 @@ class Account(UuidMixin, BaseMixin[int, 'Account'], Model):
             account=self,
             phone_number=accountphone.phone_number,
         )
-        if primary:
+        if (primary is None and self.primary_phone is None) or primary is True:
             self.primary_phone = accountphone
         return accountphone
 

--- a/tests/unit/models/account_User_test.py
+++ b/tests/unit/models/account_User_test.py
@@ -81,7 +81,7 @@ def test_user_organization_owned(
 def test_user_email(db_session: scoped_session, user_twoflower: models.User) -> None:
     """Add and retrieve an email address."""
     assert user_twoflower.email == ''
-    accountemail = user_twoflower.add_email('twoflower@example.org')
+    accountemail = user_twoflower.add_email('twoflower@example.org', primary=False)
     assert isinstance(accountemail, models.AccountEmail)
     db_session.commit()
     assert accountemail.primary is False
@@ -153,7 +153,7 @@ def test_user_del_email(
 def test_user_phone(db_session: scoped_session, user_twoflower: models.User) -> None:
     """Test to retrieve AccountPhone property phone."""
     assert user_twoflower.phone == ''
-    accountphone = user_twoflower.add_phone('+12345678900')
+    accountphone = user_twoflower.add_phone('+12345678900', primary=False)
     assert isinstance(accountphone, models.AccountPhone)
     db_session.commit()
     assert accountphone.primary is False
@@ -220,6 +220,18 @@ def test_user_del_phone(
     assert len(user_twoflower.phones) == 0
     assert user_twoflower.primary_phone is None
     assert user_twoflower.phone == ''
+
+
+def test_phone_auto_primary(
+    db_session: scoped_session, user_rincewind: models.User
+) -> None:
+    """Adding a phone without an existing primary automatically makes this primary."""
+    accphone1 = user_rincewind.add_phone('+12345678900', primary=False)
+    assert user_rincewind.primary_phone is None
+    assert set(user_rincewind.phones) == {accphone1}
+    accphone2 = user_rincewind.add_phone('+12345678901')  # Automatic primary
+    assert user_rincewind.primary_phone == accphone2
+    assert set(user_rincewind.phones) == {accphone1, accphone2}
 
 
 def test_user_autocomplete(
@@ -355,10 +367,24 @@ def test_user_add_email(
     assert useremail2.primary is False
 
 
-def test_make_email_primary(user_rincewind: models.User) -> None:
+def test_email_auto_primary(
+    db_session: scoped_session, user_rincewind: models.User
+) -> None:
+    """Adding an email without an existing primary automatically makes this primary."""
+    accemail1 = user_rincewind.add_email('rincewind@example.org', primary=False)
+    assert user_rincewind.primary_email is None
+    assert set(user_rincewind.emails) == {accemail1}
+    accemail2 = user_rincewind.add_email('rincewind@example.com')  # Automatic primary
+    assert user_rincewind.primary_email == accemail2
+    assert set(user_rincewind.emails) == {accemail1, accemail2}
+
+
+def test_make_email_primary(
+    db_session: scoped_session, user_rincewind: models.User
+) -> None:
     """Test to make an email primary for a user."""
     email = 'rincewind@example.org'
-    accountemail = user_rincewind.add_email(email)
+    accountemail = user_rincewind.add_email(email, primary=False)
     assert accountemail.email == email
     assert accountemail.primary is False
     assert user_rincewind.primary_email is None


### PR DESCRIPTION
When using third party login to create a new account, the email address is not marked as primary. This PR fixes it by automatically marking a new email or phone number as primary if there is no existing primary.