### PR TITLE
Add SQL queries for conditional states

### DIFF
--- a/funnel/models/account.py
+++ b/funnel/models/account.py
@@ -998,6 +998,7 @@ class Account(UuidMixin, BaseMixin[int, 'Account'], Model):
         'ACTIVE_AND_PUBLIC',
         profile_state.PUBLIC,
         lambda account: bool(account.state.ACTIVE),
+        lambda account: account.state.ACTIVE.__clause_element__(),
     )
 
     @classmethod

--- a/funnel/models/project.py
+++ b/funnel/models/project.py
@@ -634,12 +634,14 @@ class Project(UuidMixin, BaseScopedNameMixin[int, Account], Model):
         'HAS_PROPOSALS',
         cfp_state.ANY,
         lambda project: db.session.query(project.proposals.exists()).scalar(),
+        lambda project: project.proposals.exists(),
         label=('has_proposals', __("Has submissions")),
     )
     cfp_state.add_conditional_state(
         'HAS_SESSIONS',
         cfp_state.ANY,
         lambda project: db.session.query(project.sessions.exists()).scalar(),
+        lambda project: project.sessions.exists(),
         label=('has_sessions', __("Has sessions")),
     )
     cfp_state.add_conditional_state(

--- a/funnel/models/proposal.py
+++ b/funnel/models/proposal.py
@@ -355,6 +355,9 @@ class Proposal(UuidMixin, BaseScopedIdNameMixin, VideoMixin, ReorderMixin, Model
         'SCHEDULED',
         state.CONFIRMED,
         lambda proposal: proposal.session is not None and proposal.session.scheduled,
+        lambda proposal: sa.and_(
+            proposal.session.isnot(None), proposal.session.scheduled
+        ),
         label=('scheduled', __("Confirmed &amp; scheduled")),
     )
 


### PR DESCRIPTION
This fixes search, where suspended accounts were not being excluded because the conditional state's class-level query was missing.