### PR TITLE
Support submission templates

### DIFF
--- a/funnel/models/account.py
+++ b/funnel/models/account.py
@@ -263,7 +263,9 @@ class Account(UuidMixin, BaseMixin[int, 'Account'], Model):
     _state: Mapped[int] = sa_orm.mapped_column(
         'state',
         sa.SmallInteger,
-        StateManager.check_constraint('state', ACCOUNT_STATE, sa.SmallInteger),
+        StateManager.check_constraint(
+            'state', ACCOUNT_STATE, sa.SmallInteger, name='account_state_check'
+        ),
         nullable=False,
         default=ACCOUNT_STATE.ACTIVE,
     )
@@ -277,7 +279,12 @@ class Account(UuidMixin, BaseMixin[int, 'Account'], Model):
     _profile_state: Mapped[int] = sa_orm.mapped_column(
         'profile_state',
         sa.SmallInteger,
-        StateManager.check_constraint('profile_state', PROFILE_STATE, sa.SmallInteger),
+        StateManager.check_constraint(
+            'profile_state',
+            PROFILE_STATE,
+            sa.SmallInteger,
+            name='account_profile_state_check',
+        ),
         nullable=False,
         default=PROFILE_STATE.AUTO,
     )

--- a/funnel/models/comment.py
+++ b/funnel/models/comment.py
@@ -93,7 +93,9 @@ class Commentset(UuidMixin, BaseMixin[int, Account], Model):
     _state: Mapped[int] = sa_orm.mapped_column(
         'state',
         sa.SmallInteger,
-        StateManager.check_constraint('state', COMMENTSET_STATE, sa.SmallInteger),
+        StateManager.check_constraint(
+            'state', COMMENTSET_STATE, sa.SmallInteger, name='commentset_state_check'
+        ),
         nullable=False,
         default=COMMENTSET_STATE.OPEN,
     )
@@ -336,7 +338,10 @@ class Comment(UuidMixin, BaseMixin[int, Account], Model):
 
     _state: Mapped[int] = sa_orm.mapped_column(
         'state',
-        StateManager.check_constraint('state', COMMENT_STATE, sa.Integer),
+        sa.SmallInteger,
+        StateManager.check_constraint(
+            'state', COMMENT_STATE, sa.SmallInteger, name='comment_state_check'
+        ),
         default=COMMENT_STATE.SUBMITTED,
         nullable=False,
     )

--- a/funnel/models/email_address.py
+++ b/funnel/models/email_address.py
@@ -231,10 +231,11 @@ class EmailAddress(BaseMixin[int, 'Account'], Model):
     #: Does this email address work? Records last known delivery state
     _delivery_state: Mapped[int] = sa_orm.mapped_column(
         'delivery_state',
+        sa.SmallInteger,
         StateManager.check_constraint(
             'delivery_state',
             EMAIL_DELIVERY_STATE,
-            sa.Integer,
+            sa.SmallInteger,
             name='email_address_delivery_state_check',
         ),
         nullable=False,

--- a/funnel/models/membership_mixin.py
+++ b/funnel/models/membership_mixin.py
@@ -222,8 +222,9 @@ class ImmutableMembershipMixin(UuidMixin, BaseMixin[UUID, Account]):
     record_type: Mapped[int] = with_roles(
         immutable(
             sa_orm.mapped_column(
+                sa.SmallInteger,
                 StateManager.check_constraint(
-                    'record_type', MembershipRecordTypeEnum, sa.Integer
+                    'record_type', MembershipRecordTypeEnum, sa.SmallInteger
                 ),
                 default=MembershipRecordTypeEnum.DIRECT_ADD,
                 nullable=False,

--- a/funnel/models/project.py
+++ b/funnel/models/project.py
@@ -157,7 +157,10 @@ class Project(UuidMixin, BaseScopedNameMixin[int, Account], Model):
 
     _state: Mapped[int] = sa_orm.mapped_column(
         'state',
-        StateManager.check_constraint('state', PROJECT_STATE, sa.Integer),
+        sa.SmallInteger,
+        StateManager.check_constraint(
+            'state', PROJECT_STATE, sa.SmallInteger, name='project_state_check'
+        ),
         default=PROJECT_STATE.DRAFT,
         nullable=False,
         index=True,
@@ -168,7 +171,10 @@ class Project(UuidMixin, BaseScopedNameMixin[int, Account], Model):
     )
     _cfp_state: Mapped[int] = sa_orm.mapped_column(
         'cfp_state',
-        StateManager.check_constraint('cfp_state', CFP_STATE, sa.Integer),
+        sa.SmallInteger,
+        StateManager.check_constraint(
+            'cfp_state', CFP_STATE, sa.SmallInteger, name='project_cfp_state_check'
+        ),
         default=CFP_STATE.NONE,
         nullable=False,
         index=True,
@@ -182,7 +188,10 @@ class Project(UuidMixin, BaseScopedNameMixin[int, Account], Model):
         sa_orm.mapped_column(
             sa.SmallInteger,
             StateManager.check_constraint(
-                'rsvp_state', ProjectRsvpStateEnum, sa.SmallInteger
+                'rsvp_state',
+                ProjectRsvpStateEnum,
+                sa.SmallInteger,
+                name='project_rsvp_state_check',
             ),
             default=ProjectRsvpStateEnum.NONE,
             nullable=False,
@@ -433,6 +442,13 @@ class Project(UuidMixin, BaseScopedNameMixin[int, Account], Model):
     # proposal.py
     proposals: DynamicMapped[Proposal] = relationship(
         lazy='dynamic', order_by=lambda: Proposal.seq, back_populates='project'
+    )
+    proposal_templates: Mapped[list[Proposal]] = relationship(
+        primaryjoin=lambda: sa.and_(
+            Proposal.project_id == Project.id, Proposal.state.TEMPLATE
+        ),
+        viewonly=True,
+        order_by=lambda: Proposal.seq,
     )
 
     # rsvp.py

--- a/funnel/models/rsvp.py
+++ b/funnel/models/rsvp.py
@@ -86,7 +86,9 @@ class Rsvp(UuidMixin, NoIdMixin, Model):
     _state: Mapped[str] = sa_orm.mapped_column(
         'state',
         sa.CHAR(1),
-        StateManager.check_constraint('state', RsvpStateEnum, sa.CHAR(1)),
+        StateManager.check_constraint(
+            'state', RsvpStateEnum, sa.CHAR(1), name='rsvp_state_check'
+        ),
         default=RsvpStateEnum.AWAITING,
         nullable=False,
     )

--- a/funnel/models/update.py
+++ b/funnel/models/update.py
@@ -55,7 +55,10 @@ class Update(UuidMixin, BaseScopedIdNameMixin[int, Account], Model):
         'visibility_state',
         sa.SmallInteger,
         StateManager.check_constraint(
-            'visibility_state', VISIBILITY_STATE, sa.SmallInteger
+            'visibility_state',
+            VISIBILITY_STATE,
+            sa.SmallInteger,
+            name='update_visibility_state_check',
         ),
         default=VISIBILITY_STATE.PUBLIC,
         nullable=False,
@@ -68,7 +71,9 @@ class Update(UuidMixin, BaseScopedIdNameMixin[int, Account], Model):
     _state: Mapped[int] = sa_orm.mapped_column(
         'state',
         sa.SmallInteger,
-        StateManager.check_constraint('state', UPDATE_STATE, sa.SmallInteger),
+        StateManager.check_constraint(
+            'state', UPDATE_STATE, sa.SmallInteger, name='update_state_check'
+        ),
         default=UPDATE_STATE.DRAFT,
         nullable=False,
         index=True,

--- a/funnel/views/project.py
+++ b/funnel/views/project.py
@@ -34,6 +34,7 @@ from ..models import (
     Account,
     Project,
     ProjectRsvpStateEnum,
+    Proposal,
     RegistrationCancellationNotification,
     RegistrationConfirmationNotification,
     Rsvp,
@@ -349,7 +350,9 @@ class ProjectView(ProjectViewBase, DraftViewProtoMixin):
             'project': self.obj.current_access(datasets=('primary', 'related')),
             'featured_proposals': [
                 _p.current_access(datasets=('without_parent', 'related'))
-                for _p in self.obj.proposals.filter_by(featured=True)
+                for _p in self.obj.proposals.filter(
+                    Proposal.state.PUBLIC, Proposal.featured.is_(True)
+                )
             ],
             'rsvp': self.obj.rsvp_for(current_auth.user),
         }
@@ -364,7 +367,7 @@ class ProjectView(ProjectViewBase, DraftViewProtoMixin):
             'project': self.obj.current_access(datasets=('primary', 'related')),
             'submissions': [
                 _p.current_access(datasets=('without_parent', 'related'))
-                for _p in self.obj.proposals
+                for _p in self.obj.proposals.filter(Proposal.state.PUBLIC)
             ],
         }
 

--- a/funnel/views/proposal.py
+++ b/funnel/views/proposal.py
@@ -88,6 +88,12 @@ class ProjectProposalView(ProjectViewBase):
             return render_redirect(self.obj.url_for())
 
         form = ProposalForm(model=Proposal, parent=self.obj)
+        if request.method == 'GET' and self.obj.proposal_templates:
+            # Apply a template since this project has one
+            # TODO: Selectable template
+            template = self.obj.proposal_templates[0]
+            form.title.data = template.title
+            form.body.data = template.body.text
         if form.validate_on_submit():
             proposal = Proposal(created_by=current_auth.user, project=self.obj)
             db.session.add(proposal)

--- a/migrations/versions/b24cbe67fdae_submission_template_state.py
+++ b/migrations/versions/b24cbe67fdae_submission_template_state.py
@@ -1,0 +1,234 @@
+"""Submission template state.
+
+Revision ID: b24cbe67fdae
+Revises: 4eb2369f47f5
+Create Date: 2024-05-03 14:18:36.613793
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = 'b24cbe67fdae'
+down_revision: str = '4eb2369f47f5'
+branch_labels: str | tuple[str, ...] | None = None
+depends_on: str | tuple[str, ...] | None = None
+
+proposal = sa.table('proposal', sa.column('state', sa.SmallInteger()))
+
+
+def upgrade(engine_name: str = '') -> None:
+    """Upgrade all databases."""
+    # Do not modify. Edit `upgrade_` instead
+    globals().get(f'upgrade_{engine_name}', lambda: None)()
+
+
+def downgrade(engine_name: str = '') -> None:
+    """Downgrade all databases."""
+    # Do not modify. Edit `downgrade_` instead
+    globals().get(f'downgrade_{engine_name}', lambda: None)()
+
+
+def upgrade_() -> None:
+    """Upgrade default database."""
+    with op.batch_alter_table('account_membership', schema=None) as batch_op:
+        batch_op.alter_column(
+            'record_type',
+            existing_type=sa.INTEGER(),
+            type_=sa.SmallInteger(),
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table('comment', schema=None) as batch_op:
+        batch_op.alter_column(
+            'state',
+            existing_type=sa.INTEGER(),
+            type_=sa.SmallInteger(),
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table('commentset_membership', schema=None) as batch_op:
+        batch_op.alter_column(
+            'record_type',
+            existing_type=sa.INTEGER(),
+            type_=sa.SmallInteger(),
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table('email_address', schema=None) as batch_op:
+        batch_op.alter_column(
+            'delivery_state',
+            existing_type=sa.INTEGER(),
+            type_=sa.SmallInteger(),
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table('project', schema=None) as batch_op:
+        batch_op.alter_column(
+            'state',
+            existing_type=sa.INTEGER(),
+            type_=sa.SmallInteger(),
+            existing_nullable=False,
+        )
+        batch_op.alter_column(
+            'cfp_state',
+            existing_type=sa.INTEGER(),
+            type_=sa.SmallInteger(),
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table('project_membership', schema=None) as batch_op:
+        batch_op.alter_column(
+            'record_type',
+            existing_type=sa.INTEGER(),
+            type_=sa.SmallInteger(),
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table('project_sponsor_membership', schema=None) as batch_op:
+        batch_op.alter_column(
+            'record_type',
+            existing_type=sa.INTEGER(),
+            type_=sa.SmallInteger(),
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table('proposal', schema=None) as batch_op:
+        batch_op.alter_column(
+            'state',
+            existing_type=sa.INTEGER(),
+            type_=sa.SmallInteger(),
+            existing_nullable=False,
+        )
+        batch_op.drop_constraint('proposal_state_check', type_='check')
+        batch_op.create_check_constraint(
+            'proposal_state_check',
+            proposal.c.state.in_([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]),
+        )
+
+    with op.batch_alter_table('proposal_membership', schema=None) as batch_op:
+        batch_op.alter_column(
+            'record_type',
+            existing_type=sa.INTEGER(),
+            type_=sa.SmallInteger(),
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table('proposal_sponsor_membership', schema=None) as batch_op:
+        batch_op.alter_column(
+            'record_type',
+            existing_type=sa.INTEGER(),
+            type_=sa.SmallInteger(),
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table('site_membership', schema=None) as batch_op:
+        batch_op.alter_column(
+            'record_type',
+            existing_type=sa.INTEGER(),
+            type_=sa.SmallInteger(),
+            existing_nullable=False,
+        )
+
+
+def downgrade_() -> None:
+    """Downgrade default database."""
+    with op.batch_alter_table('site_membership', schema=None) as batch_op:
+        batch_op.alter_column(
+            'record_type',
+            existing_type=sa.SmallInteger(),
+            type_=sa.INTEGER(),
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table('proposal_sponsor_membership', schema=None) as batch_op:
+        batch_op.alter_column(
+            'record_type',
+            existing_type=sa.SmallInteger(),
+            type_=sa.INTEGER(),
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table('proposal_membership', schema=None) as batch_op:
+        batch_op.alter_column(
+            'record_type',
+            existing_type=sa.SmallInteger(),
+            type_=sa.INTEGER(),
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table('proposal', schema=None) as batch_op:
+        batch_op.drop_constraint('proposal_state_check', type_='check')
+        batch_op.create_check_constraint(
+            'proposal_state_check',
+            proposal.c.state.in_([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]),
+        )
+        batch_op.alter_column(
+            'state',
+            existing_type=sa.SmallInteger(),
+            type_=sa.INTEGER(),
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table('project_sponsor_membership', schema=None) as batch_op:
+        batch_op.alter_column(
+            'record_type',
+            existing_type=sa.SmallInteger(),
+            type_=sa.INTEGER(),
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table('project_membership', schema=None) as batch_op:
+        batch_op.alter_column(
+            'record_type',
+            existing_type=sa.SmallInteger(),
+            type_=sa.INTEGER(),
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table('project', schema=None) as batch_op:
+        batch_op.alter_column(
+            'cfp_state',
+            existing_type=sa.SmallInteger(),
+            type_=sa.INTEGER(),
+            existing_nullable=False,
+        )
+        batch_op.alter_column(
+            'state',
+            existing_type=sa.SmallInteger(),
+            type_=sa.INTEGER(),
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table('email_address', schema=None) as batch_op:
+        batch_op.alter_column(
+            'delivery_state',
+            existing_type=sa.SmallInteger(),
+            type_=sa.INTEGER(),
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table('commentset_membership', schema=None) as batch_op:
+        batch_op.alter_column(
+            'record_type',
+            existing_type=sa.SmallInteger(),
+            type_=sa.INTEGER(),
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table('comment', schema=None) as batch_op:
+        batch_op.alter_column(
+            'state',
+            existing_type=sa.SmallInteger(),
+            type_=sa.INTEGER(),
+            existing_nullable=False,
+        )
+
+    with op.batch_alter_table('account_membership', schema=None) as batch_op:
+        batch_op.alter_column(
+            'record_type',
+            existing_type=sa.SmallInteger(),
+            type_=sa.INTEGER(),
+            existing_nullable=False,
+        )


### PR DESCRIPTION
Currently auto-applies the first available template to the new submission form. Selecting a template will require UI, deferred to a separate PR.