### PR TITLE
Changed the order of details in the profile-details to improve layout

### DIFF
--- a/funnel/assets/sass/pages/profile.scss
+++ b/funnel/assets/sass/pages/profile.scss
@@ -213,6 +213,13 @@
   }
   .profile-details {
     padding: 2 * $mui-grid-padding 0 0;
+    ul {
+      padding: 0;
+      display: flex;
+      flex-direction: row;
+      gap: 16px;
+      list-style: none;
+    }
   }
   .profile.profile--unverified {
     .profile__banner__box {

--- a/funnel/templates/profile_layout.html.jinja2
+++ b/funnel/templates/profile_layout.html.jinja2
@@ -450,15 +450,15 @@
               <p class="mui--text-title mui--text-light">@{{ profile.name }}</p>
             {%- endif %}
           </div>
-          <ul class="bullet-separated-list">
+          {%- if profile.tagline %}
+            <p>{{ profile.tagline }}</p>
+          {%- endif %}
+          <ul>
             {%- if profile.joined_at %}
               <li>{{ faicon(icon='history') }} {% trans date=profile.joined_at|date(format='MMM YYYY') %}Joined {{ date }}{% endtrans %}</li>
             {%- endif %}
             {%- if profile.website %}
               <li><a href="{{ profile.website }}" target="_blank" rel="noopener nofollow">{{ faicon(icon='globe') }} {{ profile.website|cleanurl }}</a></li>
-            {%- endif %}
-            {%- if profile.tagline %}
-              <li>{{ profile.tagline }}</li>
             {%- endif %}
           </ul>
           <div class="mui--visible-xs-block mui--visible-sm-block">


### PR DESCRIPTION
#### Before
<img width="1239" alt="Screenshot 2024-07-31 at 12 50 36 PM" src="https://github.com/user-attachments/assets/c0557fd4-7680-4e23-94e9-fddcb6d610c3">

#### After
<img width="1240" alt="Screenshot 2024-07-31 at 12 50 20 PM" src="https://github.com/user-attachments/assets/9f5f1164-c6b3-4391-82ac-805d2c2c1b5e">

