### PR TITLE
Coaster compatibility fixes

### DIFF
--- a/funnel/models/typing.py
+++ b/funnel/models/typing.py
@@ -10,7 +10,7 @@ from uuid import UUID
 from sqlalchemy import Table
 from sqlalchemy.orm import Mapped, declared_attr
 
-from coaster.sqlalchemy import LazyRoleSet, QueryProperty
+from coaster.sqlalchemy import LazyRoleSet, QueryProperty, RoleAccessProxy
 from coaster.utils import InspectableSet
 
 __all__ = [
@@ -63,6 +63,10 @@ class ModelRoleProtocol(Protocol):
     def actors_with(
         self, roles: Iterable[str], with_role: bool = False
     ) -> Iterator[Account | tuple[Account, str]]: ...
+
+    def current_access(
+        self, datasets: Sequence[str] | None = None
+    ) -> RoleAccessProxy: ...
 
 
 class ModelIdProtocol(

--- a/funnel/views/api/resource.py
+++ b/funnel/views/api/resource.py
@@ -10,7 +10,7 @@ from werkzeug.datastructures import MultiDict
 
 from baseframe import __
 from coaster.utils import getbool
-from coaster.views import jsonp, requestargs
+from coaster.views import jsonp, requestargs, requestvalues
 
 from ... import app
 from ...auth import current_auth
@@ -133,7 +133,7 @@ def api_result(
         status_code = 422
     params['status'] = status
     if _jsonp:
-        response = jsonp(params)
+        response: Response = jsonp(params)  # type: ignore[assignment]
     else:
         response = jsonify(params)
     response.status_code = status_code
@@ -205,7 +205,7 @@ def user_get_by_userid() -> ReturnView:
 
 @app.route('/api/1/user/get_by_userids', methods=['GET', 'POST'])
 @requires_client_id_or_user_or_client_login
-@requestargs(('userid[]', abort_null))
+@requestvalues(('userid[]', abort_null))
 def user_get_by_userids(userid: list[str]) -> ReturnView:
     """
     Return users and organizations with the given userids (Lastuser internal userid).
@@ -253,7 +253,7 @@ def user_get_by_userids(userid: list[str]) -> ReturnView:
 
 @app.route('/api/1/user/get', methods=['GET', 'POST'])
 @requires_user_or_client_login
-@requestargs(('name', abort_null))
+@requestvalues(('name', abort_null))
 def user_get(name: str) -> ReturnView:
     """Return user with the given username or email address."""
     if not name:
@@ -278,7 +278,7 @@ def user_get(name: str) -> ReturnView:
 
 @app.route('/api/1/user/getusers', methods=['GET', 'POST'])
 @requires_user_or_client_login
-@requestargs(('name[]', abort_null))
+@requestvalues(('name[]', abort_null))
 def user_getall(name: list[str]) -> ReturnView:
     """Return users with the given username or email address."""
     names = name
@@ -311,7 +311,7 @@ def user_getall(name: list[str]) -> ReturnView:
 
 @app.route('/api/1/user/autocomplete', methods=['GET', 'POST'])
 @requires_client_id_or_user_or_client_login
-@requestargs(('q', abort_null))
+@requestvalues(('q', abort_null))
 def user_autocomplete(q: str = '') -> ReturnView:
     """
     Return users matching the search term.
@@ -365,7 +365,7 @@ def user_autocomplete(q: str = '') -> ReturnView:
 
 @app.route('/api/1/profile/autocomplete')
 @requires_client_id_or_user_or_client_login
-@requestargs(('q', abort_null))
+@requestvalues(('q', abort_null))
 def profile_autocomplete(q: str = '') -> ReturnView:
     """Return accounts matching the search term."""
     if not q:

--- a/funnel/views/contact.py
+++ b/funnel/views/contact.py
@@ -13,7 +13,7 @@ from sqlalchemy.exc import IntegrityError
 
 from baseframe import _
 from coaster.utils import getbool, make_name, midnight_to_utc, utcnow
-from coaster.views import ClassView, render_with, requestargs, route
+from coaster.views import ClassView, render_with, requestform, route
 
 from .. import app
 from ..auth import current_auth
@@ -150,7 +150,7 @@ class ContactView(ClassView):
 
     @route('scan/connect', endpoint='scan_connect', methods=['POST'])
     @requires_login
-    @requestargs('puk', 'key')
+    @requestform('puk', 'key')
     def connect(self, puk: str, key: str) -> ReturnView:
         """Verify a badge scan and create a contact."""
         ticket_participant = TicketParticipant.query.filter_by(puk=puk, key=key).first()

--- a/funnel/views/helpers.py
+++ b/funnel/views/helpers.py
@@ -49,7 +49,7 @@ from ..auth import CurrentAuth, current_auth
 from ..forms import supported_locales
 from ..models import Account, Project, Shortlink, db, profanity
 from ..proxies import RequestWants, request_wants
-from ..typing import ResponseType, ReturnResponse, ReturnView
+from ..typing import ResponseType, ReturnResponse
 from ..utils import JinjaTemplateBase, jinja_global, jinja_undefined
 
 nocache_expires = utc.localize(datetime(1990, 1, 1))
@@ -647,7 +647,7 @@ def render_redirect(url: str, code: int = 303) -> ReturnResponse:
 
 def html_in_json(
     template: str,
-) -> dict[str, str | Callable[[Mapping[str, Any]], ReturnView]]:
+) -> Mapping[str, str | Callable[[Mapping[str, Any]], ReturnResponse]]:
     """
     Render a HTML fragment in a JSON wrapper, for use with ``@render_with``.
 

--- a/funnel/views/index.py
+++ b/funnel/views/index.py
@@ -184,7 +184,10 @@ class IndexView(ClassView):
             'past_projects': [
                 {
                     'title': p.title,
-                    'datetime': date_filter(p.end_at_localized, format='dd MMM yyyy'),
+                    'datetime': date_filter(
+                        p.end_at_localized,  # type: ignore[arg-type]
+                        format='dd MMM yyyy',
+                    ),
                     'venue': p.primary_venue.city if p.primary_venue else p.location,
                     'url': p.url_for(),
                 }

--- a/funnel/views/profile.py
+++ b/funnel/views/profile.py
@@ -90,6 +90,7 @@ def template_switcher(templateargs: Mapping[str, Any]) -> str:
 @Account.views('main')
 @route('/<account>', init_app=app)
 class ProfileView(UrlChangeCheck, AccountViewBase):
+    """Account profile views."""
 
     @route('', endpoint='profile')
     @render_with({'text/html': template_switcher}, json=True)
@@ -458,7 +459,10 @@ class ProfileView(UrlChangeCheck, AccountViewBase):
             'past_projects': [
                 {
                     'title': p.title,
-                    'datetime': date_filter(p.end_at_localized, format='dd MMM yyyy'),
+                    'datetime': date_filter(
+                        p.end_at_localized,  # type: ignore[arg-type]
+                        format='dd MMM yyyy',
+                    ),
                     'venue': p.primary_venue.city if p.primary_venue else p.location,
                     'url': p.url_for(),
                 }

--- a/funnel/views/schedule.py
+++ b/funnel/views/schedule.py
@@ -14,7 +14,7 @@ from sqlalchemy.exc import NoResultFound
 
 from baseframe import _, localize_timezone
 from coaster.utils import utcnow
-from coaster.views import render_with, requestargs, requires_roles, route
+from coaster.views import render_with, requestform, requires_roles, route
 
 from .. import app
 from ..models import Project, Proposal, Rsvp, Session, VenueRoom, db, sa
@@ -317,7 +317,7 @@ class ProjectScheduleView(ProjectViewBase):
     @route('update', methods=['POST'])
     @requires_login
     @requires_roles({'editor'})
-    @requestargs(('sessions', json.loads))
+    @requestform(('sessions', json.loads))
     def update_schedule(self, sessions: list[dict]) -> ReturnRenderWith:
         for session in sessions:
             try:


### PR DESCRIPTION
* Use `@requestvalues` when both args and form are sources, and `@requestform` when we only want form data
* Set PostgreSQL timezone to `UTC`
* Give `@render_with` a read-only mapping