### PR TITLE
Grant `project_` prefixed roles

### DIFF
--- a/funnel/models/project.py
+++ b/funnel/models/project.py
@@ -375,7 +375,21 @@ class Project(UuidMixin, BaseScopedNameMixin[int, Account], Model):
             ),
             viewonly=True,
         ),
-        grants_via={'member': {'editor', 'promoter', 'usher', 'participant', 'crew'}},
+        # Get subset of roles via offered_roles property
+        grants_via={
+            'member': {
+                'crew',
+                'editor',
+                'participant',
+                'promoter',
+                'usher',
+                'project_crew',
+                'project_editor',
+                'project_participant',
+                'project_promoter',
+                'project_usher',
+            }
+        },
     )
 
     active_editor_memberships: DynamicMapped[ProjectMembership] = relationship(
@@ -513,6 +527,8 @@ class Project(UuidMixin, BaseScopedNameMixin[int, Account], Model):
     def rooms(self) -> list[VenueRoom]:
         return [room for venue in self.venues for room in venue.rooms]
 
+    # MARK: Model config
+
     __table_args__ = (
         sa.UniqueConstraint('account_id', 'name'),
         sa.Index('ix_project_search_vector', 'search_vector', postgresql_using='gin'),
@@ -580,6 +596,8 @@ class Project(UuidMixin, BaseScopedNameMixin[int, Account], Model):
             'title',  # From BaseScopedNameMixin
         },
     }
+
+    # MARK: Conditional states
 
     state.add_conditional_state(
         'PAST',
@@ -670,6 +688,8 @@ class Project(UuidMixin, BaseScopedNameMixin[int, Account], Model):
         cfp_state.EXPIRED,
     )
 
+    # MARK: Magic methods
+
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.commentset = Commentset(settype=SET_TYPE.PROJECT)
@@ -694,6 +714,8 @@ class Project(UuidMixin, BaseScopedNameMixin[int, Account], Model):
         if not format_spec:
             return self.joined_title
         return format(self.joined_title, format_spec)
+
+    # MARK: Methods and properties
 
     @role_check('member_participant')
     def has_member_participant_role(
@@ -1609,6 +1631,7 @@ if TYPE_CHECKING:
     from .saved import SavedProject
     from .sync_ticket import TicketClient, TicketEvent, TicketParticipant, TicketType
 
+# MARK: Additional column properties
 
 # Whether the project has any featured proposals. Returns `None` instead of
 # a boolean if the project does not have any proposal.

--- a/funnel/models/project.py
+++ b/funnel/models/project.py
@@ -378,16 +378,11 @@ class Project(UuidMixin, BaseScopedNameMixin[int, Account], Model):
         # Get subset of roles via offered_roles property
         grants_via={
             'member': {
-                'crew',
-                'editor',
-                'participant',
-                'promoter',
-                'usher',
-                'project_crew',
-                'project_editor',
-                'project_participant',
-                'project_promoter',
-                'project_usher',
+                'crew': {'crew', 'project_crew'},
+                'editor': {'editor', 'project_editor'},
+                'participant': {'participant', 'project_participant'},
+                'promoter': {'promoter', 'project_promoter'},
+                'usher': {'usher', 'project_usher'},
             }
         },
     )

--- a/funnel/models/project_membership.py
+++ b/funnel/models/project_membership.py
@@ -161,11 +161,11 @@ class ProjectMembership(ImmutableMembershipMixin, Model):
     @cached_property
     def offered_roles(self) -> set[str]:
         """Roles offered by this membership record."""
-        roles = {'crew', 'participant'}
+        roles = {'crew', 'participant', 'project_crew', 'project_participant'}
         if self.is_editor:
-            roles.add('editor')
+            roles |= {'editor', 'project_editor'}
         if self.is_promoter:
-            roles.add('promoter')
+            roles |= {'promoter', 'project_promoter'}
         if self.is_usher:
-            roles.add('usher')
+            roles |= {'usher', 'project_usher'}
         return roles

--- a/funnel/models/project_membership.py
+++ b/funnel/models/project_membership.py
@@ -161,11 +161,11 @@ class ProjectMembership(ImmutableMembershipMixin, Model):
     @cached_property
     def offered_roles(self) -> set[str]:
         """Roles offered by this membership record."""
-        roles = {'crew', 'participant', 'project_crew', 'project_participant'}
+        roles = {'crew', 'participant'}
         if self.is_editor:
-            roles |= {'editor', 'project_editor'}
+            roles.add('editor')
         if self.is_promoter:
-            roles |= {'promoter', 'project_promoter'}
+            roles.add('promoter')
         if self.is_usher:
-            roles |= {'usher', 'project_usher'}
+            roles.add('usher')
         return roles

--- a/tests/unit/models/project_crew_membership_test.py
+++ b/tests/unit/models/project_crew_membership_test.py
@@ -14,18 +14,17 @@ def test_project_crew_membership(
     new_user_owner: models.User,
     new_project: models.Project,
 ) -> None:
-    """Test that project crew members get their roles from ProjectCrewMembership."""
+    """Test that project crew members get their roles from ProjectMembership."""
     # new_user is account admin
     assert 'admin' in new_project.account.roles_for(new_user_owner)
     # but it has no role in the project yet
-    assert (
-        'editor'
-        not in new_project.roles_for(  # pylint: disable=protected-access
-            new_user_owner
-        )._contents()
-    )
+    # pylint: disable=protected-access
+    assert 'editor' not in new_project.roles_for(new_user_owner)._contents()
+    assert 'project_editor' not in new_project.roles_for(new_user_owner)._contents()
     assert 'promoter' not in new_project.roles_for(new_user_owner)
+    assert 'project_promoter' not in new_project.roles_for(new_user_owner)
     assert 'usher' not in new_project.roles_for(new_user_owner)
+    assert 'project_usher' not in new_project.roles_for(new_user_owner)
 
     previous_membership = (
         models.ProjectMembership.query.filter(models.ProjectMembership.is_active)

--- a/tests/unit/views/notifications/project_crew_notification_test.py
+++ b/tests/unit/views/notifications/project_crew_notification_test.py
@@ -27,7 +27,9 @@ def given_vetinari_editor_promoter_project(
     project_expo2010: models.Project,
 ) -> models.ProjectMembership:
     assert 'promoter' in project_expo2010.roles_for(user_vetinari)
+    assert 'project_promoter' in project_expo2010.roles_for(user_vetinari)
     assert 'editor' in project_expo2010.roles_for(user_vetinari)
+    assert 'project_editor' in project_expo2010.roles_for(user_vetinari)
     vetinari_member = project_expo2010.crew_memberships.first()
     assert vetinari_member is not None
     assert vetinari_member.member == user_vetinari
@@ -53,6 +55,7 @@ def given_vimes_promoter_project(
     db_session.add(vimes_member)
     db_session.commit()
     assert 'promoter' in project_expo2010.roles_for(user_vimes)
+    assert 'project_promoter' in project_expo2010.roles_for(user_vimes)
     return vimes_member
 
 


### PR DESCRIPTION
This is needed for project notifications where the session is an optional fragment.