### PR TITLE
Disable Recaptcha in tests

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -127,11 +127,11 @@ jobs:
           psql -h localhost -U postgres geoname_testing -c "grant all privileges on schema public to $(whoami); grant all privileges on all tables in schema public to $(whoami); grant all privileges on all sequences in schema public to $(whoami);"
       - name: Test with pytest
         run: |
-          FLASK_RECAPTCHA_DISABLED=true pytest --disable-warnings --gherkin-terminal-reporter -vv --showlocals --ignore=tests/e2e
+          pytest --disable-warnings --gherkin-terminal-reporter -vv --showlocals --ignore=tests/e2e
       - name: Browser tests with pytest
         timeout-minutes: 5
         run: |
-          FLASK_RECAPTCHA_DISABLED=true pytest --disable-warnings --gherkin-terminal-reporter -vv --showlocals --cov-append --cov=funnel tests/e2e
+          pytest --disable-warnings --gherkin-terminal-reporter -vv --showlocals --cov-append --cov=funnel tests/e2e
       - name: Prepare coverage report
         run: |
           mkdir -p coverage

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -127,11 +127,11 @@ jobs:
           psql -h localhost -U postgres geoname_testing -c "grant all privileges on schema public to $(whoami); grant all privileges on all tables in schema public to $(whoami); grant all privileges on all sequences in schema public to $(whoami);"
       - name: Test with pytest
         run: |
-          pytest --disable-warnings --gherkin-terminal-reporter -vv --showlocals --ignore=tests/e2e
+          FLASK_RECAPTCHA_DISABLED=true pytest --disable-warnings --gherkin-terminal-reporter -vv --showlocals --ignore=tests/e2e
       - name: Browser tests with pytest
         timeout-minutes: 5
         run: |
-          pytest --disable-warnings --gherkin-terminal-reporter -vv --showlocals --cov-append --cov=funnel tests/e2e
+          FLASK_RECAPTCHA_DISABLED=true pytest --disable-warnings --gherkin-terminal-reporter -vv --showlocals --cov-append --cov=funnel tests/e2e
       - name: Prepare coverage report
         run: |
           mkdir -p coverage

--- a/.testenv
+++ b/.testenv
@@ -4,6 +4,8 @@
 FLASK_ENV=testing
 FLASK_TESTING=true
 FLASK_DEBUG_TB_ENABLED=false
+# Disable Recaptcha
+FLASK_RECAPTCHA_DISABLED=true
 # Enable CSRF so tests reflect production use
 FLASK_WTF_CSRF_ENABLED=true
 # Use Redis cache so that rate limit validation tests work, with Redis db

--- a/funnel/templates/account_formlayout.html.jinja2
+++ b/funnel/templates/account_formlayout.html.jinja2
@@ -81,7 +81,7 @@
     });
   </script>
   {{ ajaxform(ref_id=ref_id, request=request, force=ajax) }}
-  {%- if form and 'recaptcha' in form %}
+  {%- if form and form.recaptcha is defined and not config.get('RECAPTCHA_DISABLED') %}
     {% block recaptcha %}{{ recaptcha(ref_id=ref_id) }}{% endblock recaptcha %}
   {%- endif %}
 {% endblock footerscripts %}

--- a/funnel/templates/ajaxform.html.jinja2
+++ b/funnel/templates/ajaxform.html.jinja2
@@ -31,7 +31,7 @@
     {%- if with_chrome -%}
       {{ ajaxform(ref_id=ref_id, request=request, force=true) }}
     {%- endif -%}
-    {%- if form and 'recaptcha' in form %}
+    {%- if form and form.recaptcha is defined %}
       {% block recaptcha %}{% endblock recaptcha %}
     {%- endif %}
   {% endblock innerscripts %}

--- a/funnel/templates/login.html.jinja2
+++ b/funnel/templates/login.html.jinja2
@@ -32,7 +32,7 @@
 {% endblock afterloginbox %}
 
 {% block recaptcha %}
-  {%- if form and 'recaptcha' in form %}
+  {%- if form and form.recaptcha is defined and not config.get('RECAPTCHA_DISABLED') %}
     {{ recaptcha(ref_id, formWrapperId='loginformwrapper', ajax=true) }}
   {%- endif %}
 {% endblock recaptcha %}

--- a/funnel/templates/password_login_form.html.jinja2
+++ b/funnel/templates/password_login_form.html.jinja2
@@ -7,7 +7,7 @@
         class="mui-form mui-form--margins"
         accept-charset="UTF-8"
         action="{{ action }}"
-        {%- if not 'recaptcha' in loginform %} hx-post="{{ action }}" hx-target="#loginformwrapper" {%- endif %}
+        {%- if loginform.recaptcha is undefined %} hx-post="{{ action }}" hx-target="#loginformwrapper" {%- endif %}
       >
     <input type="hidden" name="form.id" value="{{ formid }}"/>
     {{ loginform.hidden_tag() }}

--- a/tests/e2e/account/register_test.py
+++ b/tests/e2e/account/register_test.py
@@ -224,10 +224,6 @@ def given_server_uses_recaptcha(
 @when("twoflower visits the login page, Recaptcha is required")
 def when_twoflower_visits_login_page_recaptcha(app, live_server, page: Page) -> None:
     page.goto(live_server.url + 'login')
-    assert page.wait_for_selector(
-        '#form-passwordlogin > div.g-recaptcha > div > div.grecaptcha-logo > iframe',
-        timeout=10000,
-    )
 
 
 @then("they submit and Recaptcha validation passes")

--- a/tests/e2e/account/register_test.py
+++ b/tests/e2e/account/register_test.py
@@ -52,13 +52,6 @@ def user_twoflower_with_password_and_contact(
     return user_twoflower
 
 
-def wait_until_recaptcha_loaded(page: Page) -> None:
-    page.wait_for_selector(
-        '#form-passwordlogin > div.g-recaptcha > div > div.grecaptcha-logo > iframe',
-        timeout=10000,
-    )
-
-
 @given("Anonymous visitor is on the home page")
 def given_anonuser_home_page(live_server, page: Page) -> None:
     page.goto(live_server.url)
@@ -82,7 +75,6 @@ def when_anonuser_navigates_login_and_submits(
     else:
         pytest.fail("Unknown username type")
     page.click('.header__button')
-    wait_until_recaptcha_loaded(page)
     selector = page.wait_for_selector('input[name=username]')
     assert selector is not None
     selector.fill(username)  # pylint: disable=possibly-used-before-assignment
@@ -135,7 +127,6 @@ def when_navigate_to_login_page(app, live_server, page: Page) -> None:
 @when("they submit the email address with password")
 @when("submit an email address with password")
 def when_submit_email_password(page: Page) -> None:
-    wait_until_recaptcha_loaded(page)
     selector = page.wait_for_selector('input[name=username]')
     assert selector is not None
     selector.fill(TWOFLOWER_EMAIL)
@@ -156,7 +147,6 @@ def then_logged_in(live_server, page: Page) -> None:
 @when("they submit the phone number with password")
 @when("submit a phone number with password")
 def when_submit_phone_password(app, live_server, page: Page) -> None:
-    wait_until_recaptcha_loaded(page)
     selector = page.wait_for_selector('input[name=username]')
     assert selector is not None
     selector.fill(TWOFLOWER_PHONE)
@@ -196,7 +186,6 @@ def then_register_modal_appear(page: Page) -> None:
     target_fixture='anon_username',
 )
 def when_they_enter_email(page: Page, phone_or_email: str) -> dict[str, str]:
-    wait_until_recaptcha_loaded(page)
     if phone_or_email == "a phone number":
         username = ANONYMOUS_PHONE
     elif phone_or_email == "an email address":


### PR DESCRIPTION
Recaptcha with test credentials is fairly unreliable in CI. This PR disables it completely in a test environment.