### PR TITLE
Fix boxoffice tickets sync

### DIFF
--- a/funnel/extapi/boxoffice.py
+++ b/funnel/extapi/boxoffice.py
@@ -51,7 +51,7 @@ class Boxoffice:
                             'ticket_type': line_item.get('ticket', {}).get('title', '')[
                                 :80
                             ],
-                            'order_no': str(order.get('invoice_no', '')),
+                            'order_no': str(order.get('receipt_no', '')),
                             'status': status,
                         }
                     )


### PR DESCRIPTION
In the Order list from boxoffice api, look for `receipt_no` and not `invoice_no`
Boxoffice api send receipt_no - https://github.com/hasgeek/boxoffice/blob/main/boxoffice/views/order.py#L658