### PR TITLE
Update 'Past Projects' to sort by last session date of project; Move all projects to 'Upcoming'

### DIFF
--- a/funnel/templates/index.html.jinja2
+++ b/funnel/templates/index.html.jinja2
@@ -90,7 +90,6 @@
   {% endif %}
 
   {{ open_cfp_section(open_cfp_projects) }}
-  {{ all_projects_section(all_projects) }}
   {{ past_projects_section() }}
 {% endblock basecontent %}
 

--- a/funnel/templates/profile.html.jinja2
+++ b/funnel/templates/profile.html.jinja2
@@ -180,7 +180,6 @@
     {% endif %}
 
     {{ open_cfp_section(open_cfp_projects) }}
-    {{ all_projects_section(all_projects) }}
     {{ past_featured_session_videos(profile) }}
 
     {% if sponsored_projects %}

--- a/funnel/templates/profile_layout.html.jinja2
+++ b/funnel/templates/profile_layout.html.jinja2
@@ -203,40 +203,17 @@
         {% endif %}
         <ul class="grid projects" role="list">
           {% for project in open_cfp_projects %}
-            <li class="grid__col-xs-12 grid__col-sm-6 grid__col-md-4 js-cfp-projects {% if loop.index > 4 %}mui--hide{% endif %}"
+            <li class="grid__col-xs-12 grid__col-sm-6 grid__col-md-4 js-cfp-projects {% if loop.index > 3 %}mui--hide{% endif %}"
               role="listitem">
               {{ projectcard(project, include_calendar=false, save_form_id_prefix='open_spf_') }}
             </li>
           {%- endfor -%}
         </ul>
-        {% if open_cfp_projects|length > 4 %}
+        {% if open_cfp_projects|length > 3 %}
           <div class="mui--text-center">
             <a href="#" onclick="return false;" data-target="show all cfp projects" class="jquery-show-all text-uppercase" data-projects="js-cfp-projects" data-ga="Show all cfp projects" aria-expanded="true">{% trans %}Show more{% endtrans %}</a>
           </div>
         {% endif %}
-      </div>
-    </div>
-  {% endif %}
-{% endmacro %}
-
-{% macro all_projects_section(all_projects, heading=true) %}
-  {% if all_projects %}
-    <div class="projects-wrapper">
-      <div class="mui-container">
-        {% if heading %}
-        <div class="grid">
-          <div class="grid__col-12">
-            <h2 class="mui--text-headline text-bold project-headline">{% trans %}All projects{% endtrans %}</h2>
-          </div>
-        </div>
-        {% endif %}
-        <ul class="grid projects" role="list">
-          {% for project in all_projects %}
-            <li class="grid__col-12 grid__col-xs-12 grid__col-sm-6 grid__col-lg-4" role="listitem">
-              {{ projectcard(project, save_form_id_prefix='all_spf_') }}
-            </li>
-          {%- endfor -%}
-        </ul>
       </div>
     </div>
   {% endif %}

--- a/funnel/views/index.py
+++ b/funnel/views/index.py
@@ -49,7 +49,7 @@ class IndexView(ClassView):
         g.account = None
         projects = Project.all_unsorted()
         # TODO: Move these queries into the Project class
-        all_projects = (
+        upcoming_projects = (
             projects.filter(
                 Project.state.PUBLISHED,
                 sa.or_(
@@ -65,8 +65,6 @@ class IndexView(ClassView):
             .order_by(Project.next_session_at.asc())
             .all()
         )
-        upcoming_projects = all_projects[:3]
-        all_projects = all_projects[3:]
         featured_project = (
             projects.filter(
                 Project.state.PUBLISHED,
@@ -112,8 +110,6 @@ class IndexView(ClassView):
             # pick one upcoming project from from all projects, only if
             # there are any projects left in it
             upcoming_projects.remove(featured_project)
-            if all_projects:
-                upcoming_projects.append(all_projects.pop(0))
         open_cfp_projects = (
             projects.filter(Project.state.PUBLISHED, Project.cfp_state.OPEN)
             .order_by(Project.next_session_at.asc())
@@ -132,10 +128,6 @@ class IndexView(ClassView):
         )
 
         return {
-            'all_projects': [
-                p.access_for(roles={'all'}, datasets=('primary', 'related'))
-                for p in all_projects
-            ],
             'upcoming_projects': [
                 p.access_for(roles={'all'}, datasets=('primary', 'related'))
                 for p in upcoming_projects
@@ -166,7 +158,7 @@ class IndexView(ClassView):
         projects = Project.all_unsorted()
         pagination = (
             projects.filter(Project.state.PAST)
-            .order_by(Project.start_at.desc())
+            .order_by(Project.end_at.desc())
             .paginate(page=page, per_page=per_page)
         )
         return {

--- a/funnel/views/profile.py
+++ b/funnel/views/profile.py
@@ -110,7 +110,7 @@ class ProfileView(UrlChangeCheck, AccountViewBase):
             # We're using it because we want to define our own order here.
             # listed_projects already includes a filter on Project.state.PUBLISHED
             projects = self.obj.listed_projects.order_by(None)
-            all_projects = (
+            upcoming_projects = (
                 projects.filter(
                     sa.or_(
                         Project.state.LIVE,
@@ -125,8 +125,6 @@ class ProfileView(UrlChangeCheck, AccountViewBase):
                 .all()
             )
 
-            upcoming_projects = all_projects[:3]
-            all_projects = all_projects[3:]
             featured_project = (
                 projects.filter(
                     sa.or_(
@@ -194,10 +192,6 @@ class ProfileView(UrlChangeCheck, AccountViewBase):
             ctx = {
                 'template': template_name,
                 'profile': self.obj.current_access(datasets=('primary', 'related')),
-                'all_projects': [
-                    p.current_access(datasets=('without_parent', 'related'))
-                    for p in all_projects
-                ],
                 'unscheduled_projects': [
                     p.current_access(datasets=('without_parent', 'related'))
                     for p in unscheduled_projects
@@ -336,7 +330,7 @@ class ProfileView(UrlChangeCheck, AccountViewBase):
     def past_projects(self, page: int = 1, per_page: int = 10) -> ReturnRenderWith:
         projects = self.obj.listed_projects.order_by(None)
         past_projects = projects.filter(Project.state.PAST).order_by(
-            Project.start_at.desc()
+            Project.end_at.desc()
         )
         pagination = past_projects.paginate(page=page, per_page=per_page)
         return {


### PR DESCRIPTION
In the 'Past Projects' section, sort projects based on last session date of each project. 
Remove the 'All Projects' section and relocate those projects to the 'Upcoming section."


