### PR TITLE
Badge style: system fonts and B&W for labels

### DIFF
--- a/funnel/templates/badge_label.html.jinja2
+++ b/funnel/templates/badge_label.html.jinja2
@@ -3,7 +3,6 @@
 <head>
   <title>{% trans %}Label badge{% endtrans %}</title>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css" />
   <style type="text/css">
     @page {
       size: 62mm 68mm;  /* width height */
@@ -19,7 +18,7 @@
       width: 62mm;
       height: 68mm;
       page-break-after: always;
-      font-family: 'Open Sans', sans-serif;
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
       padding: 0;
       margin: auto;
     }
@@ -58,7 +57,6 @@
       font-size: 20px;
       max-height: 40px; /* fit text within two lines */
       min-height: 40px;
-      color: #df5e0e;
       margin-bottom: 5px;
       font-weight: 700;
       min-height: 28px;
@@ -66,7 +64,6 @@
     .twitter-handle {
       font-size: 20px;
       max-height: 20px; /* fit text in one line */
-      color: #0ea5b0;
       font-weight: 700;
     }
     .qrcode {

--- a/funnel/templates/badge_lanyard.html.jinja2
+++ b/funnel/templates/badge_lanyard.html.jinja2
@@ -3,7 +3,6 @@
 <head>
   <title>{% trans %}Lanyard badge{% endtrans %}</title>
   <script src="https://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700" rel="stylesheet" type="text/css" />
   <style type="text/css">
     @page {
       size: 4.129in 11.34in;  /* width height */
@@ -21,8 +20,7 @@
       background-image: url({{ badge_template }});
       background-repeat: no-repeat;
       background-size: 100% 100%;
-      font-family: 'Open Sans', sans-serif;
-    }
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", "Noto Sans", "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";    }
     .badge {
       width: 4.129in;
       height: 5.67in;
@@ -35,7 +33,6 @@
       -o-transform: rotate(180deg);
       -ms-transform: rotate(180deg);
       transform: rotate(180deg);
-      display: none;
     }
     .badge-content {
       width: 2.75in;


### PR DESCRIPTION
Restore double-sided lanyard badges as the default since CSS customisation is now available.