### PR TITLE
Show the latest videos first on project videos page

### DIFF
--- a/funnel/models/project.py
+++ b/funnel/models/project.py
@@ -1139,6 +1139,7 @@ class Project(UuidMixin, BaseScopedNameMixin[int, Account], Model):
     sessions_with_video: DynamicMapped[Session] = with_roles(
         relationship(
             lazy='dynamic',
+            order_by=lambda: Session.start_at.desc(),
             primaryjoin=lambda: sa.and_(
                 Project.id == Session.project_id,
                 Session.video_id.is_not(None),

--- a/funnel/templates/macros.html.jinja2
+++ b/funnel/templates/macros.html.jinja2
@@ -230,7 +230,7 @@
     {%- if session.views.video %}
       <div class="mui--text-caption mui--text-light">
         {%- if session.views.video.duration %}<span>{{ session.views.video.duration|timedelta }}</span>{%- endif %}
-        {%- if session.views.video.uploaded_at %}<span class="mui--pull-right">{{ session.views.video.uploaded_at|longdate }}</span>{%- endif %}
+        {%- if session.start_at %}<span class="mui--pull-right">{{ session.start_at|longdate }}</span>{%- endif %}
       </div>
     {%- else %}
     <div class="mui--text-caption mui--text-light">


### PR DESCRIPTION
Arrange the project videos order based on their session dates(show latest first)
Show the start date of session below the video in the project page instead of uploaded date